### PR TITLE
Revamp AbstractCLI doWork to report exit code

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
@@ -134,9 +134,7 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
                  * if the audit trail already has a DataReplacedEvent, skip it, unless --force.
                  */
                 if ( this.checkForAlreadyDone( ee ) && !this.force ) {
-
-                    this.errorObjects.add( ee
-                            + ": Was already run before, use -force" );
+                    addErrorObject( ee, "Was already run before, use -force" );
                     continue;
                 }
 
@@ -144,8 +142,7 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
                  * Avoid repeated attempts that won't work e.g. no data available.
                  */
                 if ( super.auditEventService.hasEvent( ee, FailedDataReplacedEvent.class ) && !this.force ) {
-                    this.errorObjects.add( ee
-                            + ": Failed before, use -force to re-attempt" );
+                    addErrorObject( ee, "Failed before, use -force to re-attempt" );
                     continue;
                 }
 
@@ -163,32 +160,24 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
                 if ( ( GeoPlatform.isAffyPlatform( ad.getShortName() ) ) ) {
                     AbstractCLI.log.info( ad + " looks like Affy array" );
                     serv.reprocessAffyDataFromCel( thawedEe );
-
-                    this.successObjects.add( thawedEe );
-                    AbstractCLI.log.info( "Successfully processed: " + thawedEe );
+                    addSuccessObject( thawedEe, "Successfully processed: " + thawedEe );
                 } else if ( asd.isMerged( Collections.singleton( ad.getId() ) ).get( ad.getId() ) ) {
                     ad = asd.thawLite( ad );
                     if ( GeoPlatform.isAffyPlatform( ad.getMergees().iterator().next().getShortName() ) ) {
                         AbstractCLI.log.info( ad + " looks like Affy array made from merger of other platforms" );
                         serv.reprocessAffyDataFromCel( thawedEe );
-                        this.successObjects.add( thawedEe );
-                        AbstractCLI.log.info( "Successfully processed: " + thawedEe );
+                        addSuccessObject( thawedEe, "Successfully processed: " + thawedEe );
                     }
                 } else {
 
-                    this.errorObjects.add( ee + ": " +
-                            ad
-                            + " is not recognized as an Affymetrix platform. If this is a mistake, the Gemma configuration needs to be updated." );
+                    addErrorObject( ee, ad + " is not recognized as an Affymetrix platform. If this is a mistake, the Gemma configuration needs to be updated." );
                 }
 
             } catch ( Exception exception ) {
-                AbstractCLI.log.error( exception, exception );
-                this.errorObjects.add( ee + " " + exception.getLocalizedMessage() );
+                addErrorObject( ee, exception.getMessage(), exception );
             }
 
         }
-
-        super.summarizeProcessing();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
@@ -88,9 +88,7 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         DataUpdater serv = this.getBean( DataUpdater.class );
 
         if ( this.expressionExperiments.isEmpty() )

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
@@ -44,9 +44,9 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
 
     private static final String APT_FILE_OPT = "aptFile";
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         AffyDataFromCelCli c = new AffyDataFromCelCli();
-        executeCommand( c, args );
+        return executeCommand( c, args );
     }
 
     private String aptFile = null;
@@ -88,15 +88,13 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         DataUpdater serv = this.getBean( DataUpdater.class );
 
         if ( this.expressionExperiments.isEmpty() )
-            return null;
+            return;
 
         // This can be done for multiple experiments under some conditions; we get this one just  to test for some multi-platform situations
         Collection<ArrayDesign> arrayDesignsUsed = this.eeService
@@ -126,14 +124,10 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
                 throw new IllegalArgumentException( "Not an Affymetrix array so far as we can tell: " + ad );
             }
 
-            try {
-                AbstractCLI.log.info( "Loading data from " + aptFile );
-                serv.addAffyDataFromAPTOutput( thawedEe, aptFile );
+            AbstractCLI.log.info( "Loading data from " + aptFile );
+            serv.addAffyDataFromAPTOutput( thawedEe, aptFile );
 
-            } catch ( Exception exception ) {
-                return exception;
-            }
-            return null;
+            return;
         }
 
         for ( BioAssaySet ee : this.expressionExperiments ) {
@@ -202,8 +196,6 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
         }
 
         super.summarizeProcessing();
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyDataFromCelCli.java
@@ -44,11 +44,6 @@ public class AffyDataFromCelCli extends ExpressionExperimentManipulatingCLI {
 
     private static final String APT_FILE_OPT = "aptFile";
 
-    public static int main( String[] args ) {
-        AffyDataFromCelCli c = new AffyDataFromCelCli();
-        return executeCommand( c, args );
-    }
-
     private String aptFile = null;
     private String celchip = null;
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyProbeCollapseCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyProbeCollapseCli.java
@@ -19,6 +19,7 @@
 
 package ubic.gemma.core.apps;
 
+import org.apache.commons.cli.Option;
 import ubic.gemma.core.analysis.sequence.SequenceManipulation;
 import ubic.gemma.core.loader.expression.arrayDesign.AffyProbeReader;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
@@ -43,6 +44,9 @@ import java.util.Collection;
  * @author paul
  */
 public class AffyProbeCollapseCli extends ArrayDesignSequenceManipulatingCli {
+
+    private String affyProbeFileName;
+
     public static void main( String[] args ) {
         AffyProbeCollapseCli d = new AffyProbeCollapseCli();
         executeCommand( d, args );
@@ -58,17 +62,32 @@ public class AffyProbeCollapseCli extends ArrayDesignSequenceManipulatingCli {
         return "affyCollapse";
     }
 
+    @Override
+    protected void buildOptions() {
+        super.buildOptions();
+        addOption( Option.builder( "affyProbeFile" )
+                .hasArg()
+                .desc( "Affymetrix probe file to use as input" )
+                .required().build() );
+    }
+
+    @Override
+    protected void processOptions() {
+        super.processOptions();
+        affyProbeFileName = this.getOptionValue( "affyProbeFile" );
+    }
+
     /*
      * (non-Javadoc)
      *
      * @see ubic.gemma.core.util.AbstractCLI#doWork(java.lang.String[])
      */
     @Override
-    protected void doWork( String[] args ) throws IOException {
+    protected void doWork() throws IOException {
 
         // parse
         AffyProbeReader apr = new AffyProbeReader();
-        apr.parse( args[0] );
+        apr.parse( affyProbeFileName );
         Collection<CompositeSequence> compositeSequencesFromProbes = apr.getKeySet();
 
         for ( CompositeSequence newCompositeSequence : compositeSequencesFromProbes ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyProbeCollapseCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyProbeCollapseCli.java
@@ -1,8 +1,8 @@
 /*
  * The gemma-core project
- * 
+ *
  * Copyright (c) 2018 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -31,15 +31,15 @@ import java.util.Collection;
  * Purely a testing tool, to turn Affy individual probes (by probeset) into collapsed sequences. This is what happens
  * internally when we add sequences to a platform, but this makes it possible to see (and check) the sequences first
  * before committing to them.
- * 
+ * <p>
  * Should probably be in GemmaAnalysis but that is badly broken.
- * 
+ * <p>
  * You just run this like
- * 
+ * <p>
  * $GEMMACMD affyCollapse [filename]
- * 
+ * <p>
  * It doesn't handle the regular argument setup, wasn't worth the trouble. Generates FASTA format but easy to change.
- * 
+ *
  * @author paul
  */
 public class AffyProbeCollapseCli extends ArrayDesignSequenceManipulatingCli {
@@ -50,7 +50,7 @@ public class AffyProbeCollapseCli extends ArrayDesignSequenceManipulatingCli {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#getCommandName()
      */
     @Override
@@ -60,30 +60,23 @@ public class AffyProbeCollapseCli extends ArrayDesignSequenceManipulatingCli {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#doWork(java.lang.String[])
      */
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws IOException {
 
         // parse
         AffyProbeReader apr = new AffyProbeReader();
-        try {
-            apr.parse( args[0] );
-            Collection<CompositeSequence> compositeSequencesFromProbes = apr.getKeySet();
+        apr.parse( args[0] );
+        Collection<CompositeSequence> compositeSequencesFromProbes = apr.getKeySet();
 
-            for ( CompositeSequence newCompositeSequence : compositeSequencesFromProbes ) {
+        for ( CompositeSequence newCompositeSequence : compositeSequencesFromProbes ) {
 
-                BioSequence collapsed = SequenceManipulation.collapse( apr.get( newCompositeSequence ) );
-                String sequenceName = newCompositeSequence.getName() + "_collapsed";
-                System.out.println( ">" + newCompositeSequence.getName() + "\t" + sequenceName + "\n" + collapsed.getSequence() + "\n" );
-            }
-        } catch ( IOException e ) {
-
-            e.printStackTrace();
+            BioSequence collapsed = SequenceManipulation.collapse( apr.get( newCompositeSequence ) );
+            String sequenceName = newCompositeSequence.getName() + "_collapsed";
+            System.out.println( ">" + newCompositeSequence.getName() + "\t" + sequenceName + "\n" + collapsed.getSequence() + "\n" );
         }
-
-        return null;
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/AffyProbeCollapseCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/AffyProbeCollapseCli.java
@@ -47,11 +47,6 @@ public class AffyProbeCollapseCli extends ArrayDesignSequenceManipulatingCli {
 
     private String affyProbeFileName;
 
-    public static void main( String[] args ) {
-        AffyProbeCollapseCli d = new AffyProbeCollapseCli();
-        executeCommand( d, args );
-    }
-
     /*
      * (non-Javadoc)
      *

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
@@ -58,15 +58,13 @@ public class ArrayDesignAlternativePopulateCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception ex = super.processCommandLine( args );
-        if ( ex != null )
-            return ex;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
         ArrayDesignService arrayDesignService = this.getBean( ArrayDesignService.class );
 
         // Read in the mapping file, which is in the classpath. This is also used by GeoPlatform (and in the DataUpdater)
         InputStream r = this.getClass().getResourceAsStream( "/ubic/gemma/core/loader/affy.altmappings.txt" );
-        try (BufferedReader in = new BufferedReader( new InputStreamReader( r ) )) {
+        try ( BufferedReader in = new BufferedReader( new InputStreamReader( r ) ) ) {
             while ( in.ready() ) {
                 String line = in.readLine().trim();
                 if ( line.startsWith( "#" ) ) {
@@ -105,9 +103,8 @@ public class ArrayDesignAlternativePopulateCli extends AbstractCLIContextCLI {
 
             }
         } catch ( IOException e ) {
-            return e;
+            throw e;
         }
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
@@ -37,11 +37,6 @@ import java.io.InputStreamReader;
  */
 public class ArrayDesignAlternativePopulateCli extends AbstractCLIContextCLI {
 
-    public static void main( String[] args ) {
-        ArrayDesignAlternativePopulateCli c = new ArrayDesignAlternativePopulateCli();
-        executeCommand( c, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.METADATA;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
@@ -58,8 +58,7 @@ public class ArrayDesignAlternativePopulateCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         ArrayDesignService arrayDesignService = this.getBean( ArrayDesignService.class );
 
         // Read in the mapping file, which is in the classpath. This is also used by GeoPlatform (and in the DataUpdater)

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
@@ -36,7 +36,6 @@ import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.genome.gene.service.GeneService;
 import ubic.gemma.core.ontology.providers.GeneOntologyService;
 import ubic.gemma.core.util.AbstractCLI;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.arrayDesign.TechnologyType;
 import ubic.gemma.model.genome.Gene;
@@ -73,11 +72,6 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
     private String taxonName;
     private boolean notifiedAboutGOState = false;
     private TaxonService taxonService;
-
-    public static void main( String[] args ) {
-        ArrayDesignAnnotationFileCli p = new ArrayDesignAnnotationFileCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
@@ -43,9 +43,9 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 
 /**
- * Given an array design creates a Gene Ontology Annotation file
- * Given a batch file creates all the Annotation files for the AD's specified in the batch file
- * Given nothing creates annotation files for every AD that isn't subsumed or merged into another AD.
+ * Given an array design creates a Gene Ontology Annotation file Given a batch file creates all the Annotation files for
+ * the AD's specified in the batch file Given nothing creates annotation files for every AD that isn't subsumed or
+ * merged into another AD.
  *
  * @author klc
  * @author paul
@@ -298,11 +298,9 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
             try {
                 this.processOneAD( ad );
             } catch ( Exception e ) {
-                errorObjects.add( ad + " " + e.getMessage() );
+                addErrorObject( ad, e.getMessage(), e );
             }
         }
-
-        this.summarizeProcessing();
     }
 
     /**
@@ -339,17 +337,11 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
                 try {
                     this.processAD( arrayDesign );
                 } catch ( Exception e ) {
-                    AbstractCLI.log.error( "**** Exception while processing " + arrayDesign + ": " + e.getMessage()
-                            + " ********" );
-                    AbstractCLI.log.error( e, e );
-                    errorObjects.add( arrayDesign + ": " + e.getMessage() );
+                    addErrorObject( arrayDesign, e.getMessage(), e );
                 }
 
             }
         }
-
-        this.summarizeProcessing();
-
     }
 
     private void processGeneList() throws IOException {
@@ -402,7 +394,7 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
 
         this.arrayDesignAnnotationService.create( inputAd, overWrite );
 
-        successObjects.add( inputAd );
+        addSuccessObject( inputAd, "Successfully processed " + inputAd );
 
     }
 
@@ -415,9 +407,7 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
                 Thread.sleep( 10000 );
                 AbstractCLI.log.info( "Waiting for Gene Ontology to load ..." );
             } catch ( InterruptedException e ) {
-                e.printStackTrace();
-                log.error( "Failure while waiting for GO to load" );
-                exitwithError();
+                throw new RuntimeException( "Failure while waiting for GO to load", e );
             }
         }
         if ( !this.notifiedAboutGOState ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
@@ -166,44 +166,35 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         this.taxonService = this.getBean( TaxonService.class );
 
         this.waitForGeneOntologyReady();
 
-        try {
-            this.goService.init( true );
+        this.goService.init( true );
 
-            log.info( "***** Annotation file(s) will be written to " + ArrayDesignAnnotationService.ANNOT_DATA_DIR + " ******" );
+        log.info( "***** Annotation file(s) will be written to " + ArrayDesignAnnotationService.ANNOT_DATA_DIR + " ******" );
 
-            if ( StringUtils.isNotBlank( geneFileName ) ) {
-                this.processGeneList();
-            } else if ( processAllADs ) {
-                this.processAllADs(); // 'batch'
-            } else if ( batchFileName != null ) {
-                this.processFromListInFile(); // list of ADs to run
-            } else if ( this.taxonName != null ) {
-                this.processGenesForTaxon(); // more or less a generic annotation by gene symbol
-            } else {
-                if ( this.getArrayDesignsToProcess().isEmpty() ) {
-                    throw new IllegalArgumentException( "You must specify a platform, a taxon, gene file, or batch." );
-                }
-                for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {
-
-                    this.processAD( arrayDesign );
-
-                }
+        if ( StringUtils.isNotBlank( geneFileName ) ) {
+            this.processGeneList();
+        } else if ( processAllADs ) {
+            this.processAllADs(); // 'batch'
+        } else if ( batchFileName != null ) {
+            this.processFromListInFile(); // list of ADs to run
+        } else if ( this.taxonName != null ) {
+            this.processGenesForTaxon(); // more or less a generic annotation by gene symbol
+        } else {
+            if ( this.getArrayDesignsToProcess().isEmpty() ) {
+                throw new IllegalArgumentException( "You must specify a platform, a taxon, gene file, or batch." );
             }
+            for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {
 
-        } catch ( Exception e ) {
-            return e;
+                this.processAD( arrayDesign );
+
+            }
         }
-
-        return null;
     }
 
     private void processAD( ArrayDesign arrayDesign ) throws IOException {
@@ -286,7 +277,7 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
                 AbstractCLI.log.warn( "Raw sequencing platform, will not generate annotation file: " + ad );
                 continue;
             }
-            
+
             toDo.add( ad );
 
             if ( ++numChecked % 100 == 0 ) {
@@ -320,7 +311,6 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
         }
 
         this.summarizeProcessing();
-
     }
 
     /**
@@ -330,7 +320,7 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
 
         AbstractCLI.log.info( "Loading platforms to annotate from " + this.batchFileName );
         InputStream is = new FileInputStream( this.batchFileName );
-        try (BufferedReader br = new BufferedReader( new InputStreamReader( is ) )) {
+        try ( BufferedReader br = new BufferedReader( new InputStreamReader( is ) ) ) {
 
             String line;
             int lineNumber = 0;
@@ -373,7 +363,7 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
     private void processGeneList() throws IOException {
         AbstractCLI.log.info( "Loading genes to annotate from " + geneFileName );
         InputStream is = new FileInputStream( geneFileName );
-        try (BufferedReader br = new BufferedReader( new InputStreamReader( is ) )) {
+        try ( BufferedReader br = new BufferedReader( new InputStreamReader( is ) ) ) {
             String line;
             GeneService geneService = this.getBean( GeneService.class );
             Taxon taxon = taxonService.findByCommonName( taxonName );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAnnotationFileCli.java
@@ -166,9 +166,7 @@ public class ArrayDesignAnnotationFileCli extends ArrayDesignSequenceManipulatin
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         this.taxonService = this.getBean( TaxonService.class );
 
         this.waitForGeneOntologyReady();

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
@@ -97,7 +97,7 @@ public class ArrayDesignAuditTrailCleanupCli extends ArrayDesignSequenceManipula
                 // keep only last AlignmentBasedGeneMappingEvent, ArrayDesignRepeatAnalysisEvent, ArrayDesignGeneMappingEvent, ArrayDesignSequenceAnalysisEvent 
             }
 
-            this.successObjects.add( arrayDesign );
+            addSuccessObject( arrayDesign, "Successfully processed " + arrayDesign );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
@@ -46,11 +46,6 @@ public class ArrayDesignAuditTrailCleanupCli extends ArrayDesignSequenceManipula
         return "adATcleanup";
     }
 
-    public static int main( String[] args ) {
-        ArrayDesignAuditTrailCleanupCli c = new ArrayDesignAuditTrailCleanupCli();
-        return executeCommand( c, args );
-    }
-
     /*
      * (non-Javadoc)
      *

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
@@ -57,8 +57,7 @@ public class ArrayDesignAuditTrailCleanupCli extends ArrayDesignSequenceManipula
      * @see ubic.gemma.core.util.AbstractCLI#doWork(java.lang.String[])
      */
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {
             arrayDesign = getArrayDesignService().thawLite( arrayDesign );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAuditTrailCleanupCli.java
@@ -1,8 +1,8 @@
 /*
  * The gemma-core project
- * 
+ *
  * Copyright (c) 2018 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -30,16 +30,15 @@ import ubic.gemma.model.common.auditAndSecurity.eventType.AuditEventType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 
 /**
- * 
  * work in progress
- * 
+ *
  * @author paul
  */
 public class ArrayDesignAuditTrailCleanupCli extends ArrayDesignSequenceManipulatingCli {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#getCommandName()
      */
     @Override
@@ -47,21 +46,19 @@ public class ArrayDesignAuditTrailCleanupCli extends ArrayDesignSequenceManipula
         return "adATcleanup";
     }
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ArrayDesignAuditTrailCleanupCli c = new ArrayDesignAuditTrailCleanupCli();
-        c.doWork( args );
+        return executeCommand( c, args );
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#doWork(java.lang.String[])
      */
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
         for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {
             arrayDesign = getArrayDesignService().thawLite( arrayDesign );
 
@@ -108,9 +105,6 @@ public class ArrayDesignAuditTrailCleanupCli extends ArrayDesignSequenceManipula
 
             this.successObjects.add( arrayDesign );
         }
-
-        return null;
-
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBioSequenceDetachCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBioSequenceDetachCli.java
@@ -62,10 +62,8 @@ public class ArrayDesignBioSequenceDetachCli extends ArrayDesignSequenceManipula
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         BioSequenceService bioSequenceService = this.getBean( BioSequenceService.class );
 
@@ -82,7 +80,6 @@ public class ArrayDesignBioSequenceDetachCli extends ArrayDesignSequenceManipula
                 this.audit( arrayDesign, "Removed sequence associations with CLI" );
             }
         }
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBioSequenceDetachCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBioSequenceDetachCli.java
@@ -62,9 +62,7 @@ public class ArrayDesignBioSequenceDetachCli extends ArrayDesignSequenceManipula
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         BioSequenceService bioSequenceService = this.getBean( BioSequenceService.class );
 
         for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBioSequenceDetachCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBioSequenceDetachCli.java
@@ -19,7 +19,6 @@
 package ubic.gemma.core.apps;
 
 import org.apache.commons.cli.Option;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.common.auditAndSecurity.eventType.ArrayDesignSequenceRemoveEvent;
 import ubic.gemma.model.common.auditAndSecurity.eventType.AuditEventType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
@@ -40,11 +39,6 @@ import java.util.Map;
  * @author pavlidis
  */
 public class ArrayDesignBioSequenceDetachCli extends ArrayDesignSequenceManipulatingCli {
-
-    public static void main( String[] args ) {
-        ArrayDesignBioSequenceDetachCli p = new ArrayDesignBioSequenceDetachCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public String getCommandName() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
@@ -172,7 +172,7 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
                     }
                     AbstractCLI.log.info( "Persisted " + persistedResults.size() + " results" );
                 } catch ( IOException e ) {
-                    this.errorObjects.add( e );
+                    addErrorObject( null, e.getMessage(), e );
                 }
             }
 
@@ -220,13 +220,8 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
 
             this.waitForThreadPoolCompletion( threads );
 
-            /*
-             * All done
-             */
-            this.summarizeProcessing();
-
         } else {
-            exitwithError();
+            throw new RuntimeException();
         }
     }
 
@@ -248,8 +243,7 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
         Taxon arrayDesignTaxon;
         File f = new File( blatResultFile );
         if ( !f.canRead() ) {
-            AbstractCLI.log.error( "Cannot read from " + blatResultFile );
-            exitwithError();
+            throw new RuntimeException( "Cannot read from " + blatResultFile );
         }
         // check being running for just one taxon
         arrayDesignTaxon = arrayDesignSequenceAlignmentService.validateTaxaForBlatFile( arrayDesign, taxon );
@@ -268,14 +262,12 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
         try {
             // thaw is already done.
             arrayDesignSequenceAlignmentService.processArrayDesign( design, this.sensitive );
-            successObjects.add( design.getName() );
+            addSuccessObject( design, "Successfully processed " + design.getName() );
             this.audit( design, "Part of a batch job; BLAT score threshold was " + this.blatScoreThreshold );
             this.updateMergedOrSubsumed( design );
 
         } catch ( Exception e ) {
-            errorObjects.add( design + ": " + e.getMessage() );
-            AbstractCLI.log.error( "**** Exception while processing " + design + ": " + e.getMessage() + " ****" );
-            AbstractCLI.log.error( e, e );
+            addErrorObject( design, e.getMessage(), e );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
@@ -54,11 +54,6 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
     private Double blatScoreThreshold = Blat.DEFAULT_BLAT_SCORE_THRESHOLD;
     private boolean sensitive = false;
 
-    public static void main( String[] args ) {
-        ArrayDesignBlatCli p = new ArrayDesignBlatCli();
-        executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.PLATFORM;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
@@ -135,9 +135,7 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         final Date skipIfLastRunLaterThan = this.getLimitingDate();
 
         if ( !this.getArrayDesignsToProcess().isEmpty() ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignBlatCli.java
@@ -135,10 +135,8 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         final Date skipIfLastRunLaterThan = this.getLimitingDate();
 
@@ -152,7 +150,7 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
             for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {
                 if ( !this.shouldRun( skipIfLastRunLaterThan, arrayDesign, ArrayDesignSequenceAnalysisEvent.class ) ) {
                     AbstractCLI.log.warn( arrayDesign + " was last run more recently than " + skipIfLastRunLaterThan );
-                    return null;
+                    return;
                 }
 
                 arrayDesign = this.thaw( arrayDesign );
@@ -237,8 +235,6 @@ public class ArrayDesignBlatCli extends ArrayDesignSequenceManipulatingCli {
         } else {
             exitwithError();
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMapSummaryCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMapSummaryCli.java
@@ -20,7 +20,6 @@ package ubic.gemma.core.apps;
 
 import ubic.gemma.core.analysis.sequence.ArrayDesignMapResultService;
 import ubic.gemma.core.analysis.sequence.CompositeSequenceMapSummary;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 
 import java.util.Collection;
@@ -31,11 +30,6 @@ import java.util.Collection;
  * @author Paul
  */
 public class ArrayDesignMapSummaryCli extends ArrayDesignSequenceManipulatingCli {
-
-    public static void main( String[] args ) {
-        ArrayDesignMapSummaryCli p = new ArrayDesignMapSummaryCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public String getCommandName() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMapSummaryCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMapSummaryCli.java
@@ -43,8 +43,7 @@ public class ArrayDesignMapSummaryCli extends ArrayDesignSequenceManipulatingCli
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         ArrayDesignMapResultService arrayDesignMapResultService = this.getBean( ArrayDesignMapResultService.class );
 
         for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMapSummaryCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMapSummaryCli.java
@@ -43,10 +43,8 @@ public class ArrayDesignMapSummaryCli extends ArrayDesignSequenceManipulatingCli
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
         ArrayDesignMapResultService arrayDesignMapResultService = this.getBean( ArrayDesignMapResultService.class );
 
         for ( ArrayDesign arrayDesign : this.getArrayDesignsToProcess() ) {
@@ -60,7 +58,6 @@ public class ArrayDesignMapSummaryCli extends ArrayDesignSequenceManipulatingCli
                 System.out.println( summary );
             }
         }
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMergeCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMergeCli.java
@@ -46,12 +46,9 @@ public class ArrayDesignMergeCli extends ArrayDesignSequenceManipulatingCli {
     private String newShortName;
     private HashSet<ArrayDesign> otherArrayDesigns;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ArrayDesignMergeCli b = new ArrayDesignMergeCli();
-        Exception e = b.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( b, args );
     }
 
     @Override
@@ -60,16 +57,9 @@ public class ArrayDesignMergeCli extends ArrayDesignSequenceManipulatingCli {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            exitwithError();
-            return err;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
         arrayDesignMergeService.merge( arrayDesign, otherArrayDesigns, newName, newShortName, this.hasOption( "add" ) );
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMergeCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMergeCli.java
@@ -46,11 +46,6 @@ public class ArrayDesignMergeCli extends ArrayDesignSequenceManipulatingCli {
     private String newShortName;
     private HashSet<ArrayDesign> otherArrayDesigns;
 
-    public static int main( String[] args ) {
-        ArrayDesignMergeCli b = new ArrayDesignMergeCli();
-        return executeCommand( b, args );
-    }
-
     @Override
     public String getCommandName() {
         return "mergePlatforms";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMergeCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignMergeCli.java
@@ -57,8 +57,7 @@ public class ArrayDesignMergeCli extends ArrayDesignSequenceManipulatingCli {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         arrayDesignMergeService.merge( arrayDesign, otherArrayDesigns, newName, newShortName, this.hasOption( "add" ) );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
@@ -83,11 +83,8 @@ public class ArrayDesignProbeCleanupCLI extends ArrayDesignSequenceManipulatingC
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         File f = new File( file );
         if ( !f.canRead() ) {
@@ -101,8 +98,8 @@ public class ArrayDesignProbeCleanupCLI extends ArrayDesignSequenceManipulatingC
         }
 
         ArrayDesign arrayDesign = this.getArrayDesignsToProcess().iterator().next();
-        try (InputStream is = new FileInputStream( f );
-                BufferedReader br = new BufferedReader( new InputStreamReader( is ) )) {
+        try ( InputStream is = new FileInputStream( f );
+              BufferedReader br = new BufferedReader( new InputStreamReader( is ) ) ) {
 
             String line;
             int count = 0;
@@ -125,10 +122,8 @@ public class ArrayDesignProbeCleanupCLI extends ArrayDesignSequenceManipulatingC
                 }
             }
             AbstractCLI.log.info( "Deleted " + count + " probes" );
-        } catch ( IOException e ) {
-            return e;
+        } catch ( Exception e ) {
+            throw e;
         }
-
-        return null;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
@@ -80,8 +80,7 @@ public class ArrayDesignProbeCleanupCLI extends ArrayDesignSequenceManipulatingC
     protected void doWork() throws Exception {
         File f = new File( file );
         if ( !f.canRead() ) {
-            AbstractCLI.log.fatal( "Cannot read from " + file );
-            exitwithError();
+            throw new RuntimeException( "Cannot read from " + file );
         }
 
         if ( this.getArrayDesignsToProcess().size() > 1 ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
@@ -83,9 +83,7 @@ public class ArrayDesignProbeCleanupCLI extends ArrayDesignSequenceManipulatingC
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         File f = new File( file );
         if ( !f.canRead() ) {
             AbstractCLI.log.fatal( "Cannot read from " + file );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeCleanupCLI.java
@@ -22,7 +22,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.util.AbstractCLI;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.persistence.service.expression.bioAssayData.ProcessedExpressionDataVectorService;
@@ -43,11 +42,6 @@ public class ArrayDesignProbeCleanupCLI extends ArrayDesignSequenceManipulatingC
     private RawExpressionDataVectorService rawExpressionDataVectorService;
     private ProcessedExpressionDataVectorService processedExpressionDataVectorService;
     private String file;
-
-    public static void main( String[] args ) {
-        ArrayDesignProbeCleanupCLI p = new ArrayDesignProbeCleanupCLI();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
@@ -363,9 +363,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         final Date skipIfLastRunLaterThan = this.getLimitingDate();
 
         if ( this.taxon != null && this.directAnnotationInputFileName == null && this.getArrayDesignsToProcess()

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
@@ -40,7 +40,7 @@ import java.util.concurrent.BlockingQueue;
  * </ol>
  * This can also allow directly associating probes with genes (via products) based on an input file, without any
  * sequence analysis.
- * 
+ * <p>
  * In batch mode, platforms that are "children" (mergees or subsumees) of other platforms will be skipped. Platforms
  * which are themselves merged or subsumers, when run, will result in the child platforms being updated implicitly (via
  * an audit event and report update)
@@ -76,7 +76,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
         return GemmaCLI.CommandGroup.PLATFORM;
     }
 
-    @SuppressWarnings({ "AccessStaticViaInstance", "static-access", "deprecation" })
+    @SuppressWarnings({"AccessStaticViaInstance", "static-access", "deprecation"})
     @Override
     protected void buildOptions() {
         super.buildOptions();
@@ -235,7 +235,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
      */
     @Override
     boolean needToRun( Date skipIfLastRunLaterThan, ArrayDesign arrayDesign,
-            Class<? extends ArrayDesignAnalysisEvent> eventClass ) {
+                       Class<? extends ArrayDesignAnalysisEvent> eventClass ) {
 
         if ( this.hasOption( "force" ) ) {
             return true;
@@ -363,11 +363,8 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         final Date skipIfLastRunLaterThan = this.getLimitingDate();
 
@@ -432,7 +429,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
                                 this.audit( arrayDesign, "Run in miRNA-only mode.", new AlignmentBasedGeneMappingEvent() );
                             } else if ( this.hasOption( ArrayDesignProbeMapperCli.CONFIG_OPTION ) ) {
                                 this.audit( arrayDesign, "Run with configuration=" + this
-                                        .getOptionValue( ArrayDesignProbeMapperCli.CONFIG_OPTION ),
+                                                .getOptionValue( ArrayDesignProbeMapperCli.CONFIG_OPTION ),
                                         new AlignmentBasedGeneMappingEvent() );
                             } else {
                                 this.audit( arrayDesign, "Run with default parameters",
@@ -461,10 +458,8 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
             this.batchRun( skipIfLastRunLaterThan );
 
         } else {
-            return new IllegalArgumentException( "Seems you did not set options to get anything to happen." );
+            throw new IllegalArgumentException( "Seems you did not set options to get anything to happen." );
         }
-
-        return null;
     }
 
     @Override
@@ -485,7 +480,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
         } else {
             allArrayDesigns = getArrayDesignService().loadAll();
         }
-        
+
         // TODO: process array designs in order of how many experiments they use (most first)
 
         final SecurityContext context = SecurityContextHolder.getContext();
@@ -655,7 +650,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
     /**
      * When we analyze a platform that has mergees or subsumed platforms, we can treat them as if they were analyzed as
      * well. We simply add an audit event, and update the report for the platform.
-     * 
+     *
      * @param design platform
      */
     private void updateMergedOrSubsumed( ArrayDesign design ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
@@ -26,8 +26,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 /**
- * Process the blat results for an array design to map them onto genes.
- * Typical workflow would be to run:
+ * Process the blat results for an array design to map them onto genes. Typical workflow would be to run:
  * <ol>
  * <li>Create the array design, perhaps by loading a GPL or via a GSE.
  * <li>ArrayDesignSequenceAssociationCli - attach sequences to array design, fetching from BLAST database if necessary.
@@ -398,9 +397,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
                                 .processArrayDesign( arrayDesign, taxon, f, this.sourceDatabase, this.ncbiIds );
                         this.audit( arrayDesign, "Imported from " + f, new AnnotationBasedGeneMappingEvent() );
                     } catch ( IOException e ) {
-                        errorObjects.add( arrayDesign + ": " + e.getMessage() );
-                        AbstractCLI.log.error( "**** Exception while processing " + arrayDesign + ": " + e.getMessage() + " ****" );
-                        AbstractCLI.log.error( e, e );
+                        addErrorObject( arrayDesign, e.getMessage(), e );
                     }
                 } else {
 
@@ -430,16 +427,13 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
                             updateMergedOrSubsumed( arrayDesign );
                         }
 
-                        successObjects.add( arrayDesign );
+                        addSuccessObject( arrayDesign, "Successfully processed " + arrayDesign );
                     } catch ( Exception e ) {
-                        errorObjects.add( arrayDesign + ": " + e.getMessage() );
-                        AbstractCLI.log.error( "**** Exception while processing " + arrayDesign + ": " + e.getMessage() + " ****" );
-                        AbstractCLI.log.error( e, e );
+                        addErrorObject( arrayDesign, e.getMessage(), e );
                     }
                 }
 
             }
-            this.summarizeProcessing();
         } else if ( taxon != null || skipIfLastRunLaterThan != null || autoSeek ) {
 
             if ( directAnnotationInputFileName != null ) {
@@ -488,7 +482,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
 
                 if ( x.getCurationDetails().getTroubled() ) {
                     AbstractCLI.log.warn( "Skipping troubled platform: " + x );
-                    errorObjects.add( x + ": " + "Skipped because it is troubled; run in non-batch-mode" );
+                    addErrorObject( x, "Skipped because it is troubled; run in non-batch-mode" );
                     return;
                 }
 
@@ -513,11 +507,6 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
         }
 
         this.waitForThreadPoolCompletion( threads );
-
-        /*
-         * All done
-         */
-        this.summarizeProcessing();
     }
 
     private void configure( ArrayDesign arrayDesign ) {
@@ -626,16 +615,14 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
                 log.info( getRelatedDesigns( design ).size() + " subsumed or merged platforms will be implicitly updated" );
             }
             arrayDesignProbeMapperService.processArrayDesign( design, this.config, this.useDB );
-            successObjects.add( design );
+            addSuccessObject( design, "Successfully processed " + design );
             ArrayDesignGeneMappingEvent eventType = new AlignmentBasedGeneMappingEvent();
             this.audit( design, "Part of a batch job", eventType );
 
             updateMergedOrSubsumed( design );
 
         } catch ( Exception e ) {
-            errorObjects.add( design + ": " + e.getMessage() );
-            AbstractCLI.log.error( "**** Exception while processing " + design + ": " + e.getMessage() + " ****" );
-            AbstractCLI.log.error( e, e );
+            addErrorObject( design, e.getMessage(), e );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
@@ -6,7 +6,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import ubic.gemma.core.analysis.sequence.ProbeMapperConfig;
 import ubic.gemma.core.loader.expression.arrayDesign.ArrayDesignProbeMapperService;
 import ubic.gemma.core.util.AbstractCLI;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.common.auditAndSecurity.AuditEvent;
 import ubic.gemma.model.common.auditAndSecurity.eventType.*;
 import ubic.gemma.model.common.description.ExternalDatabase;
@@ -65,11 +64,6 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
     private ExternalDatabase sourceDatabase = null;
     private Taxon taxon = null;
     private boolean useDB = true;
-
-    public static void main( String[] args ) {
-        ArrayDesignProbeMapperCli p = new ArrayDesignProbeMapperCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeRenamerCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeRenamerCli.java
@@ -45,11 +45,6 @@ public class ArrayDesignProbeRenamerCli extends ArrayDesignSequenceManipulatingC
 
     private String fileName;
 
-    public static int main( String[] args ) {
-        ArrayDesignProbeRenamerCli a = new ArrayDesignProbeRenamerCli();
-        return executeCommand( a, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.PLATFORM;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeRenamerCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeRenamerCli.java
@@ -76,9 +76,7 @@ public class ArrayDesignProbeRenamerCli extends ArrayDesignSequenceManipulatingC
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         if ( fileName == null ) {
             throw new IllegalArgumentException( "filename cannot be null" );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeRenamerCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeRenamerCli.java
@@ -45,16 +45,9 @@ public class ArrayDesignProbeRenamerCli extends ArrayDesignSequenceManipulatingC
 
     private String fileName;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ArrayDesignProbeRenamerCli a = new ArrayDesignProbeRenamerCli();
-        try {
-            Exception e = a.doWork( args );
-            if ( e != null ) {
-                AbstractCLI.log.fatal( e, e );
-            }
-        } catch ( RuntimeException e ) {
-            AbstractCLI.log.fatal( e, e );
-        }
+        return executeCommand( a, args );
     }
 
     @Override
@@ -83,11 +76,8 @@ public class ArrayDesignProbeRenamerCli extends ArrayDesignSequenceManipulatingC
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = this.processCommandLine( args );
-        if ( e != null ) {
-            return e;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         if ( fileName == null ) {
             throw new IllegalArgumentException( "filename cannot be null" );
@@ -103,18 +93,16 @@ public class ArrayDesignProbeRenamerCli extends ArrayDesignSequenceManipulatingC
 
         File file = new File( fileName );
         if ( !file.canRead() ) {
-            return new IOException( "Cannot read from " + fileName );
+            throw new IOException( "Cannot read from " + fileName );
         }
-        try (InputStream newIdFile = new FileInputStream( file )) {
+        try ( InputStream newIdFile = new FileInputStream( file ) ) {
 
             this.rename( arrayDesign, newIdFile );
             newIdFile.close();
             this.audit( arrayDesign, "Probes renamed using file " + fileName );
         } catch ( Exception ex ) {
-            return ex;
+            throw ex;
         }
-
-        return null;
     }
 
     private void rename( ArrayDesign arrayDesign, InputStream newIdFile ) {
@@ -156,7 +144,7 @@ public class ArrayDesignProbeRenamerCli extends ArrayDesignSequenceManipulatingC
     }
 
     private Map<String, String> parseIdFile( InputStream newIdFile ) throws IOException {
-        try (BufferedReader br = new BufferedReader( new InputStreamReader( newIdFile ) )) {
+        try ( BufferedReader br = new BufferedReader( new InputStreamReader( newIdFile ) ) ) {
 
             String line;
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
@@ -75,10 +75,8 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception exception = this.processCommandLine( args );
-        if ( exception != null )
-            return exception;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         bsService = this.getBean( BioSequenceService.class );
 
@@ -89,7 +87,7 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
 
                 if ( !this.needToRun( skipIfLastRunLaterThan, arrayDesign, ArrayDesignRepeatAnalysisEvent.class ) ) {
                     AbstractCLI.log.warn( arrayDesign + " was last run more recently than " + skipIfLastRunLaterThan );
-                    return null;
+                    return;
                 }
 
                 arrayDesign = this.thaw( arrayDesign );
@@ -136,8 +134,6 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
         } else {
             exitwithError();
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
@@ -75,9 +75,7 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         bsService = this.getBean( BioSequenceService.class );
 
         Date skipIfLastRunLaterThan = this.getLimitingDate();

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
@@ -22,7 +22,6 @@ import org.apache.commons.cli.Option;
 import ubic.gemma.core.analysis.sequence.RepeatScan;
 import ubic.gemma.core.loader.expression.arrayDesign.ArrayDesignSequenceAlignmentServiceImpl;
 import ubic.gemma.core.util.AbstractCLI;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.common.auditAndSecurity.eventType.ArrayDesignRepeatAnalysisEvent;
 import ubic.gemma.model.common.auditAndSecurity.eventType.AuditEventType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
@@ -41,11 +40,6 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
 
     private BioSequenceService bsService;
     private String inputFileName;
-
-    public static void main( String[] args ) {
-        ArrayDesignRepeatScanCli p = new ArrayDesignRepeatScanCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignRepeatScanCli.java
@@ -95,16 +95,14 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
                 if ( !this.needToRun( skipIfLastRunLaterThan, design, ArrayDesignRepeatAnalysisEvent.class ) ) {
                     AbstractCLI.log.warn( design + " was last run more recently than " + skipIfLastRunLaterThan );
                     // not really an error, but nice to get notification.
-                    errorObjects
-                            .add( design + ": " + "Skipped because it was last run after " + skipIfLastRunLaterThan );
+                    addErrorObject( design, "Skipped because it was last run after " + skipIfLastRunLaterThan );
                     continue;
                 }
 
                 if ( this.isSubsumedOrMerged( design ) ) {
                     AbstractCLI.log.warn( design + " is subsumed or merged into another design, it will not be run." );
                     // not really an error, but nice to get notification.
-                    errorObjects
-                            .add( design + ": " + "Skipped because it is subsumed by or merged into another design." );
+                    addErrorObject( design, "Skipped because it is subsumed by or merged into another design." );
                     continue;
                 }
 
@@ -112,19 +110,15 @@ public class ArrayDesignRepeatScanCli extends ArrayDesignSequenceManipulatingCli
                 try {
                     design = getArrayDesignService().thaw( design );
                     this.processArrayDesign( design );
-                    successObjects.add( design.getName() );
+                    addSuccessObject( design, "Successfully processed " + design.getName() );
                     this.audit( design, "" );
                 } catch ( Exception e ) {
-                    errorObjects.add( design + ": " + e.getMessage() );
-                    AbstractCLI.log
-                            .error( "**** Exception while processing " + design + ": " + e.getMessage() + " ****" );
-                    AbstractCLI.log.error( e, e );
+                    addErrorObject( design, e.getMessage(), e );
                 }
 
             }
-            this.summarizeProcessing();
         } else {
-            exitwithError();
+            throw new RuntimeException();
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSequenceAssociationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSequenceAssociationCli.java
@@ -49,11 +49,6 @@ public class ArrayDesignSequenceAssociationCli extends ArrayDesignSequenceManipu
     private String taxonName = null;
     private TaxonService taxonService;
 
-    public static void main( String[] args ) {
-        ArrayDesignSequenceAssociationCli p = new ArrayDesignSequenceAssociationCli();
-        executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "addPlatformSequences";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSequenceAssociationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSequenceAssociationCli.java
@@ -60,9 +60,7 @@ public class ArrayDesignSequenceAssociationCli extends ArrayDesignSequenceManipu
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         // this is kind of an oddball function of this tool.
         if ( this.hasOption( 's' ) ) {
             BioSequence updated = arrayDesignSequenceProcessingService.processSingleAccession( this.sequenceId,

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSequenceAssociationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSequenceAssociationCli.java
@@ -60,87 +60,78 @@ public class ArrayDesignSequenceAssociationCli extends ArrayDesignSequenceManipu
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        try {
-            Exception err = this.processCommandLine( args );
-            if ( err != null )
-                return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
-            // this is kind of an oddball function of this tool.
-            if ( this.hasOption( 's' ) ) {
-                BioSequence updated = arrayDesignSequenceProcessingService.processSingleAccession( this.sequenceId,
-                        new String[] { "nt", "est_others", "est_human", "est_mouse" }, null, force );
-                if ( updated != null ) {
-                    AbstractCLI.log.info( "Updated or created " + updated );
-                }
-                return null;
+        // this is kind of an oddball function of this tool.
+        if ( this.hasOption( 's' ) ) {
+            BioSequence updated = arrayDesignSequenceProcessingService.processSingleAccession( this.sequenceId,
+                    new String[]{"nt", "est_others", "est_human", "est_mouse"}, null, force );
+            if ( updated != null ) {
+                AbstractCLI.log.info( "Updated or created " + updated );
             }
-
-            if ( getArrayDesignsToProcess().size() > 1 ) {
-                throw new IllegalStateException( "Only one platform can be processed by this CLI" );
-            }
-
-            ArrayDesign arrayDesign = this.getArrayDesignsToProcess().iterator().next();
-
-            arrayDesign = this.thaw( arrayDesign );
-
-            SequenceType sequenceTypeEn = SequenceType.fromString( sequenceType );
-
-            if ( sequenceTypeEn == null ) {
-                throw new IllegalArgumentException( "No sequenceType " + sequenceType + " found" );
-
-            }
-
-            Taxon taxon = null;
-            if ( this.hasOption( 't' ) ) {
-                assert StringUtils.isNotBlank( this.taxonName );
-                taxon = taxonService.findByCommonName( this.taxonName );
-                if ( taxon == null ) {
-                    throw new IllegalArgumentException( "No taxon named " + taxonName );
-                }
-            }
-
-            if ( this.hasOption( 'f' ) ) {
-                try (InputStream sequenceFileIs = FileTools
-                        .getInputStreamFromPlainOrCompressedFile( sequenceFile )) {
-
-                    if ( sequenceFileIs == null ) {
-                        throw new IllegalArgumentException( "No file " + sequenceFile + " was readable" );
-                    }
-
-                    AbstractCLI.log.info( "Processing ArrayDesign..." );
-
-                    arrayDesignSequenceProcessingService
-                            .processArrayDesign( arrayDesign, sequenceFileIs, sequenceTypeEn, taxon );
-
-                    this.audit( arrayDesign, "Sequences read from file: " + sequenceFile );
-                }
-            } else if ( this.hasOption( 'i' ) ) {
-                try (InputStream idFileIs = FileTools.getInputStreamFromPlainOrCompressedFile( idFile )) {
-
-                    if ( idFileIs == null ) {
-                        throw new IllegalArgumentException( "No file " + idFile + " was readable" );
-                    }
-
-                    AbstractCLI.log.info( "Processing ArrayDesign..." );
-
-                    arrayDesignSequenceProcessingService.processArrayDesign( arrayDesign, idFileIs,
-                            new String[] { "nt", "est_others", "est_human", "est_mouse" }, null, taxon, force );
-
-                    this.audit( arrayDesign, "Sequences identifiers from file: " + idFile );
-                }
-            } else {
-                AbstractCLI.log.info( "Retrieving sequences from BLAST databases" );
-                arrayDesignSequenceProcessingService.processArrayDesign( arrayDesign,
-                        new String[] { "nt", "est_others", "est_human", "est_mouse" }, null, force );
-                this.audit( arrayDesign, "Sequence looked up from BLAST databases" );
-            }
-
-        } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-            return e;
+            return;
         }
-        return null;
+
+        if ( getArrayDesignsToProcess().size() > 1 ) {
+            throw new IllegalStateException( "Only one platform can be processed by this CLI" );
+        }
+
+        ArrayDesign arrayDesign = this.getArrayDesignsToProcess().iterator().next();
+
+        arrayDesign = this.thaw( arrayDesign );
+
+        SequenceType sequenceTypeEn = SequenceType.fromString( sequenceType );
+
+        if ( sequenceTypeEn == null ) {
+            throw new IllegalArgumentException( "No sequenceType " + sequenceType + " found" );
+
+        }
+
+        Taxon taxon = null;
+        if ( this.hasOption( 't' ) ) {
+            assert StringUtils.isNotBlank( this.taxonName );
+            taxon = taxonService.findByCommonName( this.taxonName );
+            if ( taxon == null ) {
+                throw new IllegalArgumentException( "No taxon named " + taxonName );
+            }
+        }
+
+        if ( this.hasOption( 'f' ) ) {
+            try ( InputStream sequenceFileIs = FileTools
+                    .getInputStreamFromPlainOrCompressedFile( sequenceFile ) ) {
+
+                if ( sequenceFileIs == null ) {
+                    throw new IllegalArgumentException( "No file " + sequenceFile + " was readable" );
+                }
+
+                AbstractCLI.log.info( "Processing ArrayDesign..." );
+
+                arrayDesignSequenceProcessingService
+                        .processArrayDesign( arrayDesign, sequenceFileIs, sequenceTypeEn, taxon );
+
+                this.audit( arrayDesign, "Sequences read from file: " + sequenceFile );
+            }
+        } else if ( this.hasOption( 'i' ) ) {
+            try ( InputStream idFileIs = FileTools.getInputStreamFromPlainOrCompressedFile( idFile ) ) {
+
+                if ( idFileIs == null ) {
+                    throw new IllegalArgumentException( "No file " + idFile + " was readable" );
+                }
+
+                AbstractCLI.log.info( "Processing ArrayDesign..." );
+
+                arrayDesignSequenceProcessingService.processArrayDesign( arrayDesign, idFileIs,
+                        new String[]{"nt", "est_others", "est_human", "est_mouse"}, null, taxon, force );
+
+                this.audit( arrayDesign, "Sequences identifiers from file: " + idFile );
+            }
+        } else {
+            AbstractCLI.log.info( "Retrieving sequences from BLAST databases" );
+            arrayDesignSequenceProcessingService.processArrayDesign( arrayDesign,
+                    new String[]{"nt", "est_others", "est_human", "est_mouse"}, null, force );
+            this.audit( arrayDesign, "Sequence looked up from BLAST databases" );
+        }
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSubsumptionTesterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSubsumptionTesterCli.java
@@ -20,7 +20,6 @@ package ubic.gemma.core.apps;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
-import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.model.common.auditAndSecurity.eventType.ArrayDesignSubsumeCheckEvent;
 import ubic.gemma.model.common.auditAndSecurity.eventType.AuditEventType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
@@ -49,9 +48,7 @@ public class ArrayDesignSubsumptionTesterCli extends ArrayDesignSequenceManipula
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         if ( this.getArrayDesignsToProcess().size() > 1 ) {
             throw new IllegalArgumentException(
                     "Cannot be applied to more than one array design given to the '-a' option" );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSubsumptionTesterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSubsumptionTesterCli.java
@@ -37,11 +37,6 @@ public class ArrayDesignSubsumptionTesterCli extends ArrayDesignSequenceManipula
 
     private Collection<String> otherArrayDesignNames;
 
-    public static int main( String[] args ) {
-        ArrayDesignSubsumptionTesterCli tester = new ArrayDesignSubsumptionTesterCli();
-        return executeCommand( tester, args );
-    }
-
     @Override
     public String getCommandName() {
         return "platformSubsumptionTest";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSubsumptionTesterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignSubsumptionTesterCli.java
@@ -38,12 +38,9 @@ public class ArrayDesignSubsumptionTesterCli extends ArrayDesignSequenceManipula
 
     private Collection<String> otherArrayDesignNames;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ArrayDesignSubsumptionTesterCli tester = new ArrayDesignSubsumptionTesterCli();
-        Exception e = tester.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( tester, args );
     }
 
     @Override
@@ -52,13 +49,8 @@ public class ArrayDesignSubsumptionTesterCli extends ArrayDesignSequenceManipula
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            exitwithError();
-            return err;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         if ( this.getArrayDesignsToProcess().size() > 1 ) {
             throw new IllegalArgumentException(
@@ -76,8 +68,7 @@ public class ArrayDesignSubsumptionTesterCli extends ArrayDesignSequenceManipula
             }
 
             if ( otherArrayDesign == null ) {
-                AbstractCLI.log.error( "No arrayDesign " + otherArrayDesignName + " found" );
-                exitwithError();
+                throw new Exception( "No arrayDesign " + otherArrayDesignName + " found" );
             }
 
             otherArrayDesign = this.thaw( otherArrayDesign );
@@ -92,8 +83,6 @@ public class ArrayDesignSubsumptionTesterCli extends ArrayDesignSequenceManipula
         }
 
         this.audit( arrayDesign, "Tested to see if it subsumes: " + StringUtils.join( otherArrayDesignNames, ',' ) );
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
@@ -28,11 +28,6 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public class BatchEffectPopulationCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        BatchEffectPopulationCli b = new BatchEffectPopulationCli();
-        return executeCommand( b, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
@@ -63,20 +63,17 @@ public class BatchEffectPopulationCli extends ExpressionExperimentManipulatingCL
                     ee = this.eeService.thawLite( ee );
                     boolean success = ser.fillBatchInformation( ee, force );
                     if ( success ) {
-                        this.successObjects.add( bas.toString() );
+                        addSuccessObject( bas, "Successfully processed " + bas );
                     } else {
-                        this.errorObjects.add( bas.toString() );
+                        addErrorObject( bas, "Failed to process " + bas );
                     }
 
                 } catch ( Exception e ) {
-                    AbstractCLI.log.error( e, e );
-                    this.errorObjects.add( bas + ": " + e.getMessage() );
+                    addErrorObject( bas, e.getMessage(), e );
                 }
 
             }
         }
-
-        this.summarizeProcessing();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
@@ -50,9 +50,7 @@ public class BatchEffectPopulationCli extends ExpressionExperimentManipulatingCL
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         BatchInfoPopulationService ser = this.getBean( BatchInfoPopulationService.class );
 
         for ( BioAssaySet bas : this.expressionExperiments ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BatchEffectPopulationCli.java
@@ -28,13 +28,9 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public class BatchEffectPopulationCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         BatchEffectPopulationCli b = new BatchEffectPopulationCli();
-
-        Exception e = b.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( b, args );
     }
 
     @Override
@@ -54,11 +50,8 @@ public class BatchEffectPopulationCli extends ExpressionExperimentManipulatingCL
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception ex = super.processCommandLine( args );
-        if ( ex != null )
-            return ex;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         BatchInfoPopulationService ser = this.getBean( BatchInfoPopulationService.class );
 
@@ -91,7 +84,6 @@ public class BatchEffectPopulationCli extends ExpressionExperimentManipulatingCL
         }
 
         this.summarizeProcessing();
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BibRefUpdaterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BibRefUpdaterCli.java
@@ -36,11 +36,6 @@ import java.util.Collection;
  */
 public class BibRefUpdaterCli extends AbstractCLIContextCLI {
 
-    public static void main( String[] args ) {
-        BibRefUpdaterCli e = new BibRefUpdaterCli();
-        executeCommand( e, args );
-    }
-
     @Override
     public String getCommandName() {
         return "updatePubMeds";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BibRefUpdaterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BibRefUpdaterCli.java
@@ -63,8 +63,7 @@ public class BibRefUpdaterCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         BibliographicReferenceService bibliographicReferenceService = this
                 .getBean( BibliographicReferenceService.class );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BibRefUpdaterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BibRefUpdaterCli.java
@@ -1,8 +1,8 @@
 /*
  * The gemma project
- * 
+ *
  * Copyright (c) 2013 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -31,7 +31,7 @@ import java.util.Collection;
 
 /**
  * Refreshes the information in all the bibliographic references in the system.
- * 
+ *
  * @author Paul
  */
 public class BibRefUpdaterCli extends AbstractCLIContextCLI {
@@ -63,9 +63,8 @@ public class BibRefUpdaterCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception ex = super.processCommandLine( args );
-        if ( ex != null ) return ex;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
         BibliographicReferenceService bibliographicReferenceService = this
                 .getBean( BibliographicReferenceService.class );
 
@@ -101,14 +100,8 @@ public class BibRefUpdaterCli extends AbstractCLIContextCLI {
             } catch ( Exception e ) {
                 log.info( "Failed to update: " + bibref + " (" + e.getMessage() + ")" );
             }
-            try {
-                Thread.sleep( RandomUtils.nextInt( 1000 ) );
-            } catch ( InterruptedException e ) {
-                return e;
-            }
+            Thread.sleep( RandomUtils.nextInt( 1000 ) );
         }
-
-        return null;
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
@@ -32,7 +32,6 @@ import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityDao
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.io.IOException;
 
 /**
  * Add entries to the blacklist
@@ -81,9 +80,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         BlacklistedEntityDao blacklistedEntityDao = this.getBean( BlacklistedEntityDao.class );
         ExternalDatabaseDao externalDatabaseDao = this.getBean( ExternalDatabaseDao.class );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
@@ -35,18 +35,12 @@ import java.io.FileReader;
 
 /**
  * Add entries to the blacklist
- *
  * @author paul
  */
 public class BlacklistCli extends AbstractCLIContextCLI {
 
     String fileName = null;
     private boolean remove = false;
-
-    public static void main( String[] args ) {
-        BlacklistCli e = new BlacklistCli();
-        executeCommand( e, args );
-    }
 
     @Override
     public CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
@@ -81,11 +81,8 @@ public class BlacklistCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception ex = super.processCommandLine( args );
-        if ( ex != null )
-            return ex;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         BlacklistedEntityDao blacklistedEntityDao = this.getBean( BlacklistedEntityDao.class );
         ExternalDatabaseDao externalDatabaseDao = this.getBean( ExternalDatabaseDao.class );
@@ -95,7 +92,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
         if ( geo == null )
             throw new IllegalStateException( "GEO not found as an external database in the system" );
 
-        try (BufferedReader in = new BufferedReader( new FileReader( fileName ) )) {
+        try ( BufferedReader in = new BufferedReader( new FileReader( fileName ) ) ) {
             while ( in.ready() ) {
                 String line = in.readLine().trim();
                 if ( line.startsWith( "#" ) ) {
@@ -165,11 +162,9 @@ public class BlacklistCli extends AbstractCLIContextCLI {
                 log.info( "Blacklisted " + accession );
             }
 
-        } catch ( IOException e ) {
-            return e;
+        } catch ( Exception e ) {
+            throw e;
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/CountObsoleteTermsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/CountObsoleteTermsCli.java
@@ -75,10 +75,8 @@ public class CountObsoleteTermsCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = super.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         int start = Integer.parseInt( startArg ) + 1;
         int step = Integer.parseInt( stepArg ) + 1;
@@ -99,7 +97,5 @@ public class CountObsoleteTermsCli extends AbstractCLIContextCLI {
         }
         AbstractCLI.log.info( "======================================================" );
         AbstractCLI.log.info( "======================================================" );
-
-        return null;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/CountObsoleteTermsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/CountObsoleteTermsCli.java
@@ -75,9 +75,7 @@ public class CountObsoleteTermsCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         int start = Integer.parseInt( startArg ) + 1;
         int step = Integer.parseInt( stepArg ) + 1;
         int stop = Integer.parseInt( stopArg ) + 1;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/CountObsoleteTermsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/CountObsoleteTermsCli.java
@@ -15,11 +15,6 @@ public class CountObsoleteTermsCli extends AbstractCLIContextCLI {
     private String stepArg = "100000";
     private String stopArg;
 
-    public static void main( String[] args ) {
-        CountObsoleteTermsCli p = new CountObsoleteTermsCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DatabaseViewGeneratorCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DatabaseViewGeneratorCLI.java
@@ -87,8 +87,7 @@ public class DatabaseViewGeneratorCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         DatabaseViewGenerator v = this.getBean( DatabaseViewGenerator.class );
         v.runAll();
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DatabaseViewGeneratorCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DatabaseViewGeneratorCLI.java
@@ -31,7 +31,7 @@ import ubic.gemma.core.util.AbstractCLIContextCLI;
  *
  * @author paul
  */
-@SuppressWarnings({ "FieldCanBeLocal", "unused" }) // Possible external use
+@SuppressWarnings({"FieldCanBeLocal", "unused"}) // Possible external use
 public class DatabaseViewGeneratorCLI extends AbstractCLIContextCLI {
 
     private boolean generateDatasetSummary = false;
@@ -39,12 +39,9 @@ public class DatabaseViewGeneratorCLI extends AbstractCLIContextCLI {
     private boolean generateTissueSummary = false;
     private int limit = 0;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         DatabaseViewGeneratorCLI o = new DatabaseViewGeneratorCLI();
-        Exception e = o.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( o, args );
     }
 
     @Override
@@ -90,14 +87,10 @@ public class DatabaseViewGeneratorCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = super.processCommandLine( args );
-        if ( err != null )
-            return err;
-
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
         DatabaseViewGenerator v = this.getBean( DatabaseViewGenerator.class );
         v.runAll();
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DatabaseViewGeneratorCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DatabaseViewGeneratorCLI.java
@@ -39,11 +39,6 @@ public class DatabaseViewGeneratorCLI extends AbstractCLIContextCLI {
     private boolean generateTissueSummary = false;
     private int limit = 0;
 
-    public static int main( String[] args ) {
-        DatabaseViewGeneratorCLI o = new DatabaseViewGeneratorCLI();
-        return executeCommand( o, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.ANALYSIS;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
@@ -43,16 +43,13 @@ public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
                 }
                 log.info( "--------- Deleting any diff ex analyses for " + bas + " --------" );
                 deas.removeForExperiment( ( ExpressionExperiment ) bas );
-                successObjects.add( bas );
+                addSuccessObject( bas, "Successfully processed " + bas );
                 log.info( "--------- Finished Deleting for " + bas + " -------" );
 
             } catch ( Exception ex ) {
-                log.error( ex );
-                errorObjects.add( bas + " :" + ex.getMessage() );
+                addErrorObject( bas, ex.getMessage(), ex );
             }
         }
-
-        summarizeProcessing();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
@@ -27,7 +27,7 @@ public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
 
     public static int main( String[] args ) {
         DeleteDiffExCli d = new DeleteDiffExCli();
-        return executeCommand(d, args);
+        return executeCommand( d, args );
     }
 
     @Override
@@ -36,9 +36,8 @@ public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
+    protected void doWork() throws Exception {
         this.force = true;
-        super.processCommandLine( args );
 
         DifferentialExpressionAnalysisService deas = this.getBean( DifferentialExpressionAnalysisService.class );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
@@ -25,12 +25,9 @@ import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpre
  */
 public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         DeleteDiffExCli d = new DeleteDiffExCli();
-        Exception e = d.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand(d, args);
     }
 
     @Override
@@ -39,11 +36,9 @@ public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
         this.force = true;
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+        super.processCommandLine( args );
 
         DifferentialExpressionAnalysisService deas = this.getBean( DifferentialExpressionAnalysisService.class );
 
@@ -64,8 +59,6 @@ public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
         }
 
         summarizeProcessing();
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteDiffExCli.java
@@ -25,11 +25,6 @@ import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpre
  */
 public class DeleteDiffExCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        DeleteDiffExCli d = new DeleteDiffExCli();
-        return executeCommand( d, args );
-    }
-
     @Override
     public String getCommandName() {
         return "deleteDiffEx";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
@@ -35,10 +35,8 @@ public class DeleteExperimentsCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
+    protected void doWork() throws Exception {
         this.force = true;
-        super.processCommandLine( args );
-
         for ( BioAssaySet bas : this.expressionExperiments ) {
             try {
                 log.info( "--------- Deleting " + bas + " --------" );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
@@ -24,11 +24,6 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public class DeleteExperimentsCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        DeleteExperimentsCli d = new DeleteExperimentsCli();
-        return executeCommand( d, args );
-    }
-
     @Override
     public String getCommandName() {
         return "deleteExperiments";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
@@ -24,12 +24,9 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public class DeleteExperimentsCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         DeleteExperimentsCli d = new DeleteExperimentsCli();
-        Exception e = d.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( d, args );
     }
 
     @Override
@@ -38,11 +35,9 @@ public class DeleteExperimentsCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
         this.force = true;
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+        super.processCommandLine( args );
 
         for ( BioAssaySet bas : this.expressionExperiments ) {
             try {
@@ -57,8 +52,6 @@ public class DeleteExperimentsCli extends ExpressionExperimentManipulatingCLI {
         }
 
         summarizeProcessing();
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DeleteExperimentsCli.java
@@ -36,15 +36,12 @@ public class DeleteExperimentsCli extends ExpressionExperimentManipulatingCLI {
             try {
                 log.info( "--------- Deleting " + bas + " --------" );
                 this.eeService.remove( ( ExpressionExperiment ) bas );
-                successObjects.add( bas );
+                addSuccessObject( bas, "Successfully deleted " + bas );
                 log.info( "--------- Finished Deleting " + bas + " -------" );
             } catch ( Exception ex ) {
-                log.error( ex, ex );
-                errorObjects.add( bas + " " + ex.getMessage() );
+                addErrorObject( bas, ex.getMessage(), ex );
             }
         }
-
-        summarizeProcessing();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
@@ -75,12 +75,6 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
 
     private boolean persist = true;
 
-    public static void main( String[] args ) {
-        DifferentialExpressionAnalysisCli p = new DifferentialExpressionAnalysisCli();
-        executeCommand( p, args );
-
-    }
-
     @Override
     public String getCommandName() {
         return "diffExAnalyze";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
@@ -87,9 +87,7 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         SecurityService securityService = this.getBean( SecurityService.class );
 
         for ( BioAssaySet ee : expressionExperiments ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
@@ -87,11 +87,8 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            return err;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         SecurityService securityService = this.getBean( SecurityService.class );
 
@@ -118,8 +115,6 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
         }
 
         this.summarizeProcessing();
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/DifferentialExpressionAnalysisCli.java
@@ -105,8 +105,6 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
 
             this.processExperiment( ( ExpressionExperiment ) ee );
         }
-
-        this.summarizeProcessing();
     }
 
     @Override
@@ -270,7 +268,7 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
             if ( delete ) {
                 AbstractCLI.log.info( "Deleting any analyses for experiment=" + ee );
                 differentialExpressionAnalyzerService.deleteAnalyses( ee );
-                successObjects.add( "Deleted analysis for: " + ee.toString() );
+                addSuccessObject( ee, "Deleted analysis" );
                 return;
             }
 
@@ -392,12 +390,11 @@ public class DifferentialExpressionAnalysisCli extends ExpressionExperimentManip
                 }
             }
 
-            successObjects.add( ee.toString() );
+            addSuccessObject( ee, "Successfully processed " + ee.getShortName() );
 
         } catch ( Exception e ) {
-            AbstractCLI.log.error( "Error while processing " + ee + ": " + e.getMessage() );
             ExceptionUtils.printRootCauseStackTrace( e );
-            errorObjects.add( ee + ": " + e.getMessage() );
+            addErrorObject( ee, e.getMessage(), e );
         }
 
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
@@ -32,7 +32,7 @@ import java.io.*;
 
 /**
  * @author Paul
- * @see    ExperimentalDesignImporter
+ * @see ExperimentalDesignImporter
  */
 public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
 
@@ -72,10 +72,8 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = this.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         ExperimentalFactorOntologyService mos = this.getBean( OntologyService.class )
                 .getExperimentalFactorOntologyService();
@@ -92,13 +90,7 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
         ExperimentalDesignImporter edImp = this.getBean( ExperimentalDesignImporter.class );
         ExpressionExperimentService ees = this.getBean( ExpressionExperimentService.class );
         expressionExperiment = ees.thawBioAssays( expressionExperiment );
-        try {
-            edImp.importDesign( expressionExperiment, inputStream );
-        } catch ( IOException e1 ) {
-            return e1;
-        }
-
-        return null;
+        edImp.importDesign( expressionExperiment, inputStream );
     }
 
     @Override
@@ -134,7 +126,7 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
      * @return           experiment with the given short name, if it exists. Bails otherwise with
      *                   {@link ubic.gemma.core.util.AbstractCLI.ErrorCode#INVALID_OPTION}.
      */
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     protected ExpressionExperiment locateExpressionExperiment( String shortName ) {
 
         if ( shortName == null ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
@@ -72,9 +72,7 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         ExperimentalFactorOntologyService mos = this.getBean( OntologyService.class )
                 .getExperimentalFactorOntologyService();
         mos.startInitializationThread( true, false ); // note will *not* re-index

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
@@ -115,23 +115,22 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
     }
 
     /**
-     * @param  shortName short name of the experiment to find.
-     * @return           experiment with the given short name, if it exists. Bails otherwise with
-     *                   {@link ubic.gemma.core.util.AbstractCLI.ErrorCode#INVALID_OPTION}.
+     * @param shortName short name of the experiment to find.
+     * @return experiment with the given short name, if it exists. Bails otherwise with {@link
+     *         ubic.gemma.core.util.AbstractCLI.ErrorCode#INVALID_OPTION}.
      */
     @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     protected ExpressionExperiment locateExpressionExperiment( String shortName ) {
 
         if ( shortName == null ) {
-            errorObjects.add( "Expression experiment short name must be provided" );
+            addErrorObject( null, "Expression experiment short name must be provided" );
             return null;
         }
         ExpressionExperimentService eeService = this.getBean( ExpressionExperimentService.class );
         ExpressionExperiment experiment = eeService.findByShortName( shortName );
 
         if ( experiment == null ) {
-            AbstractCLI.log.error( "No experiment " + shortName + " found" );
-            exitwithError();
+            throw new RuntimeException( "No experiment " + shortName + " found" );
         }
         return experiment;
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
@@ -39,11 +39,6 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
     private ExpressionExperiment expressionExperiment;
     private InputStream inputStream;
 
-    public static void main( String[] args ) {
-        ExperimentalDesignImportCli e = new ExperimentalDesignImportCli();
-        executeCommand( e, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignViewCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignViewCli.java
@@ -14,11 +14,6 @@ import java.util.*;
  */
 public class ExperimentalDesignViewCli extends AbstractCLIContextCLI {
 
-    public static void main( String[] args ) {
-        ExperimentalDesignViewCli p = new ExperimentalDesignViewCli();
-        executeCommand( p, args );
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.ANALYSIS;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignViewCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignViewCli.java
@@ -39,9 +39,8 @@ public class ExperimentalDesignViewCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = processCommandLine( args );
-        if ( err != null ) return err;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         ExperimentalDesignService eds = getBean( ExperimentalDesignService.class );
 
@@ -138,8 +137,6 @@ public class ExperimentalDesignViewCli extends AbstractCLIContextCLI {
                 }
             }
         }
-
-        return null;
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignViewCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignViewCli.java
@@ -39,9 +39,7 @@ public class ExperimentalDesignViewCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         ExperimentalDesignService eds = getBean( ExperimentalDesignService.class );
 
         ExpressionExperimentService ees = getBean( ExpressionExperimentService.class );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignWriterCLI.java
@@ -36,11 +36,6 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
 
     private String outFileName;
 
-    public static int main( String[] args ) {
-        ExperimentalDesignWriterCLI cli = new ExperimentalDesignWriterCLI();
-        return executeCommand( cli, args );
-    }
-
     @Override
     public String getCommandName() {
         return "printExperimentalDesign";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignWriterCLI.java
@@ -21,7 +21,6 @@ package ubic.gemma.core.apps;
 import org.apache.commons.cli.Option;
 import ubic.basecode.util.FileTools;
 import ubic.gemma.core.datastructure.matrix.ExperimentalDesignWriter;
-import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 
@@ -48,9 +47,7 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         for ( BioAssaySet ee : expressionExperiments ) {
 
             if ( ee instanceof ExpressionExperiment ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignWriterCLI.java
@@ -37,12 +37,9 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
 
     private String outFileName;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ExperimentalDesignWriterCLI cli = new ExperimentalDesignWriterCLI();
-        Exception exc = cli.doWork( args );
-        if ( exc != null ) {
-            AbstractCLI.log.error( exc.getMessage() );
-        }
+        return executeCommand( cli, args );
     }
 
     @Override
@@ -51,31 +48,27 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         for ( BioAssaySet ee : expressionExperiments ) {
 
             if ( ee instanceof ExpressionExperiment ) {
                 ExperimentalDesignWriter edWriter = new ExperimentalDesignWriter();
 
-                try (PrintWriter writer = new PrintWriter(
+                try ( PrintWriter writer = new PrintWriter(
                         outFileName + "_" + FileTools.cleanForFileName( ( ( ExpressionExperiment ) ee ).getShortName() )
-                                + ".txt" )) {
+                                + ".txt" ) ) {
 
                     edWriter.write( writer, ( ExpressionExperiment ) ee, true );
                     writer.flush();
                 } catch ( IOException exception ) {
-                    return exception;
+                    throw exception;
                 }
             } else {
                 throw new UnsupportedOperationException( "Can't handle non-EE BioAssaySets yet" );
             }
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
@@ -30,15 +30,9 @@ import ubic.gemma.persistence.service.analysis.expression.sampleCoexpression.Sam
  */
 public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
-        try {
-            ExpressionDataCorrMatCli e = new ExpressionDataCorrMatCli();
-            Exception ex = e.doWork( args );
-            if ( ex != null )
-                AbstractCLI.log.info( ex, ex );
-        } catch ( Exception e ) {
-            AbstractCLI.log.info( e, e );
-        }
+    public static int main( String[] args ) {
+        ExpressionDataCorrMatCli e = new ExpressionDataCorrMatCli();
+        return executeCommand( e, args );
     }
 
     @Override
@@ -47,8 +41,8 @@ public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCL
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception exception = this.processCommandLine( args );
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         for ( BioAssaySet ee : expressionExperiments ) {
             try {
@@ -65,7 +59,6 @@ public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCL
 
         }
         this.summarizeProcessing();
-        return exception;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
@@ -41,9 +41,7 @@ public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCL
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         for ( BioAssaySet ee : expressionExperiments ) {
             try {
                 if ( !( ee instanceof ExpressionExperiment ) ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
@@ -40,18 +40,16 @@ public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCL
         for ( BioAssaySet ee : expressionExperiments ) {
             try {
                 if ( !( ee instanceof ExpressionExperiment ) ) {
-                    errorObjects.add( ee );
+                    addErrorObject( ee, "This is not an ExpressionExperiment!" );
                     continue;
                 }
                 this.processExperiment( ( ExpressionExperiment ) ee );
-                successObjects.add( ee );
+                addSuccessObject( ee, "Successfully processed " + ( ( ExpressionExperiment ) ee ).getShortName() );
             } catch ( Exception e ) {
-                AbstractCLI.log.error( "Error while processing " + ee, e );
-                errorObjects.add( ee );
+                addErrorObject( ee, "Error while processing", e );
             }
 
         }
-        this.summarizeProcessing();
     }
 
     @Override
@@ -67,7 +65,7 @@ public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCL
 
     private void audit( ExpressionExperiment ee ) {
         auditTrailService.addUpdateEvent( ee, null, "Generated sample correlation matrix" );
-        successObjects.add( ee.toString() );
+        addSuccessObject( ee, "Successfully processed " + ee.getShortName() );
     }
 
     private void processExperiment( ExpressionExperiment ee ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataCorrMatCli.java
@@ -30,11 +30,6 @@ import ubic.gemma.persistence.service.analysis.expression.sampleCoexpression.Sam
  */
 public class ExpressionDataCorrMatCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        ExpressionDataCorrMatCli e = new ExpressionDataCorrMatCli();
-        return executeCommand( e, args );
-    }
-
     @Override
     public String getCommandName() {
         return "corrMat";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
@@ -83,7 +83,7 @@ public class ExpressionDataMatrixWriterCLI extends ExpressionExperimentManipulat
             try {
                 fs.writeDataFile( ( ExpressionExperiment ) ee, filter, fileName, false );
             } catch ( IOException e ) {
-                this.errorObjects.add( ee + ": " + e );
+                addErrorObject( ee, e.getMessage(), e );
             }
         }
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
@@ -36,11 +36,6 @@ public class ExpressionDataMatrixWriterCLI extends ExpressionExperimentManipulat
     private boolean filter = false;
     private String outFileName = null;
 
-    public static void main( String[] args ) {
-        ExpressionDataMatrixWriterCLI cli = new ExpressionDataMatrixWriterCLI();
-        executeCommand( cli, args );
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
@@ -70,9 +70,7 @@ public class ExpressionDataMatrixWriterCLI extends ExpressionExperimentManipulat
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         ExpressionDataFileService fs = this.getBean( ExpressionDataFileService.class );
 
         if ( expressionExperiments.size() > 1 && StringUtils.isNotBlank( outFileName ) ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionDataMatrixWriterCLI.java
@@ -70,11 +70,8 @@ public class ExpressionDataMatrixWriterCLI extends ExpressionExperimentManipulat
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         ExpressionDataFileService fs = this.getBean( ExpressionDataFileService.class );
 
@@ -96,8 +93,6 @@ public class ExpressionDataMatrixWriterCLI extends ExpressionExperimentManipulat
                 this.errorObjects.add( ee + ": " + e );
             }
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
@@ -44,11 +44,6 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
     private ExpressionDataFileService expressionDataFileService;
     private boolean force_write = false;
 
-    public static int main( String[] args ) {
-        ExpressionExperimentDataFileGeneratorCli p = new ExpressionExperimentDataFileGeneratorCli();
-        return executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "generateDataFile";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
@@ -107,8 +107,6 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
         }
 
         this.waitForThreadPoolCompletion( threads );
-
-        this.summarizeProcessing();
     }
 
     @Override
@@ -156,12 +154,10 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
             expressionDataFileService.writeOrLocateDiffExpressionDataFiles( ee, force_write );
 
             ats.addUpdateEvent( ee, type, "Generated Flat data files for downloading" );
-            super.successObjects.add( "Success:  generated data file for " + ee.getShortName() + " ID=" + ee.getId() );
+            addSuccessObject( ee, "Success:  generated data file for " + ee.getShortName() + " ID=" + ee.getId() );
 
         } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-            super.errorObjects
-                    .add( "FAILED: for ee: " + ee.getShortName() + " ID= " + ee.getId() + " Error: " + e.getMessage() );
+            addErrorObject( ee, "FAILED: for ee: " + ee.getShortName() + " ID= " + ee.getId() + " Error: " + e.getMessage(), e );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
@@ -44,12 +44,9 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
     private ExpressionDataFileService expressionDataFileService;
     private boolean force_write = false;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ExpressionExperimentDataFileGeneratorCli p = new ExpressionExperimentDataFileGeneratorCli();
-        Exception e = p.doWork( args );
-        if ( e != null ) {
-            AbstractCLI.log.fatal( e, e );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -58,12 +55,8 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception exp = this.processCommandLine( args );
-        if ( exp != null ) {
-            return exp;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         BlockingQueue<BioAssaySet> queue = new ArrayBlockingQueue<>( expressionExperiments.size() );
 
@@ -123,9 +116,6 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
         this.waitForThreadPoolCompletion( threads );
 
         this.summarizeProcessing();
-
-        return null;
-
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentDataFileGeneratorCli.java
@@ -55,9 +55,7 @@ public class ExpressionExperimentDataFileGeneratorCli extends ExpressionExperime
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         BlockingQueue<BioAssaySet> queue = new ArrayBlockingQueue<>( expressionExperiments.size() );
 
         // Add the Experiments to the queue for processing

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentManipulatingCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentManipulatingCLI.java
@@ -269,8 +269,7 @@ public abstract class ExpressionExperimentManipulatingCLI extends AbstractCLICon
             expressionExperiments.add( expressionExperiment );
         }
         if ( expressionExperiments.size() == 0 ) {
-            AbstractCLI.log.error( "There were no valid experimnents specified" );
-            exitwithError();
+            throw new RuntimeException( "There were no valid experimnents specified" );
         }
     }
 
@@ -331,15 +330,14 @@ public abstract class ExpressionExperimentManipulatingCLI extends AbstractCLICon
     private ExpressionExperiment locateExpressionExperiment( String name ) {
 
         if ( name == null ) {
-            errorObjects.add( "Expression experiment short name must be provided" );
+            addErrorObject( null, "Expression experiment short name must be provided" );
             return null;
         }
 
         ExpressionExperiment experiment = eeService.findByShortName( name );
 
         if ( experiment == null ) {
-            AbstractCLI.log.error( "No experiment " + name + " found" );
-            exitwithError();
+            throw new RuntimeException( "No experiment " + name + " found" );
         }
         return experiment;
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
@@ -40,12 +40,9 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
     private ArrayDesignService arrayDesignService;
     private ExpressionExperimentPlatformSwitchService serv;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         ExpressionExperimentPlatformSwitchCli p = new ExpressionExperimentPlatformSwitchCli();
-        Exception e = p.doWork( args );
-        if ( e != null ) {
-            AbstractCLI.log.fatal( e, e );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -54,12 +51,8 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-
-        Exception exp = this.processCommandLine( args );
-        if ( exp != null ) {
-            return exp;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         serv = this.getBean( ExpressionExperimentPlatformSwitchService.class );
 
@@ -72,8 +65,6 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
 
         }
         this.summarizeProcessing();
-        return null;
-
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
@@ -51,9 +51,7 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         serv = this.getBean( ExpressionExperimentPlatformSwitchService.class );
 
         for ( BioAssaySet ee : expressionExperiments ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
@@ -57,7 +57,6 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
             }
 
         }
-        this.summarizeProcessing();
     }
 
     @Override
@@ -96,8 +95,7 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
             if ( this.arrayDesignName != null ) {
                 ArrayDesign ad = this.locateArrayDesign( this.arrayDesignName, arrayDesignService );
                 if ( ad == null ) {
-                    AbstractCLI.log.error( "Unknown array design" );
-                    exitwithError();
+                    throw new RuntimeException( "Unknown array design" );
                 }
                 ad = arrayDesignService.thaw( ad );
                 ee = serv.switchExperimentToArrayDesign( ee, ad );
@@ -110,10 +108,9 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
                 ats.addUpdateEvent( ee, type, "Switched to use merged array Design " );
             }
 
-            super.successObjects.add( ee.toString() );
+            addSuccessObject( ee, "Successfully processed " + ee.getShortName() );
         } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-            super.errorObjects.add( ee + ": " + e.getMessage() );
+            addErrorObject( ee, e.getMessage(), e );
         }
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPlatformSwitchCli.java
@@ -40,11 +40,6 @@ public class ExpressionExperimentPlatformSwitchCli extends ExpressionExperimentM
     private ArrayDesignService arrayDesignService;
     private ExpressionExperimentPlatformSwitchService serv;
 
-    public static int main( String[] args ) {
-        ExpressionExperimentPlatformSwitchCli p = new ExpressionExperimentPlatformSwitchCli();
-        return executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "switchExperimentPlatform";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPrimaryPubCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPrimaryPubCli.java
@@ -47,11 +47,6 @@ public class ExpressionExperimentPrimaryPubCli extends ExpressionExperimentManip
     private String pubmedIdFilename;
     private Map<String, Integer> pubmedIds = new HashMap<>();
 
-    public static void main( String[] args ) {
-        ExpressionExperimentPrimaryPubCli p = new ExpressionExperimentPrimaryPubCli();
-        executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "pubmedAssociateToExperiments";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPrimaryPubCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPrimaryPubCli.java
@@ -78,8 +78,7 @@ public class ExpressionExperimentPrimaryPubCli extends ExpressionExperimentManip
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        processCommandLine( args );
+    protected void doWork() throws Exception {
         ExpressionExperimentService ees = this.getBean( ExpressionExperimentService.class );
 
         Persister ph = this.getPersisterHelper();

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPrimaryPubCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentPrimaryPubCli.java
@@ -78,10 +78,8 @@ public class ExpressionExperimentPrimaryPubCli extends ExpressionExperimentManip
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        processCommandLine( args );
         ExpressionExperimentService ees = this.getBean( ExpressionExperimentService.class );
 
         Persister ph = this.getPersisterHelper();
@@ -158,8 +156,6 @@ public class ExpressionExperimentPrimaryPubCli extends ExpressionExperimentManip
         log.info( "Diff publication: " + Arrays.toString( diffPubCount.toArray() ) );
         log.info( "No initial publication: " + Arrays.toString( nullPubCount.toArray() ) );
         log.info( "No publications found: " + Arrays.toString( failedEe.toArray() ) );
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalDatabaseAdderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalDatabaseAdderCli.java
@@ -30,12 +30,6 @@ import ubic.gemma.persistence.service.common.description.ExternalDatabaseService
  */
 public class ExternalDatabaseAdderCli extends AbstractCLIContextCLI {
 
-    public static void main( String[] args ) {
-        ExternalDatabaseAdderCli p = new ExternalDatabaseAdderCli();
-        executeCommand( p, args );
-
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.SYSTEM;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalDatabaseAdderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalDatabaseAdderCli.java
@@ -56,9 +56,7 @@ public class ExternalDatabaseAdderCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        processCommandLine( args );
-
+    protected void doWork() throws Exception {
         // ContactService contactService = this.getBean( ContactService.class );
 
         ExternalDatabase toAdd = ExternalDatabase.Factory.newInstance();

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalDatabaseAdderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalDatabaseAdderCli.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2011 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -56,45 +56,38 @@ public class ExternalDatabaseAdderCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        try {
-            Exception err = processCommandLine( args );
-            if ( err != null )
-                return err;
+    protected void doWork( String[] args ) throws Exception {
+        processCommandLine( args );
 
-            // ContactService contactService = this.getBean( ContactService.class );
+        // ContactService contactService = this.getBean( ContactService.class );
 
-            ExternalDatabase toAdd = ExternalDatabase.Factory.newInstance();
+        ExternalDatabase toAdd = ExternalDatabase.Factory.newInstance();
 
-            // Contact c = contactService.findByName( "Affymetrix" ).iterator().next();
-            // toAdd.setDatabaseSupplier( c );
-            // toAdd.setDescription( "The NetAffx Analysis Center enables researchers to correlate their "
-            // + "GeneChip array results with array design and annotation information." );
-            // toAdd.setName( "NetAFFX" );
-            // toAdd.setType( DatabaseType.SEQUENCE );
-            // toAdd.setWebUri( "http://www.affymetrix.com/analysis/index.affx" );
+        // Contact c = contactService.findByName( "Affymetrix" ).iterator().next();
+        // toAdd.setDatabaseSupplier( c );
+        // toAdd.setDescription( "The NetAffx Analysis Center enables researchers to correlate their "
+        // + "GeneChip array results with array design and annotation information." );
+        // toAdd.setName( "NetAFFX" );
+        // toAdd.setType( DatabaseType.SEQUENCE );
+        // toAdd.setWebUri( "http://www.affymetrix.com/analysis/index.affx" );
 
-            // Contact c = Contact.Factory.newInstance();
-            // c.setName( "McKusick-Nathans Institute of Genetic Medicine" );
-            // c = contactService.findOrCreate( c );
-            // toAdd.setDatabaseSupplier( c );
-            // toAdd.setDescription(
-            // "Online Mendelian Inheritance in Man is a comprehensive, authoritative, and timely compendium of human
-            // genes and genetic phenotypes. "
-            // +
-            // "OMIM and Online Mendelian Inheritance in Man are registered trademarks of the Johns Hopkins University."
-            // );
-            // toAdd.setName( "OMIM" );
-            // toAdd.setType( DatabaseType.OTHER );
-            // toAdd.setWebUri( "http://omim.org/" );
+        // Contact c = Contact.Factory.newInstance();
+        // c.setName( "McKusick-Nathans Institute of Genetic Medicine" );
+        // c = contactService.findOrCreate( c );
+        // toAdd.setDatabaseSupplier( c );
+        // toAdd.setDescription(
+        // "Online Mendelian Inheritance in Man is a comprehensive, authoritative, and timely compendium of human
+        // genes and genetic phenotypes. "
+        // +
+        // "OMIM and Online Mendelian Inheritance in Man are registered trademarks of the Johns Hopkins University."
+        // );
+        // toAdd.setName( "OMIM" );
+        // toAdd.setType( DatabaseType.OTHER );
+        // toAdd.setWebUri( "http://omim.org/" );
 
-            ExternalDatabaseService eds = this.getBean( ExternalDatabaseService.class );
+        ExternalDatabaseService eds = this.getBean( ExternalDatabaseService.class );
 
-            eds.findOrCreate( toAdd );
-        } catch ( Exception e ) {
-            return e;
-        }
-        return null;
+        eds.findOrCreate( toAdd );
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalFileGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalFileGeneLoaderCLI.java
@@ -94,8 +94,7 @@ public class ExternalFileGeneLoaderCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         this.processGeneList();
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalFileGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalFileGeneLoaderCLI.java
@@ -36,17 +36,6 @@ public class ExternalFileGeneLoaderCLI extends AbstractCLIContextCLI {
     private String directGeneInputFileName = null;
     private String taxonName;
 
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
-    public ExternalFileGeneLoaderCLI() {
-        super();
-    }
-
-    public static void main( String[] args ) {
-        // super constructor calls build options
-        ExternalFileGeneLoaderCLI p = new ExternalFileGeneLoaderCLI();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
-
     @Override
     public String getShortDesc() {
         return "loading genes from a non-NCBI files; only used for species like salmon";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalFileGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExternalFileGeneLoaderCLI.java
@@ -36,7 +36,7 @@ public class ExternalFileGeneLoaderCLI extends AbstractCLIContextCLI {
     private String directGeneInputFileName = null;
     private String taxonName;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public ExternalFileGeneLoaderCLI() {
         super();
     }
@@ -94,18 +94,15 @@ public class ExternalFileGeneLoaderCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
         this.processGeneList();
-        return null;
     }
 
     /**
      * Main entry point to service class which reads a gene file and persists the genes in that file.
      */
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public void processGeneList() {
 
         ExternalFileGeneLoaderService loader = this.getBean( ExternalFileGeneLoaderService.class );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
@@ -92,9 +92,7 @@ public class GeeqCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         for ( BioAssaySet bioassay : expressionExperiments ) {
             if ( !( bioassay instanceof ExpressionExperiment ) ) {
                 log.debug( bioassay.getName() + " is not an ExpressionExperiment" );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
@@ -101,13 +101,10 @@ public class GeeqCli extends ExpressionExperimentManipulatingCLI {
 
             try {
                 geeqService.calculateScore( ee.getId(), mode );
-                this.successObjects.add( ee );
+                addSuccessObject( ee, "Successfully processed " + ee );
             } catch ( Exception e ) {
-                log.error( ee + " failed: " + e.getMessage() );
-                this.errorObjects.add( ee + ": " + e.getMessage() );
+                addErrorObject( ee, " failed: " + e.getMessage(), e );
             }
         }
-
-        this.summarizeProcessing();
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
@@ -26,7 +26,6 @@ import static ubic.gemma.persistence.service.expression.experiment.GeeqService.O
 import org.apache.commons.cli.Option;
 
 import ubic.gemma.core.util.AbstractCLI;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.common.auditAndSecurity.eventType.GeeqEvent;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
@@ -42,11 +41,6 @@ public class GeeqCli extends ExpressionExperimentManipulatingCLI {
     private GeeqService geeqService;
 
     private String mode = GeeqService.OPT_MODE_ALL;
-
-    public static void main( String[] args ) {
-        GeeqCli p = new GeeqCli();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
 
     @Override
     public String getShortDesc() {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeeqCli.java
@@ -1,8 +1,8 @@
 /*
  * The gemma-core project
- * 
+ *
  * Copyright (c) 2018 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -34,9 +34,8 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
 import ubic.gemma.persistence.service.expression.experiment.GeeqService;
 
 /**
- * 
  * Generate or update GEEQ scores
- * 
+ *
  * @author tesar
  */
 public class GeeqCli extends ExpressionExperimentManipulatingCLI {
@@ -93,10 +92,8 @@ public class GeeqCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = super.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         for ( BioAssaySet bioassay : expressionExperiments ) {
             if ( !( bioassay instanceof ExpressionExperiment ) ) {
@@ -120,6 +117,5 @@ public class GeeqCli extends ExpressionExperimentManipulatingCLI {
         }
 
         this.summarizeProcessing();
-        return null;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GemmaCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GemmaCLI.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  *
  * @author paul
  */
-@SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+@SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
 public class GemmaCLI {
 
     public static void main( String[] args ) {
@@ -64,17 +64,17 @@ public class GemmaCLI {
                     Object cliInstance = aClazz.newInstance();
 
                     Method method = aClazz.getMethod( "getCommandName" );
-                    String commandName = ( String ) method.invoke( cliInstance, new Object[] {} );
+                    String commandName = ( String ) method.invoke( cliInstance, new Object[]{} );
                     if ( commandName == null || StringUtils.isBlank( commandName ) ) {
                         // keep null to avoid printing some commands...
                         continue;
                     }
 
                     Method method2 = aClazz.getMethod( "getShortDesc" );
-                    String desc = ( String ) method2.invoke( cliInstance, new Object[] {} );
+                    String desc = ( String ) method2.invoke( cliInstance, new Object[]{} );
 
                     Method method3 = aClazz.getMethod( "getCommandGroup" );
-                    CommandGroup g = ( CommandGroup ) method3.invoke( cliInstance, new Object[] {} );
+                    CommandGroup g = ( CommandGroup ) method3.invoke( cliInstance, new Object[]{} );
 
                     if ( !commands.containsKey( g ) ) {
                         commands.put( g, new TreeMap<String, String>() );
@@ -95,10 +95,11 @@ public class GemmaCLI {
         if ( args.length == 0 || args[0].equalsIgnoreCase( "--help" ) || args[0].equalsIgnoreCase( "-help" ) || args[0]
                 .equalsIgnoreCase( "help" ) ) {
             GemmaCLI.printHelp( commands );
+            System.exit( 1 );
         } else {
             LinkedList<String> f = new LinkedList<>( Arrays.asList( args ) );
             String commandRequested = f.remove( 0 );
-            Object[] argsToPass = f.toArray( new String[] {} );
+            String[] argsToPass = f.toArray( new String[]{} );
 
             if ( !commandClasses.containsKey( commandRequested ) ) {
                 System.err.println( "Unrecognized command: " + commandRequested );
@@ -107,19 +108,17 @@ public class GemmaCLI {
                 System.exit( 1 );
             } else {
                 try {
-                    Class<?> c = commandClasses.get( commandRequested );
-                    Method method = c.getMethod( "main", String[].class );
+                    Class<? extends AbstractCLI> c = commandClasses.get( commandRequested );
                     System.err.println( "========= Gemma CLI invocation of " + commandRequested + " ============" );
                     System.err.println( "Options: " + GemmaCLI.getOptStringForLogging( argsToPass ) );
                     //noinspection JavaReflectionInvocation // It works
-                    method.invoke( null, ( Object ) argsToPass );
+                    System.exit( c.getDeclaredConstructor().newInstance().executeCommand( argsToPass ) );
                 } catch ( Exception e ) {
                     System.err.println( "Gemma CLI error: " + e.getClass().getName() + " - " + e.getMessage() );
                     System.err.println( ExceptionUtils.getStackTrace( e ) );
                     throw new RuntimeException( e );
                 } finally {
                     System.err.println( "========= Gemma CLI run of " + commandRequested + " complete ============" );
-                    System.exit( 0 );
                 }
             }
         }
@@ -127,8 +126,8 @@ public class GemmaCLI {
 
     /**
      * Mask password for logging
-     * 
-     * @param  argsToPass
+     *
+     * @param argsToPass
      * @return
      */
     public static String getOptStringForLogging( Object[] argsToPass ) {
@@ -138,7 +137,7 @@ public class GemmaCLI {
 
     /**
      * Print help and exit
-     * 
+     *
      * @param commands
      */
     public static void printHelp( Map<CommandGroup, Map<String, String>> commands ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GenericGenelistDesignGenerator.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GenericGenelistDesignGenerator.java
@@ -94,11 +94,8 @@ public class GenericGenelistDesignGenerator extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception exception = super.processCommandLine( args );
-        if ( exception != null ) {
-            return exception;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         ExternalDatabase genbank = externalDatabaseService.findByName( "Genbank" );
         ExternalDatabase ensembl = externalDatabaseService.findByName( "Ensembl" );
@@ -355,9 +352,6 @@ public class GenericGenelistDesignGenerator extends AbstractCLIContextCLI {
         arrayDesignAnnotationService.deleteExistingFiles( arrayDesign );
 
         AbstractCLI.log.info( "Don't forget to update the annotation files" );
-
-        return null;
-
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GenericGenelistDesignGenerator.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GenericGenelistDesignGenerator.java
@@ -70,11 +70,6 @@ public class GenericGenelistDesignGenerator extends AbstractCLIContextCLI {
     private boolean useEnsemblIds = false;
     private boolean useNCBIIds = false;
 
-    public static void main( String[] args ) {
-        GenericGenelistDesignGenerator b = new GenericGenelistDesignGenerator();
-        executeCommand( b, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.PLATFORM;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GenericGenelistDesignGenerator.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GenericGenelistDesignGenerator.java
@@ -94,9 +94,7 @@ public class GenericGenelistDesignGenerator extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         ExternalDatabase genbank = externalDatabaseService.findByName( "Genbank" );
         ExternalDatabase ensembl = externalDatabaseService.findByName( "Ensembl" );
         if ( genbank == null || ensembl == null ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeoGrabberCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeoGrabberCli.java
@@ -33,11 +33,6 @@ import java.util.Set;
  */
 public class GeoGrabberCli extends AbstractCLIContextCLI {
 
-    public static int main( String[] args ) {
-        GeoGrabberCli d = new GeoGrabberCli();
-        return executeCommand( d, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.ANALYSIS;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeoGrabberCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeoGrabberCli.java
@@ -53,9 +53,7 @@ public class GeoGrabberCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         Set<String> seen = new HashSet<>();
         GeoBrowserService gbs = this.getBean( GeoBrowserService.class );
         ExpressionExperimentService ees = this.getBean( ExpressionExperimentService.class );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/IndexGemmaCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/IndexGemmaCLI.java
@@ -42,11 +42,6 @@ public class IndexGemmaCLI extends AbstractCLIContextCLI {
     private boolean indexX = false;
     private boolean indexY = false;
 
-    public static int main( String[] args ) {
-        IndexGemmaCLI p = new IndexGemmaCLI();
-        return executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.SYSTEM;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/IndexGemmaCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/IndexGemmaCLI.java
@@ -43,20 +43,9 @@ public class IndexGemmaCLI extends AbstractCLIContextCLI {
     private boolean indexX = false;
     private boolean indexY = false;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         IndexGemmaCLI p = new IndexGemmaCLI();
-        StopWatch watch = new StopWatch();
-        watch.start();
-        try {
-            Exception ex = p.doWork( args );
-            if ( ex != null ) {
-                ex.printStackTrace();
-            }
-            watch.stop();
-            AbstractCLI.log.info( "Total indexing time: " + watch.getTime() );
-        } catch ( Exception e ) {
-            throw new RuntimeException( e );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -100,51 +89,42 @@ public class IndexGemmaCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
+        /*
+         * These beans are defined in Spring XML.
+         */
+        if ( this.indexG ) {
+            this.rebuildIndex( this.getBean( "geneGps", CompassGpsInterfaceDevice.class ), "Gene index" );
         }
-        try {
-            /*
-             * These beans are defined in Spring XML.
-             */
-            if ( this.indexG ) {
-                this.rebuildIndex( this.getBean( "geneGps", CompassGpsInterfaceDevice.class ), "Gene index" );
-            }
-            if ( this.indexEE ) {
-                this.rebuildIndex( this.getBean( "expressionGps", CompassGpsInterfaceDevice.class ),
-                        "Expression Experiment index" );
-            }
-            if ( this.indexAD ) {
-                this.rebuildIndex( this.getBean( "arrayGps", CompassGpsInterfaceDevice.class ), "Array Design index" );
-            }
-            if ( this.indexB ) {
-                this.rebuildIndex( this.getBean( "bibliographicGps", CompassGpsInterfaceDevice.class ),
-                        "Bibliographic Reference Index" );
-            }
-            if ( this.indexP ) {
-                this.rebuildIndex( this.getBean( "probeGps", CompassGpsInterfaceDevice.class ),
-                        "Probe Reference Index" );
-            }
-            if ( this.indexQ ) {
-                this.rebuildIndex( this.getBean( "biosequenceGps", CompassGpsInterfaceDevice.class ),
-                        "BioSequence Index" );
-            }
-
-            if ( this.indexY ) {
-                this.rebuildIndex( this.getBean( "experimentSetGps", CompassGpsInterfaceDevice.class ),
-                        "Experiment set Index" );
-            }
-
-            if ( this.indexX ) {
-                this.rebuildIndex( this.getBean( "geneSetGps", CompassGpsInterfaceDevice.class ), "Gene set Index" );
-            }
-        } catch ( Exception e ) {
-            AbstractCLI.log.error( e );
-            return e;
+        if ( this.indexEE ) {
+            this.rebuildIndex( this.getBean( "expressionGps", CompassGpsInterfaceDevice.class ),
+                    "Expression Experiment index" );
         }
-        return null;
+        if ( this.indexAD ) {
+            this.rebuildIndex( this.getBean( "arrayGps", CompassGpsInterfaceDevice.class ), "Array Design index" );
+        }
+        if ( this.indexB ) {
+            this.rebuildIndex( this.getBean( "bibliographicGps", CompassGpsInterfaceDevice.class ),
+                    "Bibliographic Reference Index" );
+        }
+        if ( this.indexP ) {
+            this.rebuildIndex( this.getBean( "probeGps", CompassGpsInterfaceDevice.class ),
+                    "Probe Reference Index" );
+        }
+        if ( this.indexQ ) {
+            this.rebuildIndex( this.getBean( "biosequenceGps", CompassGpsInterfaceDevice.class ),
+                    "BioSequence Index" );
+        }
+
+        if ( this.indexY ) {
+            this.rebuildIndex( this.getBean( "experimentSetGps", CompassGpsInterfaceDevice.class ),
+                    "Experiment set Index" );
+        }
+
+        if ( this.indexX ) {
+            this.rebuildIndex( this.getBean( "geneSetGps", CompassGpsInterfaceDevice.class ), "Gene set Index" );
+        }
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/IndexGemmaCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/IndexGemmaCLI.java
@@ -20,7 +20,6 @@
 package ubic.gemma.core.apps;
 
 import org.apache.commons.cli.Option;
-import org.apache.commons.lang3.time.StopWatch;
 import org.compass.gps.spi.CompassGpsInterfaceDevice;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.util.AbstractCLI;
@@ -89,8 +88,7 @@ public class IndexGemmaCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         /*
          * These beans are defined in Spring XML.
          */

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
@@ -187,7 +187,6 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
                     throw new UnsupportedOperationException( "Can't handle non-EE BioAssaySets yet" );
                 }
             }
-            this.summarizeProcessing();
         }
     }
 
@@ -317,8 +316,7 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
             if ( this.hasOption( 't' ) ) {
                 this.analysisTaxon = this.getOptionValue( 't' );
             } else {
-                AbstractCLI.log.error( "Must provide 'taxon' option when initializing from old data" );
-                exitwithError();
+                throw new RuntimeException( "Must provide 'taxon' option when initializing from old data" );
             }
             // all other options ignored.
             return;
@@ -327,8 +325,7 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
             if ( this.hasOption( 't' ) ) {
                 this.analysisTaxon = this.getOptionValue( 't' );
             } else {
-                AbstractCLI.log.error( "Must provide 'taxon' option when updating node degree" );
-                exitwithError();
+                throw new RuntimeException( "Must provide 'taxon' option when updating node degree" );
             }
             // all other options ignored.
             return;
@@ -336,23 +333,19 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
 
         if ( this.hasOption( "dataFile" ) ) {
             if ( this.expressionExperiments.size() > 0 ) {
-                AbstractCLI.log.error( "The 'dataFile' option is incompatible with other data set selection options" );
-                exitwithError();
+                throw new RuntimeException( "The 'dataFile' option is incompatible with other data set selection options" );
             }
 
             if ( this.hasOption( "array" ) ) {
                 this.linkAnalysisConfig.setArrayName( this.getOptionValue( "array" ) );
             } else {
-                AbstractCLI.log.error( "Must provide 'array' option if you  use 'dataFile" );
-                exitwithError();
+                throw new RuntimeException( "Must provide 'array' option if you  use 'dataFile" );
             }
 
             if ( this.hasOption( 't' ) ) {
                 this.analysisTaxon = this.getOptionValue( 't' );
             } else {
-                AbstractCLI.log
-                        .error( "Must provide 'taxon' option if you  use 'dataFile' as RNA taxon may be different to array taxon" );
-                exitwithError();
+                throw new RuntimeException( "Must provide 'taxon' option if you  use 'dataFile' as RNA taxon may be different to array taxon" );
             }
 
             this.dataFileName = this.getOptionValue( "dataFile" );
@@ -530,9 +523,9 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
         if ( this.deleteAnalyses ) {
             AbstractCLI.log.info( "======= Deleting coexpression analysis (if any) for: " + ee );
             if ( this.getBean( LinkAnalysisPersister.class ).deleteAnalyses( ee ) ) {
-                successObjects.add( ee.toString() );
+                addSuccessObject( ee, "Successfully processed" + ee.getShortName() );
             } else {
-                errorObjects.add( ee + ": Seems to not have any eligible link analysis to remove" );
+                addErrorObject( ee, "Seems to not have any eligible link analysis to remove" );
             }
             return;
         }
@@ -561,11 +554,9 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
 
             linkAnalysisService.process( ee, filterConfig, linkAnalysisConfig );
 
-            successObjects.add( ee.toString() );
+            addSuccessObject( ee, "Successfully processed " + ee.getShortName() );
         } catch ( Exception e ) {
-            errorObjects.add( ee + ": " + e.getMessage() );
-            AbstractCLI.log.error( "**** Exception while processing " + ee + ": " + e.getMessage() + " ********" );
-            AbstractCLI.log.error( e, e );
+            addErrorObject( ee, e.getMessage(), e );
         }
         AbstractCLI.log.info( "==== Done: [" + ee.getShortName() + "] ======" );
         AbstractCLI.log.info( "Time elapsed: " + String.format( "%.2f", sw.getTime() / 1000.0 / 60.0 ) + " minutes" );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
@@ -80,25 +80,20 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            return err;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         if ( initializeFromOldData ) {
             AbstractCLI.log.info( "Initializing links from old data for " + this.getTaxon() );
             LinkAnalysisPersister s = this.getBean( LinkAnalysisPersister.class );
             s.initializeLinksFromOldData( this.getTaxon() );
-            return null;
+            return;
         } else if ( updateNodeDegree ) {
 
             // we waste some time here getting the experiments.
             this.loadTaxon();
 
             this.getBean( CoexpressionService.class ).updateNodeDegrees( this.getTaxon() );
-
-            return null;
         }
 
         this.linkAnalysisService = this.getBean( LinkAnalysisService.class );
@@ -113,7 +108,7 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
             ArrayDesign arrayDesign = arrayDesignService.findByShortName( this.linkAnalysisConfig.getArrayName() );
 
             if ( arrayDesign == null ) {
-                return new IllegalArgumentException( "No such array design " + this.linkAnalysisConfig.getArrayName() );
+                throw new IllegalArgumentException( "No such array design " + this.linkAnalysisConfig.getArrayName() );
             }
 
             this.loadTaxon();
@@ -131,7 +126,7 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
             SimpleExpressionDataLoaderService simpleExpressionDataLoaderService = this
                     .getBean( SimpleExpressionDataLoaderService.class );
             ByteArrayConverter bArrayConverter = new ByteArrayConverter();
-            try (InputStream data = new FileInputStream( new File( this.dataFileName ) )) {
+            try ( InputStream data = new FileInputStream( new File( this.dataFileName ) ) ) {
 
                 DoubleMatrix<String, String> matrix = simpleExpressionDataLoaderService.parse( data );
 
@@ -158,7 +153,7 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
                 AbstractCLI.log.info( "Read " + dataVectors.size() + " data vectors" );
 
             } catch ( Exception e ) {
-                return e;
+                throw e;
             }
 
             this.linkAnalysisService.processVectors( this.getTaxon(), dataVectors, filterConfig, linkAnalysisConfig );
@@ -201,8 +196,6 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
             }
             this.summarizeProcessing();
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
@@ -80,9 +80,7 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         if ( initializeFromOldData ) {
             AbstractCLI.log.info( "Initializing links from old data for " + this.getTaxon() );
             LinkAnalysisPersister s = this.getBean( LinkAnalysisPersister.class );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LinkAnalysisCli.java
@@ -69,11 +69,6 @@ public class LinkAnalysisCli extends ExpressionExperimentManipulatingCLI {
     private boolean updateNodeDegree = false;
     private boolean deleteAnalyses = false;
 
-    public static void main( String[] args ) {
-        LinkAnalysisCli p = new LinkAnalysisCli();
-        executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "coexpAnalyze";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadExpressionDataCli.java
@@ -151,7 +151,7 @@ public class LoadExpressionDataCli extends AbstractCLIContextCLI {
                         ArrayDesign ad = ( ArrayDesign ) object;
                         ad = ads.thawLite( ad );
 
-                        successObjects.add( ad.getName() + " (" + ad.getExternalReferences().iterator().next()
+                        addSuccessObject( ad, ad.getName() + " (" + ad.getExternalReferences().iterator().next()
                                 .getAccession() + ")" );
                     }
                 } else {
@@ -178,7 +178,6 @@ public class LoadExpressionDataCli extends AbstractCLIContextCLI {
                 }
             }
         }
-        this.summarizeProcessing();
     }
 
     @Override
@@ -241,14 +240,11 @@ public class LoadExpressionDataCli extends AbstractCLIContextCLI {
 
             for ( Object object : ees ) {
                 assert object instanceof ExpressionExperiment;
-                successObjects.add( ( ( Describable ) object ).getName() + " (" + ( ( ExpressionExperiment ) object )
+                addSuccessObject( object, ( ( Describable ) object ).getName() + " (" + ( ( ExpressionExperiment ) object )
                         .getAccession().getAccession() + ")" );
             }
         } catch ( Exception e ) {
-            errorObjects.add( accession + ": " + e.getMessage() );
-            AbstractCLI.log
-                    .error( "**** Exception while processing " + accession + ": " + e.getMessage() + " ********" );
-            AbstractCLI.log.error( e, e );
+            addErrorObject( accession, e.getMessage(), e );
         }
     }
 
@@ -285,9 +281,8 @@ public class LoadExpressionDataCli extends AbstractCLIContextCLI {
             try {
                 preprocessorService.process( ee );
             } catch ( PreprocessingException e ) {
-                AbstractCLI.log.error( "Experiment was loaded, but there was an error during postprocessing: " + ee
+                addErrorObject( ee, "Experiment was loaded, but there was an error during postprocessing: " + ee
                         + " , make sure additional steps are completed", e );
-                errorObjects.add( ee.getShortName() + ": " + e.getMessage() );
             }
 
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadExpressionDataCli.java
@@ -127,9 +127,7 @@ public class LoadExpressionDataCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         GeoService geoService = this.getBean( GeoService.class );
         geoService.setGeoDomainObjectGenerator( new GeoDomainObjectGenerator() );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadExpressionDataCli.java
@@ -64,11 +64,6 @@ public class LoadExpressionDataCli extends AbstractCLIContextCLI {
     private boolean splitByPlatform = false;
     private boolean suppressPostProcessing = false;
 
-    public static int main( String[] args ) {
-        LoadExpressionDataCli p = new LoadExpressionDataCli();
-        return executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
@@ -70,11 +70,6 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
     private String fileName = null;
     private TaxonService taxonService = null;
 
-    public static int main( String[] args ) {
-        LoadSimpleExpressionDataCli p = new LoadSimpleExpressionDataCli();
-        return executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
@@ -135,15 +135,12 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
 
                     try {
                         this.loadExperiment( conf );
-                        AbstractCLI.log.info( "Successfully Loaded " + expName );
-                        successObjects.add( expName );
+                        addSuccessObject( expName, "Successfully Loaded " + expName );
                     } catch ( Exception e ) {
-                        errorObjects.add( expName + ": " + e.getMessage() );
-                        AbstractCLI.log.error( "Failure loading " + expName, e );
+                        addErrorObject( expName, "Failure loading " + expName, e );
                     }
                 }
             }
-            this.summarizeProcessing();
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
@@ -21,7 +21,6 @@ package ubic.gemma.core.apps;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.StopWatch;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.expression.simple.SimpleExpressionDataLoaderService;
 import ubic.gemma.core.loader.expression.simple.model.SimpleExpressionExperimentMetaData;
@@ -117,8 +116,7 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         this.eeLoaderService = this.getBean( SimpleExpressionDataLoaderService.class );
         this.eeService = this.getBean( ExpressionExperimentService.class );
         this.adService = this.getBean( ArrayDesignService.class );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
@@ -71,21 +71,9 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
     private String fileName = null;
     private TaxonService taxonService = null;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         LoadSimpleExpressionDataCli p = new LoadSimpleExpressionDataCli();
-        StopWatch watch = new StopWatch();
-        watch.start();
-        try {
-            Exception ex = p.doWork( args );
-            if ( ex != null ) {
-                ex.printStackTrace();
-            }
-            watch.stop();
-            AbstractCLI.log.info( watch.getTime() );
-        } catch ( Exception e ) {
-            AbstractCLI.log.fatal( e, e );
-            throw new RuntimeException( e );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -129,49 +117,41 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            return err;
-        }
-        try {
-            this.eeLoaderService = this.getBean( SimpleExpressionDataLoaderService.class );
-            this.eeService = this.getBean( ExpressionExperimentService.class );
-            this.adService = this.getBean( ArrayDesignService.class );
-            this.taxonService = this.getBean( TaxonService.class );
-            if ( this.fileName != null ) {
-                AbstractCLI.log.info( "Loading experiments from " + this.fileName );
-                InputStream is = new FileInputStream( new File( this.dirName, this.fileName ) );
-                try (BufferedReader br = new BufferedReader( new InputStreamReader( is ) )) {
-                    String conf;
-                    while ( ( conf = br.readLine() ) != null ) {
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
+        this.eeLoaderService = this.getBean( SimpleExpressionDataLoaderService.class );
+        this.eeService = this.getBean( ExpressionExperimentService.class );
+        this.adService = this.getBean( ArrayDesignService.class );
+        this.taxonService = this.getBean( TaxonService.class );
+        if ( this.fileName != null ) {
+            AbstractCLI.log.info( "Loading experiments from " + this.fileName );
+            InputStream is = new FileInputStream( new File( this.dirName, this.fileName ) );
+            try ( BufferedReader br = new BufferedReader( new InputStreamReader( is ) ) ) {
+                String conf;
+                while ( ( conf = br.readLine() ) != null ) {
 
-                        if ( StringUtils.isBlank( conf ) ) {
-                            continue;
-                        }
+                    if ( StringUtils.isBlank( conf ) ) {
+                        continue;
+                    }
 
-                        /* Comments in the list file */
-                        if ( conf.startsWith( "#" ) )
-                            continue;
+                    /* Comments in the list file */
+                    if ( conf.startsWith( "#" ) )
+                        continue;
 
-                        String expName = conf.split( LoadSimpleExpressionDataCli.SPLIT_CHAR )[0];
+                    String expName = conf.split( LoadSimpleExpressionDataCli.SPLIT_CHAR )[0];
 
-                        try {
-                            this.loadExperiment( conf );
-                            AbstractCLI.log.info( "Successfully Loaded " + expName );
-                            successObjects.add( expName );
-                        } catch ( Exception e ) {
-                            errorObjects.add( expName + ": " + e.getMessage() );
-                            AbstractCLI.log.error( "Failure loading " + expName, e );
-                        }
+                    try {
+                        this.loadExperiment( conf );
+                        AbstractCLI.log.info( "Successfully Loaded " + expName );
+                        successObjects.add( expName );
+                    } catch ( Exception e ) {
+                        errorObjects.add( expName + ": " + e.getMessage() );
+                        AbstractCLI.log.error( "Failure loading " + expName, e );
                     }
                 }
-                this.summarizeProcessing();
             }
-        } catch ( IOException e ) {
-            return e;
+            this.summarizeProcessing();
         }
-        return null;
     }
 
     private void checkForArrayDesignName( String[] fields ) {
@@ -289,8 +269,8 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
 
         this.configureArrayDesigns( fields, metaData );
 
-        try (InputStream data = new FileInputStream(
-                new File( this.dirName, fields[LoadSimpleExpressionDataCli.DATA_FILE_I] ) )) {
+        try ( InputStream data = new FileInputStream(
+                new File( this.dirName, fields[LoadSimpleExpressionDataCli.DATA_FILE_I] ) ) ) {
 
             metaData.setSourceUrl( fields[LoadSimpleExpressionDataCli.SOURCE_I] );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MakeExperimentsPublicCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MakeExperimentsPublicCli.java
@@ -25,12 +25,9 @@ import ubic.gemma.model.expression.experiment.BioAssaySet;
  */
 public class MakeExperimentsPublicCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         MakeExperimentsPublicCli d = new MakeExperimentsPublicCli();
-        Exception e = d.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( d, args );
     }
 
     @Override
@@ -39,10 +36,8 @@ public class MakeExperimentsPublicCli extends ExpressionExperimentManipulatingCL
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         SecurityService securityService = this.getBean( SecurityService.class );
         for ( BioAssaySet ee : this.expressionExperiments ) {
@@ -50,8 +45,6 @@ public class MakeExperimentsPublicCli extends ExpressionExperimentManipulatingCL
             this.auditTrailService.addUpdateEvent( ee, MakePublicEvent.class, "Made public from command line", null );
 
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MakeExperimentsPublicCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MakeExperimentsPublicCli.java
@@ -36,14 +36,11 @@ public class MakeExperimentsPublicCli extends ExpressionExperimentManipulatingCL
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         SecurityService securityService = this.getBean( SecurityService.class );
         for ( BioAssaySet ee : this.expressionExperiments ) {
             securityService.makePublic( ee );
             this.auditTrailService.addUpdateEvent( ee, MakePublicEvent.class, "Made public from command line", null );
-
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MakeExperimentsPublicCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MakeExperimentsPublicCli.java
@@ -25,11 +25,6 @@ import ubic.gemma.model.expression.experiment.BioAssaySet;
  */
 public class MakeExperimentsPublicCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        MakeExperimentsPublicCli d = new MakeExperimentsPublicCli();
-        return executeCommand( d, args );
-    }
-
     @Override
     public String getCommandName() {
         return "makePublic";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MeshTermFetcherCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MeshTermFetcherCli.java
@@ -72,9 +72,7 @@ public class MeshTermFetcherCli extends AbstractCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         PubMedXMLFetcher fetcher = new PubMedXMLFetcher();
 
         Collection<Integer> ids = this.readIdsFromFile( file );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MeshTermFetcherCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MeshTermFetcherCli.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author     pavlidis
+ * @author pavlidis
  * @deprecated should not be part of Gemma main code
  */
 @Deprecated
@@ -45,12 +45,9 @@ public class MeshTermFetcherCli extends AbstractCLI {
     private String file;
     private boolean majorTopicsOnly = false;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         MeshTermFetcherCli p = new MeshTermFetcherCli();
-        Exception exception = p.doWork( args );
-        if ( exception != null ) {
-            AbstractCLI.log.error( exception, exception );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -75,36 +72,27 @@ public class MeshTermFetcherCli extends AbstractCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         PubMedXMLFetcher fetcher = new PubMedXMLFetcher();
 
-        try {
-            Collection<Integer> ids = this.readIdsFromFile( file );
-            Collection<Integer> chunk = new ArrayList<>();
-            for ( Integer i : ids ) {
+        Collection<Integer> ids = this.readIdsFromFile( file );
+        Collection<Integer> chunk = new ArrayList<>();
+        for ( Integer i : ids ) {
 
-                chunk.add( i );
+            chunk.add( i );
 
-                if ( chunk.size() == MeshTermFetcherCli.CHUNK_SIZE ) {
+            if ( chunk.size() == MeshTermFetcherCli.CHUNK_SIZE ) {
 
-                    this.processChunk( fetcher, chunk );
-                    chunk.clear();
-                }
-            }
-
-            if ( !chunk.isEmpty() ) {
                 this.processChunk( fetcher, chunk );
+                chunk.clear();
             }
-
-        } catch ( IOException exception ) {
-            return exception;
         }
 
-        return null;
+        if ( !chunk.isEmpty() ) {
+            this.processChunk( fetcher, chunk );
+        }
     }
 
     @Override
@@ -121,7 +109,7 @@ public class MeshTermFetcherCli extends AbstractCLI {
         AbstractCLI.log.info( "Reading " + inFile );
 
         Collection<Integer> ids = new ArrayList<>();
-        try (BufferedReader in = new BufferedReader( new FileReader( file ) )) {
+        try ( BufferedReader in = new BufferedReader( new FileReader( file ) ) ) {
             String line;
             while ( ( line = in.readLine() ) != null ) {
                 if ( line.startsWith( "#" ) )

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MeshTermFetcherCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MeshTermFetcherCli.java
@@ -45,11 +45,6 @@ public class MeshTermFetcherCli extends AbstractCLI {
     private String file;
     private boolean majorTopicsOnly = false;
 
-    public static int main( String[] args ) {
-        MeshTermFetcherCli p = new MeshTermFetcherCli();
-        return executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "fetchMeshTerms";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MultifunctionalityCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MultifunctionalityCli.java
@@ -49,9 +49,7 @@ public class MultifunctionalityCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         GeneMultifunctionalityPopulationService gfs = this.getBean( GeneMultifunctionalityPopulationService.class );
 
         if ( this.taxon != null ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MultifunctionalityCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MultifunctionalityCli.java
@@ -28,11 +28,6 @@ public class MultifunctionalityCli extends AbstractCLIContextCLI {
 
     private Taxon taxon;
 
-    public static int main( String[] args ) {
-        MultifunctionalityCli c = new MultifunctionalityCli();
-        return executeCommand( c, args );
-    }
-
     @Override
     public String getCommandName() {
         return "updateMultifunc";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/MultifunctionalityCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/MultifunctionalityCli.java
@@ -28,12 +28,9 @@ public class MultifunctionalityCli extends AbstractCLIContextCLI {
 
     private Taxon taxon;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         MultifunctionalityCli c = new MultifunctionalityCli();
-        Exception e = c.doWork( args );
-        if ( e != null ) {
-            AbstractCLI.log.fatal( e );
-        }
+        return executeCommand( c, args );
     }
 
     @Override
@@ -52,10 +49,8 @@ public class MultifunctionalityCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         GeneMultifunctionalityPopulationService gfs = this.getBean( GeneMultifunctionalityPopulationService.class );
 
@@ -64,8 +59,6 @@ public class MultifunctionalityCli extends AbstractCLIContextCLI {
         } else {
             gfs.updateMultifunctionality();
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
@@ -45,11 +45,6 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
     private static final String GENE2GO_FILE = "gene2go.gz";
     private String filePath = null;
 
-    public static int main( String[] args ) {
-        NCBIGene2GOAssociationLoaderCLI p = new NCBIGene2GOAssociationLoaderCLI();
-        return executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "updateGOAnnots";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
@@ -46,12 +46,9 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
     private static final String GENE2GO_FILE = "gene2go.gz";
     private String filePath = null;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         NCBIGene2GOAssociationLoaderCLI p = new NCBIGene2GOAssociationLoaderCLI();
-        Exception e = p.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -69,12 +66,8 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = this.processCommandLine( args );
-        if ( e != null ) {
-            AbstractCLI.log.error( e );
-            return e;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         TaxonService taxonService = this.getBean( TaxonService.class );
 
@@ -92,15 +85,11 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
         if ( filePath != null ) {
             File f = new File( filePath );
             if ( !f.canRead() ) {
-                return new IOException( "Cannot read from " + filePath );
+                throw new IOException( "Cannot read from " + filePath );
             }
             files = new HashSet<>();
             LocalFile lf = LocalFile.Factory.newInstance();
-            try {
-                lf.setLocalURL( f.toURI().toURL() );
-            } catch ( MalformedURLException e1 ) {
-                return e1;
-            }
+            lf.setLocalURL( f.toURI().toURL() );
             files.add( lf );
         } else {
             files = fetcher.fetch( "ftp://ftp.ncbi.nih.gov/gene/DATA/" + NCBIGene2GOAssociationLoaderCLI.GENE2GO_FILE );
@@ -115,8 +104,6 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
         gene2GOAssLoader.load( gene2Gofile );
 
         AbstractCLI.log.info( "Don't forget to update the annotation files for platforms." );
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
@@ -32,7 +32,6 @@ import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -66,9 +65,7 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         TaxonService taxonService = this.getBean( TaxonService.class );
 
         NCBIGene2GOAssociationLoader gene2GOAssLoader = new NCBIGene2GOAssociationLoader();

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
@@ -48,7 +48,7 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
 
     private Integer startNcbiId = null;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public NcbiGeneLoaderCLI() {
         super();
     }
@@ -96,10 +96,8 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
         loader = new NcbiGeneLoader();
         TaxonService taxonService = this.getBean( TaxonService.class );
         loader.setTaxonService( taxonService );
@@ -134,8 +132,6 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
                 loader.load( true );
             }
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
@@ -96,8 +96,7 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         loader = new NcbiGeneLoader();
         TaxonService taxonService = this.getBean( TaxonService.class );
         loader.setTaxonService( taxonService );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
@@ -53,11 +53,6 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
         super();
     }
 
-    public static void main( String[] args ) {
-        NcbiGeneLoaderCLI p = new NcbiGeneLoaderCLI();
-        AbstractCLIContextCLI.executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.SYSTEM;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/OrderVectorsByDesignCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/OrderVectorsByDesignCli.java
@@ -31,14 +31,9 @@ import ubic.gemma.persistence.service.expression.bioAssayData.ProcessedExpressio
  */
 public class OrderVectorsByDesignCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         OrderVectorsByDesignCli c = new OrderVectorsByDesignCli();
-
-        Exception e = c.doWork( args );
-
-        if ( e != null ) {
-            throw ( new RuntimeException( e ) );
-        }
+        return executeCommand( c, args );
     }
 
     @Override
@@ -47,10 +42,8 @@ public class OrderVectorsByDesignCli extends ExpressionExperimentManipulatingCLI
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         ProcessedExpressionDataVectorService processedExpressionDataVectorService = this
                 .getBean( ProcessedExpressionDataVectorService.class );
@@ -63,8 +56,6 @@ public class OrderVectorsByDesignCli extends ExpressionExperimentManipulatingCLI
             ee = this.eeService.thawLite( ( ExpressionExperiment ) ee );
             processedExpressionDataVectorService.reorderByDesign( ee.getId() );
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/OrderVectorsByDesignCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/OrderVectorsByDesignCli.java
@@ -31,11 +31,6 @@ import ubic.gemma.persistence.service.expression.bioAssayData.ProcessedExpressio
  */
 public class OrderVectorsByDesignCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        OrderVectorsByDesignCli c = new OrderVectorsByDesignCli();
-        return executeCommand( c, args );
-    }
-
     @Override
     public String getCommandName() {
         return "orderVectorsByDesign";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/OrderVectorsByDesignCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/OrderVectorsByDesignCli.java
@@ -42,9 +42,7 @@ public class OrderVectorsByDesignCli extends ExpressionExperimentManipulatingCLI
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         ProcessedExpressionDataVectorService processedExpressionDataVectorService = this
                 .getBean( ProcessedExpressionDataVectorService.class );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
@@ -33,7 +33,7 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
  * Prepare the "processed" expression data vectors, and can also do batch correction.
  *
  * @author xwan, paul
- * @see    ProcessedExpressionDataVectorServiceImpl
+ * @see ProcessedExpressionDataVectorServiceImpl
  */
 public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI {
 
@@ -66,7 +66,7 @@ public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI
         Option outputFileOption = Option.builder( "b" )
                 .desc( "Attempt to batch-correct the data without recomputing data  (may be combined with other options)" ).longOpt( "batchcorr" )
                 .build();
-        this.addOption( "diagupdate", 
+        this.addOption( "diagupdate",
                 "Only update the diagnostics without recomputing data (PCA, M-V, sample correlation, GEEQ; may be combined with other options)" );
         this.addOption( "rankupdate", "Only update the expression intensity rank information (may be combined with other options)" );
 
@@ -102,22 +102,18 @@ public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            return err;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         if ( expressionExperiments.size() == 0 ) {
             AbstractCLI.log.error( "You did not select any usable expression experiments" );
-            return null;
+            return;
         }
 
         for ( BioAssaySet ee : expressionExperiments ) {
             this.processExperiment( ( ExpressionExperiment ) ee );
         }
         this.summarizeProcessing();
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
@@ -44,11 +44,6 @@ public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI
     private boolean updateRanks = false;
     private boolean updateDiagnostics = false;
 
-    public static void main( String[] args ) {
-        ProcessedDataComputeCLI p = new ProcessedDataComputeCLI();
-        executeCommand( p, args );
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
@@ -102,9 +102,7 @@ public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         if ( expressionExperiments.size() == 0 ) {
             AbstractCLI.log.error( "You did not select any usable expression experiments" );
             return;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ProcessedDataComputeCLI.java
@@ -106,7 +106,6 @@ public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI
         for ( BioAssaySet ee : expressionExperiments ) {
             this.processExperiment( ( ExpressionExperiment ) ee );
         }
-        this.summarizeProcessing();
     }
 
     @Override
@@ -146,11 +145,9 @@ public class ProcessedDataComputeCLI extends ExpressionExperimentManipulatingCLI
             }
 
             // Note the auditing is done by the service.
-            successObjects.add( ee );
-            AbstractCLI.log.info( "Successfully processed: " + ee );
+            addSuccessObject( ee, "Successfully processed: " + ee );
         } catch ( PreprocessingException | Exception e ) {
-            errorObjects.add( ee + ": " + e.getMessage() );
-            AbstractCLI.log.error( "**** Exception while processing " + ee + ": " + e.getMessage() + " ********", e );
+            addErrorObject( ee, e.getMessage(), e );
         }
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/PubMedLoaderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/PubMedLoaderCli.java
@@ -21,7 +21,6 @@ package ubic.gemma.core.apps;
 import org.apache.commons.cli.Option;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.entrez.pubmed.PubMedService;
-import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.core.util.AbstractCLIContextCLI;
 
 import java.io.File;
@@ -35,12 +34,9 @@ public class PubMedLoaderCli extends AbstractCLIContextCLI {
 
     private String directory;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         PubMedLoaderCli p = new PubMedLoaderCli();
-        Exception exception = p.doWork( args );
-        if ( exception != null ) {
-            AbstractCLI.log.error( exception, exception );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -63,13 +59,10 @@ public class PubMedLoaderCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
         PubMedService pms = this.getBean( PubMedService.class );
         pms.loadFromDirectory( new File( directory ) );
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/PubMedLoaderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/PubMedLoaderCli.java
@@ -59,8 +59,7 @@ public class PubMedLoaderCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         PubMedService pms = this.getBean( PubMedService.class );
         pms.loadFromDirectory( new File( directory ) );
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/PubMedLoaderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/PubMedLoaderCli.java
@@ -34,11 +34,6 @@ public class PubMedLoaderCli extends AbstractCLIContextCLI {
 
     private String directory;
 
-    public static int main( String[] args ) {
-        PubMedLoaderCli p = new PubMedLoaderCli();
-        return executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.MISC;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
@@ -31,11 +31,6 @@ public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
     private BatchInfoPopulationService batchService;
     private String fastqRootDir = Settings.getString( "gemma.fastq.headers.dir" );
 
-    public static int main( String[] args ) {
-        RNASeqBatchInfoCli d = new RNASeqBatchInfoCli();
-        return executeCommand( d, args );
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
@@ -59,9 +59,7 @@ public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         batchService = this.getBean( BatchInfoPopulationService.class );
 
         log.info( "Checking folders for existing experiments in " + fastqRootDir );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
@@ -22,7 +22,7 @@ import ubic.gemma.persistence.util.Settings;
 /**
  * Add batch information for RNA-seq experiments.
  *
- * @author     tesar
+ * @author tesar
  * @deprecated this should not be necessary and the regular batch population tool can be used instead.
  */
 public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
@@ -31,12 +31,9 @@ public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
     private BatchInfoPopulationService batchService;
     private String fastqRootDir = Settings.getString( "gemma.fastq.headers.dir" );
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         RNASeqBatchInfoCli d = new RNASeqBatchInfoCli();
-        Exception e = d.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( d, args );
     }
 
     @Override
@@ -62,10 +59,8 @@ public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = super.processCommandLine( args );
-        if ( e != null )
-            return e;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         batchService = this.getBean( BatchInfoPopulationService.class );
 
@@ -86,8 +81,6 @@ public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
         }
 
         summarizeProcessing();
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqBatchInfoCli.java
@@ -61,19 +61,15 @@ public class RNASeqBatchInfoCli extends ExpressionExperimentManipulatingCLI {
 
         for ( BioAssaySet ee : this.expressionExperiments ) {
             if ( !( ee instanceof ExpressionExperiment ) ) {
-                errorObjects.add( ee + " is not an expressionexperiment " );
+                addErrorObject( ee, "This is not an ExpressionExperiment!" );
             }
 
             if ( batchService.fillBatchInformation( ( ExpressionExperiment ) ee, this.force ) ) {
-                log.info( "Added batch information for " + ee );
-                successObjects.add( ee );
+                addSuccessObject( ee, "Added batch information" );
             } else {
-                log.info( "Failed to add batch information for " + ee );
-                errorObjects.add( ee );
+                addErrorObject( ee, "Failed to add batch information" );
             }
         }
-
-        summarizeProcessing();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
@@ -48,11 +48,6 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     private String rpkmFile = null;
     private boolean justbackfillLog2cpm = false;
 
-    public static void main( String[] args ) {
-        RNASeqDataAddCli c = new RNASeqDataAddCli();
-        executeCommand( c, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
@@ -142,9 +142,7 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         DataUpdater serv = this.getBean( DataUpdater.class );
 
         if ( this.justbackfillLog2cpm ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
@@ -142,10 +142,8 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception exception = super.processCommandLine( args );
-        if ( exception != null )
-            return exception;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         DataUpdater serv = this.getBean( DataUpdater.class );
 
@@ -173,7 +171,6 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
             }
 
             this.summarizeProcessing();
-            return null;
         }
 
         /*
@@ -206,10 +203,8 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
                     allowMissingSamples );
 
         } catch ( IOException e ) {
-            AbstractCLI.log.error( "Failed while processing " + ee, e );
-            return e;
+            throw new Exception( "Failed while processing " + ee, e );
         }
-        return null;
     }
 
     @Override
@@ -217,7 +212,7 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
         return "Add expression quantifiation to an RNA-seq experiment";
     }
 
-    private ArrayDesign locateArrayDesign( String name ) {
+    private ArrayDesign locateArrayDesign( String name ) throws Exception {
 
         ArrayDesign arrayDesign = null;
         ArrayDesignService arrayDesignService = this.getBean( ArrayDesignService.class );
@@ -233,9 +228,9 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
         }
 
         if ( arrayDesign == null ) {
-            AbstractCLI.log.error( "No arrayDesign " + name + " found" );
-            exitwithError();
+            throw new Exception( "No arrayDesign " + name + " found" );
         }
+
         return arrayDesign;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
@@ -152,18 +152,15 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
                     QuantitationType qt = pqts.iterator().next();
                     if ( !qt.getType().equals( StandardQuantitationType.COUNT ) ) {
                         AbstractCLI.log.warn( "Preferred data is not counts for " + ee );
-                        this.errorObjects.add( ee.getShortName() + ": Preferred data is not counts" );
+                        addErrorObject( ee.getShortName(), "Preferred data is not counts" );
                         continue;
                     }
                     serv.log2cpmFromCounts( ee, qt );
-                    this.successObjects.add( ee );
+                    addSuccessObject( ee, "Successfully processed " + ee.getShortName() );
                 } catch ( Exception e ) {
-                    AbstractCLI.log.error( e, e );
-                    this.errorObjects.add( ( ( ExpressionExperiment ) bas ).getShortName() + ": " + e.getMessage() );
+                    addErrorObject( ( ( ExpressionExperiment ) bas ).getShortName(), e.getMessage(), e );
                 }
             }
-
-            this.summarizeProcessing();
         }
 
         /*

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ReplaceDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ReplaceDataCli.java
@@ -39,11 +39,6 @@ public class ReplaceDataCli extends ExpressionExperimentManipulatingCLI {
 
     private String file = null;
 
-    public static void main( String[] args ) {
-        ReplaceDataCli c = new ReplaceDataCli();
-        executeCommand( c, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ReplaceDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ReplaceDataCli.java
@@ -18,12 +18,10 @@ import ubic.basecode.dataStructure.matrix.DoubleMatrix;
 import ubic.basecode.io.reader.DoubleMatrixReader;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.expression.DataUpdater;
-import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -74,9 +72,7 @@ public class ReplaceDataCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         DataUpdater dataUpdater = this.getBean( DataUpdater.class );
 
         if ( this.expressionExperiments.size() > 1 ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ReplaceDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ReplaceDataCli.java
@@ -74,11 +74,8 @@ public class ReplaceDataCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception exception = super.processCommandLine( args );
-        if ( exception != null ) {
-            return exception;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         DataUpdater dataUpdater = this.getBean( DataUpdater.class );
 
@@ -110,18 +107,11 @@ public class ReplaceDataCli extends ExpressionExperimentManipulatingCLI {
 
         QuantitationType qt = qts.iterator().next();
 
-        try {
-            DoubleMatrixReader reader = new DoubleMatrixReader();
+        DoubleMatrixReader reader = new DoubleMatrixReader();
 
-            DoubleMatrix<String, String> data = reader.read( file );
+        DoubleMatrix<String, String> data = reader.read( file );
 
-            dataUpdater.replaceData( ee, targetArrayDesign, qt, data );
-
-        } catch ( IOException e ) {
-            AbstractCLI.log.error( "Failed while processing " + ee, e );
-            return e;
-        }
-        return null;
+        dataUpdater.replaceData( ee, targetArrayDesign, qt, data );
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
@@ -58,9 +58,7 @@ public class SVDCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         SVDService svdService = this.getBean( SVDService.class );
 
         for ( BioAssaySet bas : this.expressionExperiments ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
@@ -59,7 +59,7 @@ public class SVDCli extends ExpressionExperimentManipulatingCLI {
         for ( BioAssaySet bas : this.expressionExperiments ) {
 
             if ( !force && this.noNeedToRun( bas, PCAAnalysisEvent.class ) ) {
-                this.errorObjects.add( bas + ": Already has PCA; use -force to override" );
+                addErrorObject( bas, "Already has PCA; use -force to override" );
                 continue;
             }
 
@@ -69,13 +69,11 @@ public class SVDCli extends ExpressionExperimentManipulatingCLI {
 
                 svdService.svd( ee.getId() );
 
-                this.successObjects.add( bas.toString() );
+                addSuccessObject( bas, "Successfully processed " + bas );
             } catch ( Exception e ) {
-                AbstractCLI.log.error( e, e );
-                this.errorObjects.add( bas + ": " + e.getMessage() );
+                addErrorObject( bas, e.getMessage(), e );
             }
         }
-        this.summarizeProcessing();
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
@@ -31,11 +31,6 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public class SVDCli extends ExpressionExperimentManipulatingCLI {
 
-    public static int main( String[] args ) {
-        SVDCli s = new SVDCli();
-        return executeCommand( s, args );
-    }
-
     @Override
     public String getShortDesc() {
         return "Run PCA (using SVD) on data sets";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SVDCli.java
@@ -31,14 +31,9 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public class SVDCli extends ExpressionExperimentManipulatingCLI {
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         SVDCli s = new SVDCli();
-        Exception e = s.doWork( args );
-
-        if ( e != null ) {
-            AbstractCLI.log.error( e, e );
-        }
-        System.exit( 0 ); // dangling threads?
+        return executeCommand( s, args );
     }
 
     @Override
@@ -63,11 +58,8 @@ public class SVDCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = super.processCommandLine( args );
-
-        if ( err != null )
-            return err;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
 
         SVDService svdService = this.getBean( SVDService.class );
 
@@ -91,7 +83,6 @@ public class SVDCli extends ExpressionExperimentManipulatingCLI {
             }
         }
         this.summarizeProcessing();
-        return null;
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SplitExperimentCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SplitExperimentCli.java
@@ -26,7 +26,6 @@ import org.apache.commons.cli.Option;
 import ubic.gemma.core.analysis.preprocess.SplitExperimentService;
 import ubic.gemma.core.analysis.preprocess.batcheffects.BatchInfoPopulationServiceImpl;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
-import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
@@ -44,11 +43,6 @@ public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
      *
      */
     private static final String FACTOR_OPTION = "factor";
-
-    public static void main( String[] args ) {
-        SplitExperimentCli c = new SplitExperimentCli();
-        AbstractCLIContextCLI.executeCommand( c, args );
-    }
 
     private Long factorId;
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SplitExperimentCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SplitExperimentCli.java
@@ -1,8 +1,8 @@
 /*
  * The gemma-core project
- * 
+ *
  * Copyright (c) 2018 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,13 +35,13 @@ import ubic.gemma.persistence.service.expression.experiment.ExperimentalFactorSe
 
 /**
  * Split an experiment into parts based on an experimental factor
- * 
+ *
  * @author paul
  */
 public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
 
     /**
-     * 
+     *
      */
     private static final String FACTOR_OPTION = "factor";
 
@@ -61,7 +61,7 @@ public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#getCommandName()
      */
     @Override
@@ -85,15 +85,12 @@ public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#doWork(java.lang.String[])
      */
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception err = this.processCommandLine( args );
-        if ( err != null ) {
-            return err;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         if ( expressionExperiments.size() > 1 ) {
             throw new IllegalArgumentException( "Can only split one experiment at a time" );
@@ -113,8 +110,6 @@ public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
         ExperimentalFactor splitOn = this.guessFactor( ee );
 
         serv.split( ee, splitOn );
-
-        return null;
     }
 
     @Override
@@ -136,8 +131,8 @@ public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
 
     /**
      * Adapted from code in DifferentialExpressionAnalysisCli
-     * 
-     * @param  ee
+     *
+     * @param ee
      * @return
      */
     private ExperimentalFactor guessFactor( ExpressionExperiment ee ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/SplitExperimentCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/SplitExperimentCli.java
@@ -89,9 +89,7 @@ public class SplitExperimentCli extends ExpressionExperimentManipulatingCLI {
      * @see ubic.gemma.core.util.AbstractCLI#doWork(java.lang.String[])
      */
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         if ( expressionExperiments.size() > 1 ) {
             throw new IllegalArgumentException( "Can only split one experiment at a time" );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TaxonLoaderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TaxonLoaderCli.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2006 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -58,33 +58,25 @@ public class TaxonLoaderCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        try {
-            Exception err = processCommandLine( args );
-            if ( err != null )
-                return err;
-            TaxonFetcher tf = new TaxonFetcher();
-            Collection<LocalFile> files = tf.fetch();
-            LocalFile names = null;
-            for ( LocalFile file : files ) {
-                if ( file.getLocalURL().toString().endsWith( "names.dmp" ) ) {
-                    names = file;
-                }
+    protected void doWork( String[] args ) throws Exception {
+        processCommandLine( args );
+        TaxonFetcher tf = new TaxonFetcher();
+        Collection<LocalFile> files = tf.fetch();
+        LocalFile names = null;
+        for ( LocalFile file : files ) {
+            if ( file.getLocalURL().toString().endsWith( "names.dmp" ) ) {
+                names = file;
             }
-
-            if ( names == null ) {
-                throw new IllegalStateException( "No names.dmp file" );
-            }
-
-            TaxonLoader tl = new TaxonLoader();
-            tl.setPersisterHelper( this.getBean( PersisterHelper.class ) );
-            int numLoaded = tl.load( names.asFile() );
-            log.info( "Loaded " + numLoaded + " taxa" );
-        } catch ( Exception e ) {
-            log.error( e );
-            return e;
         }
-        return null;
+
+        if ( names == null ) {
+            throw new IllegalStateException( "No names.dmp file" );
+        }
+
+        TaxonLoader tl = new TaxonLoader();
+        tl.setPersisterHelper( this.getBean( PersisterHelper.class ) );
+        int numLoaded = tl.load( names.asFile() );
+        log.info( "Loaded " + numLoaded + " taxa" );
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TaxonLoaderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TaxonLoaderCli.java
@@ -32,11 +32,6 @@ import java.util.Collection;
  */
 public class TaxonLoaderCli extends AbstractCLIContextCLI {
 
-    public static void main( String[] args ) {
-        TaxonLoaderCli p = new TaxonLoaderCli();
-        executeCommand( p, args );
-    }
-
     @Override
     public String getCommandName() {
         return "loadTaxa";

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TaxonLoaderCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TaxonLoaderCli.java
@@ -58,8 +58,7 @@ public class TaxonLoaderCli extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        processCommandLine( args );
+    protected void doWork() throws Exception {
         TaxonFetcher tf = new TaxonFetcher();
         Collection<LocalFile> files = tf.fetch();
         LocalFile names = null;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
@@ -131,8 +131,6 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
                         "Can't do two-channel missing values on " + ee.getClass().getName() );
             }
         }
-
-        this.summarizeProcessing();
     }
 
     @Override
@@ -210,10 +208,10 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
             }
         }
 
-        if ( !wasProcessed ) {
-            errorObjects.add( ee.getShortName() );
+        if ( wasProcessed ) {
+            addSuccessObject( ee.toString(), "Was processed" );
         } else {
-            successObjects.add( ee.toString() );
+            addErrorObject( ee.getShortName(), "Was not processed" );
         }
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
@@ -59,11 +59,6 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
     private double s2n = TwoChannelMissingValues.DEFAULT_SIGNAL_TO_NOISE_THRESHOLD;
     private TwoChannelMissingValues tcmv;
 
-    public static int main( String[] args ) {
-        TwoChannelMissingValueCLI p = new TwoChannelMissingValueCLI();
-        return executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
@@ -127,9 +127,7 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         for ( BioAssaySet ee : expressionExperiments ) {
             if ( ee instanceof ExpressionExperiment ) {
                 this.processForMissingValues( ( ExpressionExperiment ) ee );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
@@ -59,16 +59,9 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
     private double s2n = TwoChannelMissingValues.DEFAULT_SIGNAL_TO_NOISE_THRESHOLD;
     private TwoChannelMissingValues tcmv;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         TwoChannelMissingValueCLI p = new TwoChannelMissingValueCLI();
-        try {
-            Exception ex = p.doWork( args );
-            if ( ex != null ) {
-                ex.printStackTrace();
-            }
-        } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-        }
+        return executeCommand( p, args );
     }
 
     @Override
@@ -117,8 +110,7 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
                     this.extraMissingValueIndicators.add( new Double( string ) );
                 }
             } catch ( NumberFormatException e ) {
-                AbstractCLI.log.error( "Arguments to mvind must be numbers" );
-                exitwithError();
+                throw new RuntimeException( "Arguments to mvind must be numbers", e );
             }
         }
         tcmv = this.getBean( TwoChannelMissingValues.class );
@@ -135,11 +127,9 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
 
-        Exception err = this.processCommandLine( args );
-        if ( err != null )
-            return err;
+        this.processCommandLine( args );
         for ( BioAssaySet ee : expressionExperiments ) {
             if ( ee instanceof ExpressionExperiment ) {
                 this.processForMissingValues( ( ExpressionExperiment ) ee );
@@ -150,7 +140,6 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
         }
 
         this.summarizeProcessing();
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
@@ -54,9 +54,7 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         mergingService = this.getBean( VectorMergingService.class );
 
         for ( BioAssaySet ee : expressionExperiments ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
@@ -32,11 +32,6 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
 
     private VectorMergingService mergingService;
 
-    public static int main( String[] args ) {
-        VectorMergingCli v = new VectorMergingCli();
-        return executeCommand( v, args );
-    }
-
     @Override
     public GemmaCLI.CommandGroup getCommandGroup() {
         return GemmaCLI.CommandGroup.EXPERIMENT;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
@@ -60,8 +60,6 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
                         "Can't do vector merging on non-expressionExperiment bioassaysets" );
             }
         }
-
-        this.summarizeProcessing();
     }
 
     @Override
@@ -72,15 +70,10 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
     private void processExperiment( ExpressionExperiment expressionExperiment ) {
         try {
             expressionExperiment = eeService.thawLite( expressionExperiment );
-
             expressionExperiment = mergingService.mergeVectors( expressionExperiment );
-
-            super.successObjects.add( expressionExperiment.toString() );
+            addSuccessObject( expressionExperiment.toString(), "Finished processing " + expressionExperiment );
         } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-            super.errorObjects.add( expressionExperiment + ": " + e.getMessage() );
-
+            addErrorObject( expressionExperiment, e.getMessage(), e );
         }
-        AbstractCLI.log.info( "Finished processing " + expressionExperiment );
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/VectorMergingCli.java
@@ -32,12 +32,9 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
 
     private VectorMergingService mergingService;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         VectorMergingCli v = new VectorMergingCli();
-        Exception e = v.doWork( args );
-        if ( e != null ) {
-            AbstractCLI.log.fatal( e );
-        }
+        return executeCommand( v, args );
     }
 
     @Override
@@ -57,11 +54,8 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e = this.processCommandLine( args );
-        if ( e != null ) {
-            return e;
-        }
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
         mergingService = this.getBean( VectorMergingService.class );
 
@@ -75,8 +69,6 @@ public class VectorMergingCli extends ExpressionExperimentManipulatingCLI {
         }
 
         this.summarizeProcessing();
-        return null;
-
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/job/executor/worker/WorkerCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/job/executor/worker/WorkerCLI.java
@@ -74,8 +74,7 @@ public class WorkerCLI extends AbstractSpringAwareCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
+    protected void doWork() throws Exception {
         this.init();
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/job/executor/worker/WorkerCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/job/executor/worker/WorkerCLI.java
@@ -32,12 +32,9 @@ public class WorkerCLI extends AbstractSpringAwareCLI {
 
     private RemoteTaskRunningService taskRunningService;
 
-    public static void main( String[] args ) {
+    public static int main( String[] args ) {
         WorkerCLI me = new WorkerCLI();
-        Exception e = me.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( me, args );
     }
 
     @Override
@@ -52,8 +49,8 @@ public class WorkerCLI extends AbstractSpringAwareCLI {
 
     @Override
     protected String[] getAdditionalSpringConfigLocations() {
-        return new String[] { "classpath*:ubic/gemma/workerContext-component-scan.xml",
-                "classpath*:ubic/gemma/workerContext-jms.xml" };
+        return new String[]{"classpath*:ubic/gemma/workerContext-component-scan.xml",
+                "classpath*:ubic/gemma/workerContext-jms.xml"};
     }
 
     @Override
@@ -77,18 +74,9 @@ public class WorkerCLI extends AbstractSpringAwareCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception commandArgumentErrors = this.processCommandLine( args );
-        if ( commandArgumentErrors != null ) {
-            return commandArgumentErrors;
-        }
-
-        try {
-            this.init();
-        } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-        }
-        return null;
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
+        this.init();
     }
 
     private void init() {
@@ -98,7 +86,7 @@ public class WorkerCLI extends AbstractSpringAwareCLI {
         taskRunningService = ctx.getBean( RemoteTaskRunningService.class );
     }
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public class ShutdownHook extends Thread {
         @Override
         public void run() {

--- a/gemma-core/src/main/java/ubic/gemma/core/job/executor/worker/WorkerCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/job/executor/worker/WorkerCLI.java
@@ -32,11 +32,6 @@ public class WorkerCLI extends AbstractSpringAwareCLI {
 
     private RemoteTaskRunningService taskRunningService;
 
-    public static int main( String[] args ) {
-        WorkerCLI me = new WorkerCLI();
-        return executeCommand( me, args );
-    }
-
     @Override
     public String getShortDesc() {
         return "Start worker application for processing tasks sent by Gemma webapp.";

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/CtdDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/CtdDatabaseImporterCli.java
@@ -70,8 +70,7 @@ public class CtdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         super.init();
 
         writeFolder = ppUtil.createWriteFolderIfDoesntExist( CtdDatabaseImporterCli.CTD );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/CtdDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/CtdDatabaseImporterCli.java
@@ -38,11 +38,6 @@ public class CtdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
         super();
     }
 
-    public static int main( String[] args ) throws Exception {
-        CtdDatabaseImporterCli importEvidence = new CtdDatabaseImporterCli();
-        return executeCommand( importEvidence, args );
-    }
-
     @Override
     public String getCommandName() {
         return "ctdDownload";

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/CtdDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/CtdDatabaseImporterCli.java
@@ -33,18 +33,14 @@ public class CtdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     // location of the ctd file
     private String ctdFile = "";
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public CtdDatabaseImporterCli() throws Exception {
         super();
     }
 
-    public static void main( String[] args ) throws Exception {
+    public static int main( String[] args ) throws Exception {
         CtdDatabaseImporterCli importEvidence = new CtdDatabaseImporterCli();
-
-        Exception e = importEvidence.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( importEvidence, args );
     }
 
     @Override
@@ -74,25 +70,16 @@ public class CtdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e1 = super.processCommandLine( args );
-        if ( e1 != null ) return e1;
-        e1 = super.init();
-        if ( e1 != null ) return e1;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
+        super.init();
 
-        try {
-            writeFolder = ppUtil.createWriteFolderIfDoesntExist( CtdDatabaseImporterCli.CTD );
-            this.downloadCTDFileIfDoesntExist();
+        writeFolder = ppUtil.createWriteFolderIfDoesntExist( CtdDatabaseImporterCli.CTD );
+        this.downloadCTDFileIfDoesntExist();
 
-            // using the disease ontology file creates the mapping from mesh and omim id to valuesUri
-            ppUtil.loadMESHOMIM2DOMappings();
-            this.processCTDFile();
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            return e;
-        }
-
-        return null;
+        // using the disease ontology file creates the mapping from mesh and omim id to valuesUri
+        ppUtil.loadMESHOMIM2DOMappings();
+        this.processCTDFile();
     }
 
     private void downloadCTDFileIfDoesntExist() {
@@ -123,7 +110,7 @@ public class CtdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
             if ( line.indexOf( '#' ) != -1 ) {
                 continue;
             }
-            
+
             // fields: GeneSymbol    GeneID  DiseaseName     DiseaseID       DirectEvidence  InferenceChemicalName   InferenceScore  OmimIDs PubMedIDs
 
             String[] tokens = line.split( "\t" );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DeleteEvidenceCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DeleteEvidenceCLI.java
@@ -37,22 +37,7 @@ public class DeleteEvidenceCLI extends AbstractCLIContextCLI {
     public static void main( String[] args ) {
 
         DeleteEvidenceCLI deleteEvidenceImporterCLI = new DeleteEvidenceCLI();
-
-        try {
-            Exception ex;
-
-            String[] argsToTake;
-
-            argsToTake = args;
-
-            ex = deleteEvidenceImporterCLI.doWork( argsToTake );
-
-            if ( ex != null ) {
-                ex.printStackTrace();
-            }
-        } catch ( Exception e ) {
-            throw new RuntimeException( e );
-        }
+        executeCommand( deleteEvidenceImporterCLI, args );
     }
 
     @Override
@@ -80,12 +65,9 @@ public class DeleteEvidenceCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
 
-        Exception err = this.processCommandLine( args );
-
-        if ( err != null )
-            return err;
+        this.processCommandLine( args );
 
         try {
             this.loadServices();
@@ -104,16 +86,14 @@ public class DeleteEvidenceCLI extends AbstractCLIContextCLI {
         while ( evidenceToDelete.size() > 0 ) {
             for ( EvidenceValueObject<?> e : evidenceToDelete ) {
                 this.phenotypeAssociationService.remove( e.getId() );
-             //   AbstractCLI.log.info( i++ );
+                //   AbstractCLI.log.info( i++ );
                 i++;
             }
-            
+
             // WTF?
             evidenceToDelete = this.phenotypeAssociationService
                     .loadEvidenceWithExternalDatabaseName( externalDatabaseName, limit, 0 );
         }
-      //  System.exit( -1 ); // ???
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DeleteEvidenceCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DeleteEvidenceCLI.java
@@ -34,12 +34,6 @@ public class DeleteEvidenceCLI extends AbstractCLIContextCLI {
     private String externalDatabaseName = "";
     private PhenotypeAssociationManagerService phenotypeAssociationService = null;
 
-    public static void main( String[] args ) {
-
-        DeleteEvidenceCLI deleteEvidenceImporterCLI = new DeleteEvidenceCLI();
-        executeCommand( deleteEvidenceImporterCLI, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.PHENOTYPES;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DeleteEvidenceCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DeleteEvidenceCLI.java
@@ -65,10 +65,7 @@ public class DeleteEvidenceCLI extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         try {
             this.loadServices();
         } catch ( Exception e ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DgaDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DgaDatabaseImporterCli.java
@@ -15,9 +15,9 @@ import java.util.Set;
 
 /**
  * this importer cannot automatically download files it expects the files to already be there
- * 
+ * <p>
  * WARNING: the DGA web site is gone, and no replacement has been identified.
- * 
+ *
  * @author Nicolas
  */
 public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbstractCLI {
@@ -32,17 +32,14 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     private final Set<String> linesToExclude = new HashSet<>();
     private File dgaFile = null;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public DgaDatabaseImporterCli() throws Exception {
         super();
     }
 
-    public static void main( String[] args ) throws Exception {
+    public static int main( String[] args ) throws Exception {
         DgaDatabaseImporterCli databaseImporter = new DgaDatabaseImporterCli();
-        Exception e = databaseImporter.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( databaseImporter, args );
     }
 
     @Override
@@ -61,22 +58,13 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e1 = super.processCommandLine( args );
-        if ( e1 != null ) return e1;
-        e1 = super.init();
-        if ( e1 != null ) return e1;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
+        super.init();
 
-        
-        try {
-            this.checkForDGAFile();
-            this.findTermsWithParents();
-            this.processDGAFile();
-        } catch ( Exception e ) {
-            e.printStackTrace();
-        }
-
-        return null;
+        this.checkForDGAFile();
+        this.findTermsWithParents();
+        this.processDGAFile();
     }
 
     @Override
@@ -139,7 +127,7 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     // example: same pubed, same gene 1-leukemia 2-myeloid leukemia 3-acute myeloid leukemia, keep only 3-
     private void findTermsWithParents() throws Exception {
 
-        try (BufferedReader dgaReader = new BufferedReader( new FileReader( dgaFile ) )) {
+        try ( BufferedReader dgaReader = new BufferedReader( new FileReader( dgaFile ) ) ) {
             String line;
 
             while ( ( line = dgaReader.readLine() ) != null ) {
@@ -209,7 +197,7 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
 
         ppUtil.initFinalOutputFile( "DGA", this.writeFolder, false, true );
 
-        try (BufferedReader dgaReader = new BufferedReader( new FileReader( dgaFile ) )) {
+        try ( BufferedReader dgaReader = new BufferedReader( new FileReader( dgaFile ) ) ) {
             String line;
 
             while ( ( line = dgaReader.readLine() ) != null ) {
@@ -243,11 +231,11 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
                                 // negative
                                 if ( ( geneRIF.contains( " is not " ) || geneRIF.contains( " not associated " )
                                         || geneRIF.contains( " no significant " ) || geneRIF
-                                                .contains( " no association " )
+                                        .contains( " no association " )
                                         || geneRIF.contains( " not significant " )
                                         || geneRIF.contains( " not expressed " ) )
                                         && !geneRIF
-                                                .contains( "is associated" )
+                                        .contains( "is associated" )
                                         && !geneRIF.contains( "is significant" )
                                         && !geneRIF.contains( "is not only" ) && !geneRIF.contains( "is expressed" ) ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DgaDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DgaDatabaseImporterCli.java
@@ -32,16 +32,6 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     private final Set<String> linesToExclude = new HashSet<>();
     private File dgaFile = null;
 
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
-    public DgaDatabaseImporterCli() throws Exception {
-        super();
-    }
-
-    public static int main( String[] args ) throws Exception {
-        DgaDatabaseImporterCli databaseImporter = new DgaDatabaseImporterCli();
-        return executeCommand( databaseImporter, args );
-    }
-
     @Override
     public String getCommandName() {
         return "dgaDownload";

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DgaDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/DgaDatabaseImporterCli.java
@@ -58,10 +58,8 @@ public class DgaDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         super.init();
-
         this.checkForDGAFile();
         this.findTermsWithParents();
         this.processDGAFile();

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/EvidenceImporterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/EvidenceImporterCLI.java
@@ -40,9 +40,8 @@ import java.util.*;
 @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
 public class EvidenceImporterCLI extends EvidenceImporterAbstractCLI {
 
-    public static int main( String[] args ) {
-        EvidenceImporterCLI evidenceImporterCLI = new EvidenceImporterCLI();
-
+    @Override
+    public int executeCommand( String[] args ) {
         String[] argsToTake;
 
         if ( args.length == 0 ) {
@@ -50,8 +49,7 @@ public class EvidenceImporterCLI extends EvidenceImporterAbstractCLI {
         } else {
             argsToTake = args;
         }
-
-        return executeCommand( evidenceImporterCLI, argsToTake );
+        return super.executeCommand( argsToTake );
     }
 
     // initArgument is only call when no argument is given on the command line, (it make it faster to run it in eclipse)

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/EvidenceImporterCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/EvidenceImporterCLI.java
@@ -80,9 +80,7 @@ public class EvidenceImporterCLI extends EvidenceImporterAbstractCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         this.createWriteFolder();
 
         FileWriter fstream = new FileWriter(

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/ExternalDatabaseEvidenceImporterAbstractCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/ExternalDatabaseEvidenceImporterAbstractCLI.java
@@ -33,7 +33,7 @@ public abstract class ExternalDatabaseEvidenceImporterAbstractCLI extends Abstra
     protected GeneService geneService;
 
     // the init is in the constructor, we always need those
-    public ExternalDatabaseEvidenceImporterAbstractCLI() throws Exception {
+    public ExternalDatabaseEvidenceImporterAbstractCLI() {
         super();
     }
 
@@ -47,18 +47,10 @@ public abstract class ExternalDatabaseEvidenceImporterAbstractCLI extends Abstra
      *
      * @return an exception, if there were any problems, or null otherwise.
      */
-    protected Exception init() {
-
-        try {
-            this.geneService = this.getBean( GeneService.class );
-            this.taxonService = getBean( TaxonService.class );
-            this.ppUtil = new PhenotypeProcessingUtil( geneService, this.getBean( OntologyService.class ) );
-        } catch ( Exception e ) {
-            return e;
-        }
-
-        return null;
-
+    protected void init() throws Exception {
+        this.geneService = this.getBean( GeneService.class );
+        this.taxonService = getBean( TaxonService.class );
+        this.ppUtil = new PhenotypeProcessingUtil( geneService, this.getBean( OntologyService.class ) );
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/GwasDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/GwasDatabaseImporterCli.java
@@ -94,18 +94,14 @@ public class GwasDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     private static final String STRONGEST_SNP = "STRONGEST SNP-RISK ALLELE";
     private static final Integer STRONGEST_SNP_INDEX = 20;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
-    public GwasDatabaseImporterCli() throws Exception {
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
+    public GwasDatabaseImporterCli() {
         super();
     }
 
-    public static void main( String[] args ) throws Exception {
-
+    public static int main( String[] args ) {
         GwasDatabaseImporterCli importEvidence = new GwasDatabaseImporterCli();
-        Exception e = importEvidence.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( importEvidence, args );
     }
 
     @Override
@@ -119,25 +115,17 @@ public class GwasDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e1 = super.processCommandLine( args );
-        if ( e1 != null ) return e1;
-        e1 = super.init();
-        if ( e1 != null ) return e1;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
+        super.init();
 
         // creates the folder where to place the file web downloaded files and final output files
-        try {
-            this.writeFolder = ppUtil.createWriteFolderWithDate( GwasDatabaseImporterCli.GWAS );
-            // download the GWAS file
-            String gwasFile = this.ppUtil
-                    .downloadFileFromWeb( GwasDatabaseImporterCli.GWAS_URL_PATH, "", writeFolder, GWAS_FILE );
-            // process the gwas file
-            this.processGwasFile( gwasFile );
-        } catch ( Exception e ) {
-            e.printStackTrace();
-            return e;
-        }
-        return null;
+        this.writeFolder = ppUtil.createWriteFolderWithDate( GwasDatabaseImporterCli.GWAS );
+        // download the GWAS file
+        String gwasFile = this.ppUtil
+                .downloadFileFromWeb( GwasDatabaseImporterCli.GWAS_URL_PATH, "", writeFolder, GWAS_FILE );
+        // process the gwas file
+        this.processGwasFile( gwasFile );
     }
 
     @Override
@@ -176,7 +164,7 @@ public class GwasDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     private void processGwasFile( String gwasFile ) throws Exception {
         Taxon human = taxonService.findByCommonName( "human" );
 
-        try (BufferedReader br = new BufferedReader( new FileReader( gwasFile ) )) {
+        try ( BufferedReader br = new BufferedReader( new FileReader( gwasFile ) ) ) {
 
             // check if we have correct headers and organ
             this.verifyHeaders( br.readLine().split( "\t" ) );
@@ -265,7 +253,7 @@ public class GwasDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.core.util.AbstractCLI#buildOptions()
      */
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/GwasDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/GwasDatabaseImporterCli.java
@@ -115,8 +115,7 @@ public class GwasDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         super.init();
 
         // creates the folder where to place the file web downloaded files and final output files

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/GwasDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/GwasDatabaseImporterCli.java
@@ -94,16 +94,6 @@ public class GwasDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     private static final String STRONGEST_SNP = "STRONGEST SNP-RISK ALLELE";
     private static final Integer STRONGEST_SNP_INDEX = 20;
 
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
-    public GwasDatabaseImporterCli() {
-        super();
-    }
-
-    public static int main( String[] args ) {
-        GwasDatabaseImporterCli importEvidence = new GwasDatabaseImporterCli();
-        return executeCommand( importEvidence, args );
-    }
-
     @Override
     public String getCommandName() {
         return "gwasDownload";

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/LoadEvidenceForClassifier.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/LoadEvidenceForClassifier.java
@@ -47,25 +47,8 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     private BibliographicReferenceService bibliographicReferenceService = null;
     private BufferedWriter writer;
 
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
-    public LoadEvidenceForClassifier( String[] args ) throws Exception {
-
-        this.loadServices( args );
-
-        // place to put the files results
-        String writeFolder = this.createWriteFolderIfNotExists();
-
-        writer = new BufferedWriter( new FileWriter( writeFolder + "/mappingFound.tsv" ) );
-
-        this.loadTrainingSetUsed();
-
-        this.findEvidence();
-    }
-
-    public static void main( String[] args ) throws Exception {
-
-        new LoadEvidenceForClassifier( args );
-
+    public static int main( String[] args ) {
+        return executeCommand( new LoadEvidenceForClassifier(), args );
     }
 
     @Override
@@ -83,8 +66,17 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) {
-        // TODO
+    protected void doWork() throws Exception {
+        this.loadServices();
+
+        // place to put the files results
+        String writeFolder = this.createWriteFolderIfNotExists();
+
+        writer = new BufferedWriter( new FileWriter( writeFolder + "/mappingFound.tsv" ) );
+
+        this.loadTrainingSetUsed();
+
+        this.findEvidence();
     }
 
     // creates the folder where the output files will be put, use this one if file is too big
@@ -103,15 +95,7 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     }
 
     // load all needed services
-    private synchronized void loadServices( String[] args ) {
-
-        // this gets the context, so we can access beans
-        try {
-            this.processCommandLine( args );
-        } catch ( Exception exception ) {
-            AbstractCLI.log.error( exception, exception );
-        }
-
+    private synchronized void loadServices() {
         // add services if needed later
         this.bibliographicReferenceService = this.getBean( BibliographicReferenceService.class );
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/LoadEvidenceForClassifier.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/LoadEvidenceForClassifier.java
@@ -16,7 +16,6 @@ package ubic.gemma.core.loader.association.phenotype;
 
 import ubic.gemma.core.annotation.reference.BibliographicReferenceService;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
-import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.common.description.BibliographicReference;
 import ubic.gemma.model.common.description.DatabaseEntry;
@@ -46,10 +45,6 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     // the services that will be needed
     private BibliographicReferenceService bibliographicReferenceService = null;
     private BufferedWriter writer;
-
-    public static int main( String[] args ) {
-        return executeCommand( new LoadEvidenceForClassifier(), args );
-    }
 
     @Override
     public CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/LoadEvidenceForClassifier.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/LoadEvidenceForClassifier.java
@@ -47,7 +47,7 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     private BibliographicReferenceService bibliographicReferenceService = null;
     private BufferedWriter writer;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public LoadEvidenceForClassifier( String[] args ) throws Exception {
 
         this.loadServices( args );
@@ -83,8 +83,8 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        return null;
+    protected void doWork( String[] args ) {
+        // TODO
     }
 
     // creates the folder where the output files will be put, use this one if file is too big
@@ -106,10 +106,10 @@ public class LoadEvidenceForClassifier extends AbstractCLIContextCLI {
     private synchronized void loadServices( String[] args ) {
 
         // this gets the context, so we can access beans
-        Exception exception = this.processCommandLine( args );
-        if ( exception != null ) {
-            AbstractCLI.log.error( exception );
-            exception.printStackTrace();
+        try {
+            this.processCommandLine( args );
+        } catch ( Exception exception ) {
+            AbstractCLI.log.error( exception, exception );
         }
 
         // add services if needed later

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/OmimDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/OmimDatabaseImporterCli.java
@@ -44,12 +44,9 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     // FIXME INVALID URL
     private static final String OMIM_URL_PATH = "ftp://ftp.omim.org/OMIM/";// "ftp://faf.grcf.jhmi.edu/OMIM/";
 
-    public static void main( String[] args ) throws Exception {
+    public static int main( String[] args ) throws Exception {
         OmimDatabaseImporterCli importer = new OmimDatabaseImporterCli();
-        Exception e = importer.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
+        return executeCommand( importer, args );
     }
 
     // ********************************************************************************
@@ -82,43 +79,33 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
 
         // this gets the context, so we can access beans
-        Exception e1 = super.processCommandLine( args );
-        if ( e1 != null ) return e1;
-        e1 = super.init();
-        if ( e1 != null ) return e1;
+        super.processCommandLine( args );
+        super.init();
 
         // creates the folder to place the downloaded files and final output files
-        try {
-            this.writeFolder = ppUtil.createWriteFolderIfDoesntExist( OmimDatabaseImporterCli.OMIM );
-            // download the OMIM File called morbid
-            String morbidmap = this.ppUtil.downloadFileFromWeb( OmimDatabaseImporterCli.OMIM_URL_PATH, OmimDatabaseImporterCli.OMIM_FILE_MORBID,
-                    writeFolder,
-                    OMIM_FILE_MORBID + ".tsv" );
-            // download the OMIM File called mim2gene
-            String mim2gene = ppUtil
-                    .downloadFileFromWeb( OmimDatabaseImporterCli.OMIM_URL_PATH, OmimDatabaseImporterCli.OMIM_FILE_MIM, writeFolder,
-                            OMIM_FILE_MORBID + ".tsv" );
-            // find the OMIM and Mesh terms by download a version of the disease ontology
-            ppUtil.loadMESHOMIM2DOMappings();
-            // return common publications between a OMIM gene and OMIM phenotype
-            Map<Long, Collection<Long>> omimIdToPubmeds = this.findCommonPubmed( morbidmap );
-            // process the omim files to create the final output
-            this.processOmimFiles( morbidmap, mim2gene, omimIdToPubmeds );
-
-        } catch ( Exception e ) {
-            AbstractCLI.log.error( e, e );
-            return e;
-        }
-
-        return null;
+        this.writeFolder = ppUtil.createWriteFolderIfDoesntExist( OmimDatabaseImporterCli.OMIM );
+        // download the OMIM File called morbid
+        String morbidmap = this.ppUtil.downloadFileFromWeb( OmimDatabaseImporterCli.OMIM_URL_PATH, OmimDatabaseImporterCli.OMIM_FILE_MORBID,
+                writeFolder,
+                OMIM_FILE_MORBID + ".tsv" );
+        // download the OMIM File called mim2gene
+        String mim2gene = ppUtil
+                .downloadFileFromWeb( OmimDatabaseImporterCli.OMIM_URL_PATH, OmimDatabaseImporterCli.OMIM_FILE_MIM, writeFolder,
+                        OMIM_FILE_MORBID + ".tsv" );
+        // find the OMIM and Mesh terms by download a version of the disease ontology
+        ppUtil.loadMESHOMIM2DOMappings();
+        // return common publications between a OMIM gene and OMIM phenotype
+        Map<Long, Collection<Long>> omimIdToPubmeds = this.findCommonPubmed( morbidmap );
+        // process the omim files to create the final output
+        this.processOmimFiles( morbidmap, mim2gene, omimIdToPubmeds );
     }
 
     /**
      * specific to OMIM we need to combine lines with the same ncbiGeneId + omimPhenotypeId
-     * 
+     *
      * @throws IOException
      */
     private void combinePhenotypes() throws IOException {
@@ -127,7 +114,7 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
         BufferedReader br = new BufferedReader( new InputStreamReader(
                 FileTools.getInputStreamFromPlainOrCompressedFile( writeFolder + "/finalResults.tsv" ) ) );
 
-        try (BufferedWriter bw = new BufferedWriter( new FileWriter( writeFolder + "/finalResultsOmimCombine.tsv" ) )) {
+        try ( BufferedWriter bw = new BufferedWriter( new FileWriter( writeFolder + "/finalResultsOmimCombine.tsv" ) ) ) {
 
             String line = br.readLine();
 
@@ -181,9 +168,8 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     }
 
     /**
-     * 
-     * @param  valueUri
-     * @param  valueUri2
+     * @param valueUri
+     * @param valueUri2
      * @return
      */
     private String combineUri( String valueUri, String valueUri2 ) {
@@ -209,14 +195,14 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
 
     /**
      * return all common pubmed between an omimGeneId and a omimPhenotypeId
-     * 
-     * @param  omimGeneId
-     * @param  omimPhenotypeId
-     * @param  omimIdToPubmeds
+     *
+     * @param omimGeneId
+     * @param omimPhenotypeId
+     * @param omimIdToPubmeds
      * @return
      */
     private Collection<Long> findCommonPubmed( Long omimGeneId, Long omimPhenotypeId,
-            Map<Long, Collection<Long>> omimIdToPubmeds ) {
+                                               Map<Long, Collection<Long>> omimIdToPubmeds ) {
 
         Collection<Long> pubmedFromGeneId = omimIdToPubmeds.get( omimGeneId );
         Collection<Long> pubmedFromPhenotypeId = omimIdToPubmeds.get( omimPhenotypeId );
@@ -233,8 +219,8 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
 
     /**
      * process all OMIM files to get the data out and manipulates it
-     * 
-     * @param  morbidmap
+     *
+     * @param morbidmap
      * @return
      * @throws NumberFormatException
      * @throws IOException
@@ -246,7 +232,7 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
         // all omimID (gene or phenotype)
         Set<Long> allOmimId = new HashSet<>();
 
-        try (BufferedReader br = new BufferedReader( new FileReader( morbidmap ) )) {
+        try ( BufferedReader br = new BufferedReader( new FileReader( morbidmap ) ) ) {
             String line;
 
             // parse the morbid OMIM file
@@ -281,7 +267,7 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
         String line;
         Map<String, String> omimIdToGeneNCBI = new HashMap<>();
 
-        try (BufferedReader br = new BufferedReader( new FileReader( mim2gene ) )) {
+        try ( BufferedReader br = new BufferedReader( new FileReader( mim2gene ) ) ) {
 
             while ( ( line = br.readLine() ) != null ) {
 
@@ -337,7 +323,7 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
 
         String line;
 
-        try (BufferedReader br = new BufferedReader( new FileReader( morbidmap ) )) {
+        try ( BufferedReader br = new BufferedReader( new FileReader( morbidmap ) ) ) {
 
             // parse the morbid OMIM file
             while ( ( line = br.readLine() ) != null ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/OmimDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/OmimDatabaseImporterCli.java
@@ -44,18 +44,7 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     // FIXME INVALID URL
     private static final String OMIM_URL_PATH = "ftp://ftp.omim.org/OMIM/";// "ftp://faf.grcf.jhmi.edu/OMIM/";
 
-    public static int main( String[] args ) throws Exception {
-        OmimDatabaseImporterCli importer = new OmimDatabaseImporterCli();
-        return executeCommand( importer, args );
-    }
-
     // ********************************************************************************
-
-    /**
-     */
-    OmimDatabaseImporterCli() {
-        super();
-    }
 
     @Override
     public CommandGroup getCommandGroup() {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/OmimDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/OmimDatabaseImporterCli.java
@@ -52,9 +52,8 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     // ********************************************************************************
 
     /**
-     * @throws Exception
      */
-    OmimDatabaseImporterCli() throws Exception {
+    OmimDatabaseImporterCli() {
         super();
     }
 
@@ -79,10 +78,9 @@ public class OmimDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbs
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
+    protected void doWork() throws Exception {
 
         // this gets the context, so we can access beans
-        super.processCommandLine( args );
         super.init();
 
         // creates the folder to place the downloaded files and final output files

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/RgdDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/RgdDatabaseImporterCli.java
@@ -64,9 +64,8 @@ public class RgdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
+    protected void doWork() throws Exception {
         // this gets the context, so we can access beans
-        super.processCommandLine( args );
         super.init();
 
         try {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/RgdDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/RgdDatabaseImporterCli.java
@@ -38,16 +38,6 @@ public class RgdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     // name of the external database
     private static final String RGD = "RGD";
 
-    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
-    public RgdDatabaseImporterCli() {
-        super();
-    }
-
-    public static int main( String[] args ) {
-        RgdDatabaseImporterCli importEvidence = new RgdDatabaseImporterCli();
-        return executeCommand( importEvidence, args );
-    }
-
     @Override
     public String getCommandName() {
         return "rgdDownload";

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/RgdDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/RgdDatabaseImporterCli.java
@@ -38,19 +38,14 @@ public class RgdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     // name of the external database
     private static final String RGD = "RGD";
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
-    public RgdDatabaseImporterCli() throws Exception {
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
+    public RgdDatabaseImporterCli() {
         super();
     }
 
-    public static void main( String[] args ) throws Exception {
-
+    public static int main( String[] args ) {
         RgdDatabaseImporterCli importEvidence = new RgdDatabaseImporterCli();
-        Exception e = importEvidence.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
-
+        return executeCommand( importEvidence, args );
     }
 
     @Override
@@ -69,12 +64,10 @@ public class RgdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
         // this gets the context, so we can access beans
-        Exception e1 = super.processCommandLine( args );
-        if ( e1 != null ) return e1;
-        e1 = super.init();
-        if ( e1 != null ) return e1;
+        super.processCommandLine( args );
+        super.init();
 
         try {
             // creates the folder where to place the file web downloaded files and final output files
@@ -98,8 +91,6 @@ public class RgdDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbst
         } catch ( Exception e ) {
             e.printStackTrace();
         }
-
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/SfariDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/SfariDatabaseImporterCli.java
@@ -34,7 +34,7 @@ import org.apache.commons.lang.StringUtils;
 public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAbstractCLI {
 
     /**
-     * 
+     *
      */
     private static final String AUTISM_SPECTRUM_DISORDER_DOID = "http://purl.obolibrary.org/obo/DOID_0060041";
     // name of the external database
@@ -67,20 +67,15 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
     private File autismGeneDataset = null;
     private File geneScore = null;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
-    public SfariDatabaseImporterCli() throws Exception {
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
+    public SfariDatabaseImporterCli() {
         super();
     }
 
-    public static void main( String[] args ) throws Exception {
+    public static int main( String[] args ) {
         @SuppressWarnings("unused")
         SfariDatabaseImporterCli importEvidence = new SfariDatabaseImporterCli();
-        Exception e = importEvidence.doWork( args );
-        if ( e != null ) {
-            e.printStackTrace();
-        }
-        /*  */
-
+        return executeCommand( importEvidence, args );
     }
 
     @Override
@@ -100,23 +95,15 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
-        Exception e1 = super.processCommandLine( args );
-        if ( e1 != null ) return e1;
-        e1 = super.init();
-        if ( e1 != null ) return e1;
+    protected void doWork( String[] args ) throws Exception {
+        super.processCommandLine( args );
+        super.init();
 
-        try {
-            writeFolder = ppUtil.createWriteFolderIfDoesntExist( SFARI );
+        writeFolder = ppUtil.createWriteFolderIfDoesntExist( SFARI );
 
-            this.checkForSfariFiles();
-            this.processSfariScoreFile();
-            this.processSfariGeneFile();
-        } catch ( Exception e ) {
-            e.printStackTrace();
-        }
-
-        return null;
+        this.checkForSfariFiles();
+        this.processSfariScoreFile();
+        this.processSfariGeneFile();
     }
 
     @Override
@@ -132,9 +119,9 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
 
     /**
      * Parse pubmed IDs
-     * 
-     * @param  linePubmedIds
-     * @param  mySet
+     *
+     * @param linePubmedIds
+     * @param mySet
      * @throws Exception
      */
     private void addAllPubmed( String linePubmedIds, Set<String> mySet ) throws NumberFormatException {
@@ -163,7 +150,6 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
     }
 
     /**
-     * 
      * @throws Exception
      */
     private void checkForSfariFiles() throws Exception {
@@ -191,14 +177,14 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
 
     /**
      * Parse the 'gene-summary.csv' file
-     * 
+     *
      * @throws Exception
      */
     private void processSfariGeneFile() throws Exception {
 
         ppUtil.initFinalOutputFile( "SFARI", writeFolder, true, true );
 
-        try (BufferedReader brAutismGeneDataset = new BufferedReader( new FileReader( autismGeneDataset ) )) {
+        try ( BufferedReader brAutismGeneDataset = new BufferedReader( new FileReader( autismGeneDataset ) ) ) {
 
             String[] headersTokens = StringUtil.csvSplit( brAutismGeneDataset.readLine() );
 
@@ -209,21 +195,21 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
             if ( !headersSet.contains( SfariDatabaseImporterCli.GENE_SYMBOL_HEADER ) || !headersSet
                     .contains( SfariDatabaseImporterCli.ENTREZ_GENE_ID_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.SUPPORT_FOR_AUTISM_HEADER )
+                    .contains( SfariDatabaseImporterCli.SUPPORT_FOR_AUTISM_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.EVIDENCE_OF_SUPPORT_HEADER )
+                    .contains( SfariDatabaseImporterCli.EVIDENCE_OF_SUPPORT_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.POSITIVE_REFERENCE_HEADER )
+                    .contains( SfariDatabaseImporterCli.POSITIVE_REFERENCE_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.NEGATIVE_REFERENCE_HEADER )
+                    .contains( SfariDatabaseImporterCli.NEGATIVE_REFERENCE_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.PRIMARY_REFERENCE_HEADER )
+                    .contains( SfariDatabaseImporterCli.PRIMARY_REFERENCE_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.MOST_CITED_HEADER )
+                    .contains( SfariDatabaseImporterCli.MOST_CITED_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.MOST_RECENT_HEADER )
+                    .contains( SfariDatabaseImporterCli.MOST_RECENT_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.SUPPORTING_HEADER ) ) {
+                    .contains( SfariDatabaseImporterCli.SUPPORTING_HEADER ) ) {
                 throw new Exception( "Some headers not find in the autism gene dataset" );
             }
 
@@ -298,12 +284,12 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
 
     /**
      * Parse the gene-score.csv file
-     * 
+     *
      * @throws Exception
      */
     private void processSfariScoreFile() throws Exception {
 
-        try (BufferedReader brGeneScore = new BufferedReader( new FileReader( geneScore ) )) {
+        try ( BufferedReader brGeneScore = new BufferedReader( new FileReader( geneScore ) ) ) {
 
             // read headers
             String[] headersTokens = StringUtil.csvSplit( brGeneScore.readLine() );
@@ -317,9 +303,9 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
             if ( !headersSet.contains( SfariDatabaseImporterCli.GENE_SYMBOL_SCORE_HEADER ) || !headersSet
                     .contains( SfariDatabaseImporterCli.SCORE_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.SCORE_DETAILS_HEADER )
+                    .contains( SfariDatabaseImporterCli.SCORE_DETAILS_HEADER )
                     || !headersSet
-                            .contains( SfariDatabaseImporterCli.DESCRIPTION_SCORE_HEADER ) ) {
+                    .contains( SfariDatabaseImporterCli.DESCRIPTION_SCORE_HEADER ) ) {
                 throw new Exception( "Some headers not find" );
             }
 
@@ -400,7 +386,7 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
     //    }
 
     private void writeFinalSfari( Set<String> literaturePubMed, String geneSymbol, String nbciID, String description,
-            String descriptionInScore, ScoreValueObject scoreVO, boolean isNegative ) throws IOException {
+                                  String descriptionInScore, ScoreValueObject scoreVO, boolean isNegative ) throws IOException {
 
         String negative = "";
         if ( isNegative ) {
@@ -411,7 +397,7 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
          * there were special instructions about editing this file afterwards
          * "Also, change the columns in the generated finalResults.tsv file to ensure that "autism spectrum disorder"
          * is in the "OrginalPhenotype" [sp] column, and the phenotype URI is in the "Phenotypes" column."
-         * 
+         *
          * This code does not fill that in, but why not?
          */
         ppUtil.outFinalResults.write( geneSymbol + "\t" );
@@ -434,8 +420,8 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
     /**
      * Format score information as required for downstream processing. Expected fields are ScoreType\tScore\tStrength
      * (see {@link PhenotypeProcessingUtil} initFinalOutputFile.
-     * 
-     * @param  scoreVO
+     *
+     * @param scoreVO
      * @throws IOException
      */
     private void writeScore( ScoreValueObject scoreVO ) throws IOException {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/SfariDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/SfariDatabaseImporterCli.java
@@ -95,8 +95,7 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        super.processCommandLine( args );
+    protected void doWork() throws Exception {
         super.init();
 
         writeFolder = ppUtil.createWriteFolderIfDoesntExist( SFARI );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/SfariDatabaseImporterCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/association/phenotype/SfariDatabaseImporterCli.java
@@ -72,12 +72,6 @@ public class SfariDatabaseImporterCli extends ExternalDatabaseEvidenceImporterAb
         super();
     }
 
-    public static int main( String[] args ) {
-        @SuppressWarnings("unused")
-        SfariDatabaseImporterCli importEvidence = new SfariDatabaseImporterCli();
-        return executeCommand( importEvidence, args );
-    }
-
     @Override
     public String getCommandName() {
         return "sfariDownload";

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcher.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcher.java
@@ -60,28 +60,18 @@ public class PubMedSearcher extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected Exception doWork( String[] args ) {
+    protected void doWork( String[] args ) throws Exception {
+        this.processCommandLine( args );
 
-        Exception err = this.processCommandLine( args );
+        @SuppressWarnings("unchecked")
+        Collection<BibliographicReference> refs = PubMedSearcher.pms
+                .searchAndRetrieveByHTTP( ( Collection<String> ) this.getArgList() );
 
-        if ( err != null )
-            return err;
+        System.out.println( refs.size() + " references found" );
 
-        try {
-            @SuppressWarnings("unchecked")
-            Collection<BibliographicReference> refs = PubMedSearcher.pms
-                    .searchAndRetrieveByHTTP( ( Collection<String> ) this.getArgList() );
-
-            System.out.println( refs.size() + " references found" );
-
-            if ( this.hasOption( "d" ) ) {
-                this.getPersisterHelper().persist( refs );
-            }
-
-        } catch ( IOException | ParserConfigurationException | SAXException e ) {
-            return e;
+        if ( this.hasOption( "d" ) ) {
+            this.getPersisterHelper().persist( refs );
         }
-        return null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcher.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcher.java
@@ -18,13 +18,10 @@
  */
 package ubic.gemma.core.loader.entrez.pubmed;
 
-import org.xml.sax.SAXException;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.util.AbstractCLIContextCLI;
 import ubic.gemma.model.common.description.BibliographicReference;
 
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -60,9 +57,7 @@ public class PubMedSearcher extends AbstractCLIContextCLI {
     }
 
     @Override
-    protected void doWork( String[] args ) throws Exception {
-        this.processCommandLine( args );
-
+    protected void doWork() throws Exception {
         @SuppressWarnings("unchecked")
         Collection<BibliographicReference> refs = PubMedSearcher.pms
                 .searchAndRetrieveByHTTP( ( Collection<String> ) this.getArgList() );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcher.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcher.java
@@ -36,11 +36,6 @@ public class PubMedSearcher extends AbstractCLIContextCLI {
         super();
     }
 
-    public static void main( String[] args ) {
-        PubMedSearcher p = new PubMedSearcher();
-        executeCommand( p, args );
-    }
-
     @Override
     public CommandGroup getCommandGroup() {
         return CommandGroup.MISC;

--- a/gemma-core/src/main/java/ubic/gemma/core/util/AbstractCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/AbstractCLI.java
@@ -141,6 +141,13 @@ public abstract class AbstractCLI {
             buildOptions();
             buildStandardOptions();
             processCommandLine( args );
+            // check if -h/--help is provided before pursuing option processing
+            if ( commandLine.hasOption( 'h' ) ) {
+                printHelp();
+                return SUCCESS;
+            }
+            processStandardOptions();
+            processOptions();
             doWork();
             return errorObjects.isEmpty() ? SUCCESS : FAILURE_FROM_ERROR_OBJECTS;
         } catch ( Exception e ) {
@@ -524,15 +531,6 @@ public abstract class AbstractCLI {
 
             throw e;
         }
-
-        /* INTERROGATION STAGE */
-        if ( commandLine.hasOption( 'h' ) ) {
-            this.printHelp();
-            throw new Exception( "Help selected" );
-        }
-
-        this.processStandardOptions();
-        this.processOptions();
     }
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/core/util/AbstractCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/AbstractCLI.java
@@ -132,7 +132,8 @@ public abstract class AbstractCLI {
         StopWatch watch = new StopWatch();
         watch.start();
         try {
-            p.doWork( args );
+            p.processCommandLine( args );
+            p.doWork();
             return p.errorObjects.isEmpty() ? SUCCESS : FAILURE_FROM_ERROR_OBJECTS;
         } catch ( Exception e ) {
             log.error( e, e );
@@ -397,11 +398,9 @@ public abstract class AbstractCLI {
     }
 
     /**
-     * @param args
-     * @return exit code for the command, {@link ExitCode.FAILURE} is used if an exception is raised
      * @throws Exception
      */
-    protected abstract void doWork( String[] args ) throws Exception;
+    protected abstract void doWork() throws Exception;
 
     protected final double getDoubleOptionValue( char option ) {
         try {
@@ -486,7 +485,7 @@ public abstract class AbstractCLI {
      * @param args args
      * @return Exception; null if nothing went wrong.
      */
-    protected final void processCommandLine( String[] args ) throws Exception {
+    private final void processCommandLine( String[] args ) throws Exception {
         /* COMMAND LINE PARSER STAGE */
         DefaultParser parser = new DefaultParser();
         String appVersion = Settings.getAppVersion();

--- a/gemma-core/src/main/java/ubic/gemma/core/util/AbstractCLIContextCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/AbstractCLIContextCLI.java
@@ -41,42 +41,15 @@ import java.util.List;
 public abstract class AbstractCLIContextCLI extends AbstractSpringAwareCLI {
 
     /**
-     * Run a command. If
-     * 
-     * @param p    command line object
-     * @param args arguments
-     */
-    protected static void executeCommand( AbstractCLIContextCLI p, String[] args ) {
-        StopWatch watch = new StopWatch();
-        watch.start();
-        try {
-            Exception ex = p.doWork( args );
-            resetLogging();
-
-            if ( ex != null ) {
-                log.error( ex, ex );
-                exitwithError();
-            } else {
-                System.exit( 0 );
-            }
-            watch.stop();
-            AbstractCLI.log.info( "Elapsed time: " + watch.getTime() / 1000 + " seconds" );
-        } catch ( Exception e ) {
-            throw new RuntimeException( e );
-        }
-
-    }
-
-    /**
      * may be tab-delimited, only first column used, commented (#) lines are ignored.
      *
-     * @param  fileName    the file name
-     * @return             list of ee identifiers
+     * @param fileName the file name
+     * @return list of ee identifiers
      * @throws IOException in case there is an IO error while reading the file
      */
     protected static List<String> readListFileToStrings( String fileName ) throws IOException {
         List<String> eeNames = new ArrayList<>();
-        try (BufferedReader in = new BufferedReader( new FileReader( fileName ) )) {
+        try ( BufferedReader in = new BufferedReader( new FileReader( fileName ) ) ) {
             while ( in.ready() ) {
                 String line = in.readLine().trim();
                 if ( line.startsWith( "#" ) ) {
@@ -92,7 +65,6 @@ public abstract class AbstractCLIContextCLI extends AbstractSpringAwareCLI {
     }
 
     /**
-     * 
      * @return the command group for this CLI
      */
     public abstract CommandGroup getCommandGroup();
@@ -129,14 +101,13 @@ public abstract class AbstractCLIContextCLI extends AbstractSpringAwareCLI {
 
         if ( arrayDesign == null ) {
             AbstractCLI.log.error( "No arrayDesign " + name + " found" );
-            exitwithError();
         }
         return arrayDesign;
     }
 
     @Override
     protected String[] getAdditionalSpringConfigLocations() {
-        return new String[] { "classpath*:ubic/gemma/cliContext-component-scan.xml" };
+        return new String[]{"classpath*:ubic/gemma/cliContext-component-scan.xml"};
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/util/AbstractSpringAwareCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/AbstractSpringAwareCLI.java
@@ -83,8 +83,7 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
 
     /**
      * Override this method in your subclass to provide additional Spring configuration files that will be merged with
-     * the Gemma spring context. See SpringContextUtil; an example path is
-     * "classpath*:/myproject/applicationContext-mine.xml".
+     * the Gemma spring context. See SpringContextUtil; an example path is "classpath*:/myproject/applicationContext-mine.xml".
      *
      * @return string[]
      */
@@ -141,7 +140,7 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
                 if ( skipIfLastRunLaterThan != null ) {
                     if ( event.getDate().after( skipIfLastRunLaterThan ) ) {
                         AbstractCLI.log.info( auditable + ": " + " run more recently than " + skipIfLastRunLaterThan );
-                        errorObjects.add( auditable + ": " + " run more recently than " + skipIfLastRunLaterThan );
+                        addErrorObject( auditable, "Run more recently than " + skipIfLastRunLaterThan );
                         needToRun = false;
                     }
                 } else {
@@ -169,8 +168,7 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
             }
 
             if ( !okToRun ) {
-                AbstractCLI.log.info( auditable + ": has an active 'trouble' flag" );
-                errorObjects.add( auditable + ": has an active 'trouble' flag" );
+                addErrorObject( auditable, "Has an active 'trouble' flag" );
             }
         }
 
@@ -207,21 +205,18 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
             password = this.getOptionValue( 'p' );
 
             if ( StringUtils.isBlank( username ) ) {
-                System.err.println( "Not authenticated. Username was blank" );
                 AbstractCLI.log.debug( "Username=" + username );
-                exitwithError();
+                throw new RuntimeException( "Not authenticated. Username was blank" );
             }
 
             if ( StringUtils.isBlank( password ) ) {
-                System.err.println( "Not authenticated. You didn't enter a password" );
-                exitwithError();
+                throw new RuntimeException( "Not authenticated. You didn't enter a password" );
             }
 
             boolean success = manAuthentication.validateRequest( username, password );
             if ( !success ) {
-                System.err.println( "Not authenticated. Make sure you entered a valid username (got '" + username
+                throw new RuntimeException( "Not authenticated. Make sure you entered a valid username (got '" + username
                         + "') and/or password" );
-                exitwithError();
             } else {
                 AbstractCLI.log.info( "Logged in as " + username );
             }

--- a/gemma-core/src/main/java/ubic/gemma/core/util/AbstractSpringAwareCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/AbstractSpringAwareCLI.java
@@ -49,7 +49,7 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
     protected AuditEventService auditEventService;
     protected BeanFactory ctx;
 
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+    @SuppressWarnings({"unused", "WeakerAccess"}) // Possible external use
     public AbstractSpringAwareCLI() {
         super();
     }
@@ -95,10 +95,10 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
     /**
      * Convenience method to obtain instance of any bean by name.
      *
-     * @param  <T>  the bean class type
-     * @param  clz  class
-     * @param  name name
-     * @return      bean
+     * @param <T>  the bean class type
+     * @param clz  class
+     * @param name name
+     * @return bean
      */
     @SuppressWarnings("SameParameterValue") // Better for general use
     protected <T> T getBean( String name, Class<T> clz ) {
@@ -117,9 +117,9 @@ public abstract class AbstractSpringAwareCLI extends AbstractCLI {
     }
 
     /**
-     * @param  auditable  auditable
-     * @param  eventClass can be null
-     * @return            boolean
+     * @param auditable  auditable
+     * @param eventClass can be null
+     * @return boolean
      */
     protected boolean noNeedToRun( Auditable auditable, Class<? extends AuditEventType> eventClass ) {
         boolean needToRun = true;

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcherIntegrationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcherIntegrationTest.java
@@ -41,7 +41,7 @@ public class PubMedSearcherIntegrationTest {
     @Test
     public final void testMain() {
 
-        Exception result = p.doWork( new String[] { "-testing", "-v", "3", "hippocampus", "diazepam", "juvenile" } );
+        int result = p.doWork( new String[] { "-testing", "-v", "3", "hippocampus", "diazepam", "juvenile" } );
         if ( result != null ) {
             if ( result instanceof java.net.UnknownHostException ) {
                 PubMedSearcherIntegrationTest.log.warn( "Test skipped because of UnknownHostException" );

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcherIntegrationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcherIntegrationTest.java
@@ -41,7 +41,7 @@ public class PubMedSearcherIntegrationTest {
     @Test
     public final void testMain() {
         try {
-            p.doWork();
+            p.executeCommand( new String[]{"-testing", "-v", "3", "hippocampus", "diazepam", "juvenile"} );
         } catch ( Exception e ) {
             assumeFalse( "Test skipped because of UnknownHostException", e instanceof java.net.UnknownHostException );
             assumeFalse( "Test skipped because of a 502 from NCBI", e.getMessage().contains( "code: 503" ) );

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcherIntegrationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearcherIntegrationTest.java
@@ -23,12 +23,12 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Tests command line. This creates an entire new Spring Context so is pretty heavy.
  *
  * @author pavlidis
- *
  */
 public class PubMedSearcherIntegrationTest {
 
@@ -40,19 +40,13 @@ public class PubMedSearcherIntegrationTest {
      */
     @Test
     public final void testMain() {
-
-        int result = p.doWork( new String[] { "-testing", "-v", "3", "hippocampus", "diazepam", "juvenile" } );
-        if ( result != null ) {
-            if ( result instanceof java.net.UnknownHostException ) {
-                PubMedSearcherIntegrationTest.log.warn( "Test skipped because of UnknownHostException" );
-                return;
-            } else if ( result.getMessage().contains( "code: 503" ) ) {
-                PubMedSearcherIntegrationTest.log.warn( "Test skipped because of a 502 from NCBI" );
-                return;
-            }
-            fail( result.getMessage() );
+        try {
+            p.doWork();
+        } catch ( Exception e ) {
+            assumeFalse( "Test skipped because of UnknownHostException", e instanceof java.net.UnknownHostException );
+            assumeFalse( "Test skipped because of a 502 from NCBI", e.getMessage().contains( "code: 503" ) );
+            fail( e.getMessage() );
         }
-
     }
 
 }


### PR DESCRIPTION
 - use return value for main() instead of System.exit(), ensuring that we always explicitly return an exit code
 - fix multiple cases where exit codes does not propagate to the output of GemmaCLI main metohd
 - call buildOptions, buildStandardOptions and processCommandLine inside executeCommand
 - simplify doWork to focuse solely on doing the command work systematically calling processCommandLine in executeCommand
 - call executeCommand directly from GemmaCLI instead of the main() and return its value as exit code
 - make doWork raise exception instead of returning them, simplifying many cases where the exception would be captured and then returned
 - deprecate exitwithError and make it simply raise a RuntimeException which will be caught by executeCommand and result in an exit code
 - check for errorObjects in executeCommand and handle those batch-style exceptions with a different exit code (e.g. 2)