### PR TITLE
Remove ibiblio and use https:// for Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,25 +413,9 @@
 			</releases>
 		</repository>
 		<repository>
-			<id>ibiblio</id>
-			<name>ibiblio</name>
-			<url>
-                http://maven.ibiblio.org/maven2/
-            </url>
-			<layout>default</layout>
-			<snapshots>
-				<enabled>false</enabled>
-				<updatePolicy>never</updatePolicy>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>never</updatePolicy>
-			</releases>
-		</repository>
-		<repository>
 			<id>central</id>
 			<name>central</name>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 			<layout>default</layout>
 			<snapshots>
 				<enabled>false</enabled>


### PR DESCRIPTION
ibiblio is not available anymore.

Maven Central does not work with unsecure HTTP.