### PR TITLE
Web API extensions for querying AnalysisResultSet and additional filters for DE and EE

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/util/test/BaseSpringContextTest.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/test/BaseSpringContextTest.java
@@ -43,6 +43,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.springframework.test.jdbc.JdbcTestUtils;
+import ubic.gemma.model.analysis.Analysis;
 import ubic.gemma.model.association.BioSequence2GeneProduct;
 import ubic.gemma.model.common.auditAndSecurity.Contact;
 import ubic.gemma.model.common.description.BibliographicReference;
@@ -181,8 +182,14 @@ public abstract class BaseSpringContextTest extends AbstractJUnit4SpringContextT
         this.taxonService = taxonService;
     }
 
-    protected void addTestAnalyses( ExpressionExperiment ee ) {
-        testHelper.addTestAnalyses( ee );
+    /**
+     * Create test {@link Analysis} for the given expression experiment.
+     *
+     * @param ee expression experiment to use for creating test analyses
+     * @return a collection of persisted analyses that were created
+     */
+    protected Collection<Analysis> addTestAnalyses( ExpressionExperiment ee ) {
+        return testHelper.addTestAnalyses( ee );
     }
 
     /**
@@ -490,7 +497,6 @@ public abstract class BaseSpringContextTest extends AbstractJUnit4SpringContextT
         return testHelper.getTestPersistentExpressionExperiment();
     }
 
-   
 
     /**
      * Convenience method to provide an ExpressionExperiment that can be used to fill non-nullable associations in test

--- a/gemma-core/src/main/java/ubic/gemma/core/util/test/PersistentDummyObjectHelper.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/test/PersistentDummyObjectHelper.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import ubic.basecode.io.ByteArrayConverter;
+import ubic.gemma.model.analysis.Analysis;
 import ubic.gemma.model.analysis.expression.coexpression.CoexpressionAnalysis;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
 import ubic.gemma.model.association.BioSequence2GeneProduct;
@@ -159,7 +160,8 @@ public class PersistentDummyObjectHelper {
         return t;
     }
 
-    public void addTestAnalyses( ExpressionExperiment ee ) {
+    public Collection<Analysis> addTestAnalyses( ExpressionExperiment ee ) {
+        Collection<Analysis> analyses = new ArrayList<>();
         /*
          * Add analyses
          */
@@ -168,7 +170,7 @@ public class PersistentDummyObjectHelper {
 
         pca.setExperimentAnalyzed( ee );
 
-        persisterHelper.persist( pca );
+        analyses.add( ( Analysis ) persisterHelper.persist( pca ) );
 
         /*
          * Diff
@@ -180,12 +182,14 @@ public class PersistentDummyObjectHelper {
         expressionAnalysis.setProtocol( protocol );
         expressionAnalysis.setExperimentAnalyzed( ee );
 
-        persisterHelper.persist( expressionAnalysis );
+        analyses.add( ( Analysis ) persisterHelper.persist( expressionAnalysis ) );
+
+        return analyses;
     }
 
     /**
      * @param  allFactorValues all factor values
-     * @return                 Non-persistent ED
+     * @return Non-persistent ED
      */
     public ExperimentalDesign getExperimentalDesign( Collection<FactorValue> allFactorValues ) {
         ExperimentalDesign ed = ExperimentalDesign.Factory.newInstance();
@@ -278,7 +282,7 @@ public class PersistentDummyObjectHelper {
      * Add an expressionExperiment to the database for testing purposes. Includes associations
      *
      * @param  doSequence Should the array design get all the sequence information filled in? (true = slower)
-     * @return            EE
+     * @return EE
      */
     public ExpressionExperiment getTestExpressionExperimentWithAllDependencies( boolean doSequence ) {
 
@@ -366,7 +370,7 @@ public class PersistentDummyObjectHelper {
      *                               0_probe_at....N_probe_at
      * @param  doSequence            If true, biosequences and biosequence2GeneProduct associations are filled in
      *                               (slower).
-     * @return                       ArrayDesign
+     * @return ArrayDesign
      */
     public ArrayDesign getTestPersistentArrayDesign( int numCompositeSequences, boolean randomNames,
             boolean doSequence ) {
@@ -417,7 +421,7 @@ public class PersistentDummyObjectHelper {
 
     /**
      * @param  arrayDesign AD
-     * @return             A lighter-weight EE, with no data, and the ADs have no sequences.
+     * @return A lighter-weight EE, with no data, and the ADs have no sequences.
      */
     public ExpressionExperiment getTestPersistentBasicExpressionExperiment( ArrayDesign arrayDesign ) {
         ExpressionExperiment ee = ExpressionExperiment.Factory.newInstance();
@@ -479,7 +483,7 @@ public class PersistentDummyObjectHelper {
      *
      * @param  ad AD
      * @param  bm BM
-     * @return    BA
+     * @return BA
      */
     public BioAssay getTestPersistentBioAssay( ArrayDesign ad, BioMaterial bm ) {
         if ( ad == null || bm == null ) {
@@ -513,7 +517,7 @@ public class PersistentDummyObjectHelper {
 
     /**
      * @param  bioSequence bio sequence
-     * @return             bio sequence to gene products
+     * @return bio sequence to gene products
      */
     @SuppressWarnings("unchecked")
     public Collection<BioSequence2GeneProduct> getTestPersistentBioSequence2GeneProducts( BioSequence bioSequence ) {
@@ -574,7 +578,7 @@ public class PersistentDummyObjectHelper {
      * The accession is set to a random string
      *
      * @param  ed ED
-     * @return    db entry
+     * @return db entry
      */
     public DatabaseEntry getTestPersistentDatabaseEntry( ExternalDatabase ed ) {
         return this.getTestPersistentDatabaseEntry(
@@ -587,7 +591,7 @@ public class PersistentDummyObjectHelper {
      *
      * @param  ed        ED
      * @param  accession accession
-     * @return           db entry
+     * @return db entry
      */
     public DatabaseEntry getTestPersistentDatabaseEntry( String accession, ExternalDatabase ed ) {
         DatabaseEntry result = DatabaseEntry.Factory.newInstance();
@@ -613,7 +617,7 @@ public class PersistentDummyObjectHelper {
     /**
      * @param  databaseName GEO or PubMed (others could be supported)
      * @param  accession    accession
-     * @return              db entry
+     * @return db entry
      */
     public DatabaseEntry getTestPersistentDatabaseEntry( String accession, String databaseName ) {
         switch ( databaseName ) {
@@ -649,7 +653,7 @@ public class PersistentDummyObjectHelper {
      * persistent BioMaterials and BioAssays so that database taxon lookups for this experiment will work.
      *
      * @param  taxon the experiment will have this taxon
-     * @return       EE
+     * @return EE
      */
     public ExpressionExperiment getTestPersistentExpressionExperiment( Taxon taxon ) {
         BioAssay ba;
@@ -820,7 +824,7 @@ public class PersistentDummyObjectHelper {
      * @param  ad                AD
      * @param  ee                EE
      * @param  quantitationTypes QTs
-     * @return                   These are non-persistent
+     * @return These are non-persistent
      */
     private Collection<RawExpressionDataVector> getDesignElementDataVectors( ExpressionExperiment ee,
             Collection<QuantitationType> quantitationTypes, List<BioAssay> bioAssays, ArrayDesign ad ) {

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResult.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResult.java
@@ -1,0 +1,10 @@
+package ubic.gemma.model.analysis;
+
+import ubic.gemma.model.common.Identifiable;
+
+/**
+ * Abstract class representing a single result from an {@link Analysis} and a typical part of an {@link AnalysisResultSet}.
+ */
+public abstract class AnalysisResult implements Identifiable {
+
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultSet.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 /**
  * An abstract class representing a related set of generic analysis results, part of an analysis.
  */
-public abstract class AnalysisResultSet implements Identifiable, Serializable {
+public abstract class AnalysisResultSet<R extends AnalysisResult> implements Identifiable, Serializable {
 
     /**
      * The serial version UID of this class. Needed for serialization.
@@ -83,6 +83,6 @@ public abstract class AnalysisResultSet implements Identifiable, Serializable {
 
     @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
     @Transient
-    public abstract Collection<?> getResults();
+    public abstract Collection<R> getResults();
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultSetValueObject.java
@@ -1,0 +1,38 @@
+/*
+ * The Gemma project
+ *
+ * Copyright (c) 2006 University of British Columbia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package ubic.gemma.model.analysis;
+
+import ubic.gemma.model.IdentifiableValueObject;
+
+import java.util.Collection;
+
+/**
+ * Exposes an {@link AnalysisResultSet} to the public API.
+ *
+ * @param <K> underlying type of analysis result in the set
+ * @param <R> type of analysis result set this is wrapping.
+ */
+public abstract class AnalysisResultSetValueObject<K extends AnalysisResult, R extends AnalysisResultSet<K>> extends IdentifiableValueObject<R> {
+
+    protected AnalysisResultSetValueObject( R analysisResultSet ) {
+        super( analysisResultSet.getId() );
+    }
+
+    public abstract Collection<AnalysisResultValueObject<K>> getAnalysisResults();
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultSetValueObject.java
@@ -34,5 +34,7 @@ public abstract class AnalysisResultSetValueObject<K extends AnalysisResult, R e
         super( analysisResultSet.getId() );
     }
 
+    public abstract AnalysisValueObject getAnalysis();
+
     public abstract Collection<AnalysisResultValueObject<K>> getAnalysisResults();
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisResultValueObject.java
@@ -1,0 +1,33 @@
+/*
+ * The Gemma project
+ *
+ * Copyright (c) 2006 University of British Columbia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package ubic.gemma.model.analysis;
+
+import ubic.gemma.model.IdentifiableValueObject;
+
+/**
+ * Wraps an {@link AnalysisResult} to expose it on the public API.
+ *
+ * @param <A> type of {@link AnalysisResult} being wrapped by this value object
+ */
+public abstract class AnalysisResultValueObject<A extends AnalysisResult> extends IdentifiableValueObject<A> {
+
+    public AnalysisResultValueObject( AnalysisResult analysisResult ) {
+        super( analysisResult.getId() );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/AnalysisValueObject.java
@@ -1,0 +1,10 @@
+package ubic.gemma.model.analysis;
+
+import ubic.gemma.model.IdentifiableValueObject;
+
+public abstract class AnalysisValueObject<T extends Analysis> extends IdentifiableValueObject<T> {
+
+    protected AnalysisValueObject( T analysis ) {
+        super( analysis.getId() );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/FactorAssociatedAnalysisResultSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/FactorAssociatedAnalysisResultSet.java
@@ -18,13 +18,14 @@
  */
 package ubic.gemma.model.analysis.expression;
 
+import ubic.gemma.model.analysis.AnalysisResult;
 import ubic.gemma.model.analysis.AnalysisResultSet;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 
 import java.util.Collection;
 import java.util.HashSet;
 
-public abstract class FactorAssociatedAnalysisResultSet extends AnalysisResultSet {
+public abstract class FactorAssociatedAnalysisResultSet<R extends AnalysisResult> extends AnalysisResultSet<R> {
 
     /**
      * The serial version UID of this class. Needed for serialization.

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResult.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResult.java
@@ -18,7 +18,7 @@
  */
 package ubic.gemma.model.analysis.expression.diff;
 
-import ubic.gemma.model.common.Identifiable;
+import ubic.gemma.model.analysis.AnalysisResult;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 
 import java.io.Serializable;
@@ -31,7 +31,7 @@ import java.util.HashSet;
  * associated contrasts.
  */
 @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
-public class DifferentialExpressionAnalysisResult implements Identifiable, Serializable {
+public class DifferentialExpressionAnalysisResult extends AnalysisResult implements Serializable {
     /**
      * The serial version UID of this class. Needed for serialization.
      */

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResultValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResultValueObject.java
@@ -1,0 +1,43 @@
+/*
+ * The Gemma project
+ *
+ * Copyright (c) 2010 University of British Columbia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package ubic.gemma.model.analysis.expression.diff;
+
+import ubic.gemma.model.IdentifiableValueObject;
+
+public class DifferentialExpressionAnalysisResultValueObject extends IdentifiableValueObject<DifferentialExpressionAnalysisResult> {
+
+    private final Double pValue;
+    private final Double correctedPvalue;
+    private final Double rank;
+
+    public DifferentialExpressionAnalysisResultValueObject( DifferentialExpressionAnalysisResult result ) {
+        super( result.getId() );
+        this.pValue = result.getPvalue();
+        this.correctedPvalue = result.getCorrectedPvalue();
+        this.rank = result.getRank();
+    }
+
+    public Double getPvalue() {
+        return pValue;
+    }
+
+    public Double getCorrectedPvalue() {
+        return correctedPvalue;
+    }
+
+    public Double getRank() {
+        return rank;
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResultValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResultValueObject.java
@@ -14,19 +14,29 @@
  */
 package ubic.gemma.model.analysis.expression.diff;
 
-import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.analysis.AnalysisResultValueObject;
+import ubic.gemma.model.expression.designElement.CompositeSequenceValueObject;
 
-public class DifferentialExpressionAnalysisResultValueObject extends IdentifiableValueObject<DifferentialExpressionAnalysisResult> {
+/**
+ * Unlike {@link DiffExResultSetSummaryValueObject}, this value object is meant for the public API.
+ */
+public class DifferentialExpressionAnalysisResultValueObject extends AnalysisResultValueObject<DifferentialExpressionAnalysisResult> {
 
+    private final CompositeSequenceValueObject probe;
     private final Double pValue;
     private final Double correctedPvalue;
     private final Double rank;
 
     public DifferentialExpressionAnalysisResultValueObject( DifferentialExpressionAnalysisResult result ) {
-        super( result.getId() );
+        super( result );
+        this.probe = new CompositeSequenceValueObject( result.getProbe() );
         this.pValue = result.getPvalue();
         this.correctedPvalue = result.getCorrectedPvalue();
         this.rank = result.getRank();
+    }
+
+    public CompositeSequenceValueObject getProbe() {
+        return probe;
     }
 
     public Double getPvalue() {

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisValueObject.java
@@ -15,6 +15,7 @@
 package ubic.gemma.model.analysis.expression.diff;
 
 import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.analysis.AnalysisValueObject;
 import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
 import ubic.gemma.model.expression.experiment.FactorValueValueObject;
 
@@ -30,7 +31,7 @@ import java.util.Map;
  * @author paul
  */
 @SuppressWarnings("unused") // Used in frontend
-public class DifferentialExpressionAnalysisValueObject extends IdentifiableValueObject<DifferentialExpressionAnalysis>
+public class DifferentialExpressionAnalysisValueObject extends AnalysisValueObject<DifferentialExpressionAnalysis>
         implements Serializable {
 
     public static final double DEFAULT_THRESHOLD = 0.05; // should be one of the values stored in the HitListSizes
@@ -50,7 +51,7 @@ public class DifferentialExpressionAnalysisValueObject extends IdentifiableValue
      * @param analysis the analysis to read the values from
      */
     public DifferentialExpressionAnalysisValueObject( DifferentialExpressionAnalysis analysis ) {
-        this.id = analysis.getId();
+        super( analysis );
         this.bioAssaySetId = analysis.getExperimentAnalyzed().getId();
         if ( analysis.getSubsetFactorValue() != null ) {
             this.subsetFactorValue = new FactorValueValueObject( analysis.getSubsetFactorValue() );

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSet.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 /**
  * A group of results for an ExpressionExperiment.
  */
-public class ExpressionAnalysisResultSet extends FactorAssociatedAnalysisResultSet {
+public class ExpressionAnalysisResultSet extends FactorAssociatedAnalysisResultSet<DifferentialExpressionAnalysisResult> {
 
     private static final long serialVersionUID = 7226901182513177574L;
     private Integer numberOfProbesTested;

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSetValueObject.java
@@ -1,0 +1,28 @@
+package ubic.gemma.model.analysis.expression.diff;
+
+import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
+import ubic.gemma.model.analysis.AnalysisResultValueObject;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Wraps an {@link ExpressionAnalysisResultSet} and expose it to the public API.
+ */
+public class ExpressionAnalysisResultSetValueObject extends AnalysisResultSetValueObject<DifferentialExpressionAnalysisResult, ExpressionAnalysisResultSet> {
+
+    // FIXME: use Collection<DifferentialExpressionAnalysisResultValueObject>
+    private final Collection analysisResults;
+
+    public ExpressionAnalysisResultSetValueObject( ExpressionAnalysisResultSet analysisResultSet ) {
+        super( analysisResultSet );
+        this.analysisResults = analysisResultSet.getResults()
+                .stream().map( DifferentialExpressionAnalysisResultValueObject::new )
+                .collect( Collectors.toList() );
+    }
+
+    @Override
+    public Collection<AnalysisResultValueObject<DifferentialExpressionAnalysisResult>> getAnalysisResults() {
+        return this.analysisResults;
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSetValueObject.java
@@ -2,6 +2,7 @@ package ubic.gemma.model.analysis.expression.diff;
 
 import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
 import ubic.gemma.model.analysis.AnalysisResultValueObject;
+import ubic.gemma.model.analysis.AnalysisValueObject;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -11,18 +12,25 @@ import java.util.stream.Collectors;
  */
 public class ExpressionAnalysisResultSetValueObject extends AnalysisResultSetValueObject<DifferentialExpressionAnalysisResult, ExpressionAnalysisResultSet> {
 
-    // FIXME: use Collection<DifferentialExpressionAnalysisResultValueObject>
-    private final Collection analysisResults;
+    private final DifferentialExpressionAnalysisValueObject analysis;
+
+    private final Collection<AnalysisResultValueObject<DifferentialExpressionAnalysisResult>> analysisResults;
 
     public ExpressionAnalysisResultSetValueObject( ExpressionAnalysisResultSet analysisResultSet ) {
         super( analysisResultSet );
+        this.analysis = new DifferentialExpressionAnalysisValueObject( analysisResultSet.getAnalysis() );
         this.analysisResults = analysisResultSet.getResults()
                 .stream().map( DifferentialExpressionAnalysisResultValueObject::new )
                 .collect( Collectors.toList() );
     }
 
     @Override
+    public AnalysisValueObject getAnalysis() {
+        return analysis;
+    }
+
+    @Override
     public Collection<AnalysisResultValueObject<DifferentialExpressionAnalysisResult>> getAnalysisResults() {
-        return this.analysisResults;
+        return analysisResults;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/BioAssaySet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/BioAssaySet.java
@@ -20,6 +20,7 @@
 package ubic.gemma.model.expression.experiment;
 
 import ubic.gemma.model.analysis.Investigation;
+import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
 
 import java.util.Collection;
@@ -33,8 +34,16 @@ import java.util.HashSet;
 public abstract class BioAssaySet extends Investigation {
 
     private static final long serialVersionUID = 2368063046639481521L;
+    private DatabaseEntry accession;
+    protected Collection<BioAssay> bioAssays = new HashSet<>();
 
-    Collection<BioAssay> bioAssays = new HashSet<>();
+    public DatabaseEntry getAccession() {
+        return this.accession;
+    }
+
+    public void setAccession( DatabaseEntry accession ) {
+        this.accession = accession;
+    }
 
     @SuppressWarnings("JpaAttributeTypeInspection") // Inspector is not handling this correctly
     public abstract Collection<BioAssay> getBioAssays();

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperiment.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperiment.java
@@ -42,7 +42,6 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
     }
 
     private static final long serialVersionUID = -1342753625018841735L;
-    private DatabaseEntry accession;
     private String batchConfound;
     private String batchEffect;
     private CurationDetails curationDetails;
@@ -100,10 +99,6 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
             return this.getShortName().equals( that.getShortName() );
         }
         return false;
-    }
-
-    public DatabaseEntry getAccession() {
-        return this.accession;
     }
 
     public String getBatchConfound() {
@@ -190,10 +185,6 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
             return this.getShortName().hashCode();
         }
         return result;
-    }
-
-    public void setAccession( DatabaseEntry accession ) {
-        this.accession = accession;
     }
 
     public void setBatchConfound( String batchConfound ) { // FIXME don't use a string for this

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
@@ -57,7 +57,7 @@ public interface BaseService<O extends Identifiable> {
      * Loads object with given id.
      *
      * @param id the id of entity to be loaded.
-     * @return the entity with matching id.
+     * @return the entity with matching id, or null if the entity does not exist.
      */
     O load( Long id );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisResultSetDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisResultSetDao.java
@@ -1,0 +1,15 @@
+package ubic.gemma.persistence.service.analysis;
+
+import ubic.gemma.model.analysis.AnalysisResult;
+import ubic.gemma.model.analysis.AnalysisResultSet;
+import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
+import ubic.gemma.persistence.service.BaseVoEnabledDao;
+
+/**
+ * Generic DAO for manipulating {@link AnalysisResultSet}.
+ *
+ * @param <O>
+ * @param <VO>
+ */
+public interface AnalysisResultSetDao<K extends AnalysisResult, O extends AnalysisResultSet<K>, VO extends AnalysisResultSetValueObject<K, O>> extends BaseVoEnabledDao<O, VO> {
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisResultSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisResultSetService.java
@@ -1,0 +1,16 @@
+package ubic.gemma.persistence.service.analysis;
+
+import ubic.gemma.model.analysis.AnalysisResult;
+import ubic.gemma.model.analysis.AnalysisResultSet;
+import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
+import ubic.gemma.persistence.service.BaseVoEnabledService;
+
+/**
+ * Interface for services providing {@link AnalysisResultSet}.
+ *
+ * @param <O> the type of result set
+ * @param <V> a value object type to expose result sets
+ */
+public interface AnalysisResultSetService<K extends AnalysisResult, O extends AnalysisResultSet<K>, V extends AnalysisResultSetValueObject<K, O>> extends BaseVoEnabledService<O, V> {
+
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDao.java
@@ -34,7 +34,7 @@ import java.util.Map;
 /**
  * @see DifferentialExpressionAnalysis
  */
-interface DifferentialExpressionAnalysisDao extends AnalysisDao<DifferentialExpressionAnalysis> {
+public interface DifferentialExpressionAnalysisDao extends AnalysisDao<DifferentialExpressionAnalysis> {
 
     /**
      * @param threshold for corrected pvalue. Results may not be accurate for 'unreasonable' thresholds.

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import ubic.gemma.model.analysis.Investigation;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.*;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDao.java
@@ -19,6 +19,7 @@
 package ubic.gemma.persistence.service.analysis.expression.diff;
 
 import ubic.basecode.math.distribution.Histogram;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
@@ -29,6 +29,7 @@ import ubic.basecode.io.ByteArrayConverter;
 import ubic.basecode.math.distribution.Histogram;
 import ubic.basecode.util.BatchIterator;
 import ubic.basecode.util.SQLUtils;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.*;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultService.java
@@ -20,6 +20,7 @@ package ubic.gemma.persistence.service.analysis.expression.diff;
 
 import org.springframework.security.access.annotation.Secured;
 import ubic.basecode.math.distribution.Histogram;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.basecode.math.distribution.Histogram;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDao.java
@@ -25,7 +25,9 @@ import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysisResult;
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+import ubic.gemma.persistence.util.ObjectFilter;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -49,10 +51,13 @@ public interface ExpressionAnalysisResultSetDao extends AnalysisResultSetDao<Dif
     /**
      * Retrieve result sets associated to a set of {@link BioAssaySet} and external database entries.
      *
-     * @param bioAssaySets related {@link BioAssaySet},or any if null
+     * @param bioAssaySets related {@link BioAssaySet}, or any if null
      * @param databaseEntries related external identifier associated to the {@link BioAssaySet}, or any if null
+     * @param objectFilters list of object filters
+     * @param orderBy field by which the collection is sorted
+     * @param isAsc whether the sort should be ascending or descending
      * @param limit maximum number of results to return
      * @return
      */
-    Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> databaseEntries, int limit );
+    Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> databaseEntries, ArrayList<ObjectFilter[]> objectFilters, int offset, int limit, String orderBy, boolean isAsc );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDao.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2007 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,14 +18,20 @@
  */
 package ubic.gemma.persistence.service.analysis.expression.diff;
 
+import ubic.gemma.model.common.description.DatabaseEntry;
+import ubic.gemma.model.expression.experiment.BioAssaySet;
+import ubic.gemma.persistence.service.analysis.AnalysisResultSetDao;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
+import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysisResult;
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
-import ubic.gemma.persistence.service.BaseDao;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+
+import java.util.Collection;
 
 /**
  * @see ExpressionAnalysisResultSet
  */
-public interface ExpressionAnalysisResultSetDao extends BaseDao<ExpressionAnalysisResultSet> {
+public interface ExpressionAnalysisResultSetDao extends AnalysisResultSetDao<DifferentialExpressionAnalysisResult, ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject> {
 
     ExpressionAnalysisResultSet thaw( ExpressionAnalysisResultSet resultSet );
 
@@ -40,4 +46,13 @@ public interface ExpressionAnalysisResultSetDao extends BaseDao<ExpressionAnalys
 
     ExpressionAnalysisResultSet thawWithoutContrasts( ExpressionAnalysisResultSet resultSet );
 
+    /**
+     * Retrieve result sets associated to a set of {@link BioAssaySet} and external database entries.
+     *
+     * @param bioAssaySets related {@link BioAssaySet},or any if null
+     * @param databaseEntries related external identifier associated to the {@link BioAssaySet}, or any if null
+     * @param limit maximum number of results to return
+     * @return
+     */
+    Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> databaseEntries, int limit );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetService.java
@@ -1,0 +1,17 @@
+package ubic.gemma.persistence.service.analysis.expression.diff;
+
+import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysisResult;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+import ubic.gemma.model.common.description.DatabaseEntry;
+import ubic.gemma.model.expression.experiment.BioAssaySet;
+import ubic.gemma.persistence.service.BaseService;
+import ubic.gemma.persistence.service.BaseVoEnabledService;
+import ubic.gemma.persistence.service.analysis.AnalysisResultSetService;
+
+import java.util.Collection;
+
+public interface ExpressionAnalysisResultSetService extends BaseService<ExpressionAnalysisResultSet>, BaseVoEnabledService<ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject>, AnalysisResultSetService<DifferentialExpressionAnalysisResult, ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject> {
+
+    Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> externalIds, int limit );
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetService.java
@@ -8,10 +8,14 @@ import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.persistence.service.BaseService;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 import ubic.gemma.persistence.service.analysis.AnalysisResultSetService;
+import ubic.gemma.persistence.util.ObjectFilter;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 public interface ExpressionAnalysisResultSetService extends BaseService<ExpressionAnalysisResultSet>, BaseVoEnabledService<ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject>, AnalysisResultSetService<DifferentialExpressionAnalysisResult, ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject> {
 
-    Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> externalIds, int limit );
+    ExpressionAnalysisResultSet thaw( ExpressionAnalysisResultSet e );
+
+    Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> externalIds, ArrayList<ObjectFilter[]> objectFilters, int offset, int limit, String field, boolean isAsc );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetServiceImpl.java
@@ -7,7 +7,9 @@ import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValu
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.persistence.service.AbstractVoEnabledService;
+import ubic.gemma.persistence.util.ObjectFilter;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Service
@@ -22,7 +24,17 @@ public class ExpressionAnalysisResultSetServiceImpl extends AbstractVoEnabledSer
     }
 
     @Override
-    public Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> externalIds, int limit ) {
-        return voDao.findByBioAssaySetInAndDatabaseEntryInLimit( bioAssaySets, externalIds, limit );
+    public ExpressionAnalysisResultSet thaw( ExpressionAnalysisResultSet e ) {
+        return voDao.thaw( e );
+    }
+
+    @Override
+    public Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> externalIds, ArrayList<ObjectFilter[]> objectFilters, int offset, int limit, String orderBy, boolean isAsc ) {
+        return voDao.findByBioAssaySetInAndDatabaseEntryInLimit( bioAssaySets, externalIds,
+                objectFilters,
+                offset,
+                limit,
+                orderBy,
+                isAsc );
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetServiceImpl.java
@@ -1,0 +1,28 @@
+package ubic.gemma.persistence.service.analysis.expression.diff;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+import ubic.gemma.model.common.description.DatabaseEntry;
+import ubic.gemma.model.expression.experiment.BioAssaySet;
+import ubic.gemma.persistence.service.AbstractVoEnabledService;
+
+import java.util.Collection;
+
+@Service
+public class ExpressionAnalysisResultSetServiceImpl extends AbstractVoEnabledService<ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject> implements ExpressionAnalysisResultSetService {
+
+    private final ExpressionAnalysisResultSetDao voDao;
+
+    @Autowired
+    public ExpressionAnalysisResultSetServiceImpl( ExpressionAnalysisResultSetDao voDao ) {
+        super( voDao );
+        this.voDao = voDao;
+    }
+
+    @Override
+    public Collection<ExpressionAnalysisResultSet> findByBioAssaySetInAndDatabaseEntryInLimit( Collection<BioAssaySet> bioAssaySets, Collection<DatabaseEntry> externalIds, int limit ) {
+        return voDao.findByBioAssaySetInAndDatabaseEntryInLimit( bioAssaySets, externalIds, limit );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/GeneDiffExMetaAnalysisServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/GeneDiffExMetaAnalysisServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.BaseValueObject;
 import ubic.gemma.model.analysis.Investigation;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.genome.Taxon;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/ObjectFilter.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/ObjectFilter.java
@@ -35,6 +35,8 @@ public class ObjectFilter {
     public static final String DAO_GEEQ_ALIAS = "geeq";
     public static final String DAO_CHARACTERISTIC_ALIAS = "ch";
     public static final String DAO_BIOASSAY_ALIAS = "ba";
+    public static final String DAO_DATABASE_ENTRY_ALIAS = "accession";
+    public static final String DAO_EARS_ALIAS = "ears";
 
     public static final String is = "=";
     public static final String isNot = "!=";

--- a/gemma-core/src/main/resources/ehcache.clustered.xml
+++ b/gemma-core/src/main/resources/ehcache.clustered.xml
@@ -100,16 +100,6 @@
 		</terracotta>
 	</cache>
 
-	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.results"
-		maxElementsOnDisk="10000" maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
-		overflowToDisk="false">
-		<terracotta>
-			<nonstop timeoutMillis="3000">
-				<timeoutBehavior type="noop" />
-			</nonstop>
-		</terracotta>
-	</cache>
-
 	<cache name="ubic.gemma.model.analysis.expression.pca.PrincipalComponentAnalysis.eigenVectors"
 		maxElementsOnDisk="10000" maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
 		overflowToDisk="false">
@@ -132,16 +122,6 @@
 	<cache name="ubic.gemma.model.analysis.expression.pca.PrincipalComponentAnalysis.probeLoadings"
 		maxElementsOnDisk="10000" maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
 		overflowToDisk="false">
-		<terracotta>
-			<nonstop timeoutMillis="3000">
-				<timeoutBehavior type="noop" />
-			</nonstop>
-		</terracotta>
-	</cache>
-
-	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.hitListSizes"
-		maxElementsOnDisk="10000" maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="12000"
-		timeToLiveSeconds="12000" overflowToDisk="false">
 		<terracotta>
 			<nonstop timeoutMillis="3000">
 				<timeoutBehavior type="noop" />
@@ -1704,8 +1684,8 @@
 		</terracotta>
 	</cache>
 
-	<cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisResultSet" maxElementsOnDisk="10000"
-		maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false">
+	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet" maxElementsOnDisk="10000"
+           maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false">
 		<terracotta>
 			<nonstop timeoutMillis="3000">
 				<timeoutBehavior type="noop" />
@@ -1713,8 +1693,8 @@
 		</terracotta>
 	</cache>
 
-	<cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisResultSet.results" maxElementsOnDisk="10000"
-		maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false">
+	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.results" maxElementsOnDisk="10000"
+           maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false">
 		<terracotta>
 			<nonstop timeoutMillis="3000">
 				<timeoutBehavior type="noop" />
@@ -1722,6 +1702,15 @@
 		</terracotta>
 	</cache>
 
+	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.hitListSizes"
+		   maxElementsOnDisk="10000" maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="12000"
+		   timeToLiveSeconds="12000" overflowToDisk="false">
+		<terracotta>
+			<nonstop timeoutMillis="3000">
+				<timeoutBehavior type="noop" />
+			</nonstop>
+		</terracotta>
+	</cache>
 
 	<cache name="ubic.gemma.model.analysis.expression.ProbeAnalysisResultImpl" maxElementsOnDisk="10000"
 		maxElementsInMemory="50000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false">

--- a/gemma-core/src/main/resources/ehcache.nocluster.xml
+++ b/gemma-core/src/main/resources/ehcache.nocluster.xml
@@ -43,9 +43,6 @@
     <cache name="ubic.gemma.model.analysis.expression.pca.PrincipalComponentAnalysis.eigenValues"
            maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
            overflowToDisk="false"/>
-    <cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.results"
-           maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
-           overflowToDisk="false"/>
     <cache name="ubic.gemma.model.analysis.expression.pca.PrincipalComponentAnalysis.eigenVectors"
            maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
            overflowToDisk="false"/>
@@ -56,9 +53,6 @@
 
     <cache name="ubic.gemma.model.analysis.expression.diff.HitListSizeImpl" maxElementsInMemory="100000" eternal="false"
            timeToIdleSeconds="10000" timeToLiveSeconds="10000" overflowToDisk="false"/>
-    <cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.hitListSizes"
-           maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
-           overflowToDisk="false"/>
 
 
     <cache name="ubic.gemma.model.genome.sequenceAnalysis.BlatResult" maxElementsInMemory="100000" eternal="false"
@@ -646,12 +640,15 @@
            eternal="false"
            timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false"/>
 
-    <cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisResultSet" maxElementsInMemory="10000"
+    <cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet" maxElementsInMemory="10000"
            eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false"/>
 
-    <cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisResultSet.results" maxElementsInMemory="10000"
+    <cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.results" maxElementsInMemory="10000"
            eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false"/>
 
+    <cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.hitListSizes"
+           maxElementsInMemory="1000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200"
+           overflowToDisk="false"/>
 
     <cache name="ubic.gemma.model.analysis.expression.ProbeAnalysisResultImpl" maxElementsInMemory="50000"
            eternal="false"

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
@@ -27,6 +27,7 @@ import ubic.gemma.core.loader.expression.geo.service.GeoService;
 import ubic.gemma.core.loader.expression.simple.ExperimentalDesignImporter;
 import ubic.gemma.core.loader.genome.gene.ExternalFileGeneLoaderService;
 import ubic.gemma.core.loader.util.AlreadyExistsInSystemException;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.common.description.ExternalDatabase;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/TTestAnalyzerTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/TTestAnalyzerTest.java
@@ -20,6 +20,7 @@ package ubic.gemma.core.analysis.expression.diff;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.common.quantitationtype.ScaleType;
 import ubic.gemma.model.expression.biomaterial.BioMaterial;

--- a/gemma-core/src/test/resources/ehcache.nocluster.xml
+++ b/gemma-core/src/test/resources/ehcache.nocluster.xml
@@ -598,10 +598,10 @@
 	<cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisImpl" maxElementsInMemory="10000"
 		eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false" />
 
-	<cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisResultSet" maxElementsInMemory="10000"
-		eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false" />
+	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet" maxElementsInMemory="10000"
+		   eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false" />
 
-	<cache name="ubic.gemma.model.analysis.expression.ExpressionAnalysisResultSet.results"
+	<cache name="ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet.results"
 		maxElementsInMemory="10000" eternal="false" timeToIdleSeconds="1200" timeToLiveSeconds="1200" overflowToDisk="false" />
 
 

--- a/gemma-web/pom.xml
+++ b/gemma-web/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<artifactId>gemma</artifactId>
 		<groupId>gemma</groupId>
@@ -193,7 +193,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore />
+										<ignore/>
 									</action>
 								</pluginExecution>
 								<pluginExecution>
@@ -206,7 +206,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore />
+										<ignore/>
 									</action>
 								</pluginExecution>
 								<pluginExecution>
@@ -219,7 +219,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore />
+										<ignore/>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/diff/DifferentialExpressionSearchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/diff/DifferentialExpressionSearchController.java
@@ -31,6 +31,7 @@ import ubic.gemma.core.genome.gene.service.GeneService;
 import ubic.gemma.core.genome.gene.service.GeneSetService;
 import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.visualization.DifferentialExpressionSearchTaskCommand;
+import ubic.gemma.model.analysis.AnalysisResult;
 import ubic.gemma.model.analysis.expression.ExpressionExperimentSet;
 import ubic.gemma.model.analysis.expression.FactorAssociatedAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/AnalysisResultSetsWebService.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/AnalysisResultSetsWebService.java
@@ -1,0 +1,101 @@
+/*
+ * The Gemma project
+ *
+ * Copyright (c) 2006 University of British Columbia
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package ubic.gemma.web.services.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import ubic.gemma.model.analysis.AnalysisResultSet;
+import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
+import ubic.gemma.model.common.description.DatabaseEntry;
+import ubic.gemma.model.expression.experiment.BioAssaySet;
+import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
+import ubic.gemma.persistence.service.common.description.DatabaseEntryService;
+import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.services.rest.util.Responder;
+import ubic.gemma.web.services.rest.util.ResponseDataObject;
+import ubic.gemma.web.services.rest.util.WebService;
+import ubic.gemma.web.services.rest.util.args.DatabaseEntryArg;
+import ubic.gemma.web.services.rest.util.args.DatasetArg;
+import ubic.gemma.web.services.rest.util.args.ExpressionAnalysisResultSetArg;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Endpoint for {@link ubic.gemma.model.analysis.AnalysisResultSet}
+ */
+@Component
+@Path("/resultSets")
+public class AnalysisResultSetsWebService extends WebService {
+
+    @Autowired
+    private ExpressionAnalysisResultSetService expressionAnalysisResultSetService;
+
+    @Autowired
+    private ExpressionExperimentService expressionExperimentService;
+
+    @Autowired
+    private DatabaseEntryService databaseEntryService;
+
+    /**
+     * Retrieve all {@link AnalysisResultSet} matching a set of criteria.
+     *
+     * @param datasetIds filter result sets that belong to any of the provided dataset identifiers, or null to ignore
+     * @param externalIds filter by associated datasets with given external identifiers, or null to ignore
+     * @param servlet
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ResponseDataObject<List<AnalysisResultSetValueObject>> findAll(
+            @QueryParam("datasetIds") Set<DatasetArg<?>> datasetIds,
+            @QueryParam("externalIds") Set<DatabaseEntryArg<?>> externalIds,
+            @Context final HttpServletResponse servlet ) {
+        Collection<BioAssaySet> bioAssaySets = datasetIds.stream()
+                .map( datasetId -> datasetId.getPersistentObject( expressionExperimentService ) )
+                .filter( Objects::nonNull )
+                .collect( Collectors.toSet() );
+        Collection<DatabaseEntry> databaseEntries = externalIds.stream()
+                .map( externalId -> externalId.getPersistentObject( databaseEntryService ) )
+                .filter( Objects::nonNull )
+                .collect( Collectors.toSet() );
+        return Responder.code200( expressionAnalysisResultSetService.findByBioAssaySetInAndDatabaseEntryInLimit( bioAssaySets, databaseEntries, 10 ), servlet );
+    }
+
+    /**
+     * Retrieve a {@link AnalysisResultSet} given its identifier.
+     *
+     * @param analysisResultSetId
+     * @return
+     */
+    @GET
+    @Path("/{analysisResultSetId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ResponseDataObject<AnalysisResultSetValueObject> findById(
+            @PathParam("analysisResultSetId") ExpressionAnalysisResultSetArg analysisResultSetId,
+            @Context final HttpServletResponse servlet ) {
+        return Responder.code200( analysisResultSetId.getValueObject( expressionAnalysisResultSetService ), servlet );
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/AnnotationsWebService.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/AnnotationsWebService.java
@@ -266,7 +266,7 @@ public class AnnotationsWebService extends
         }
     }
 
-    private class AnnotationSearchResultValueObject {
+    private static class AnnotationSearchResultValueObject {
         public String value;
         public String valueUri;
         public String category;

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/DatasetsWebService.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/DatasetsWebService.java
@@ -264,7 +264,7 @@ public class DatasetsWebService extends
     /**
      * Returns true if the experiment has had batch information successfully filled in. This will be true even if there
      * is only one batch. It does not reflect the presence or absence of a batch effect.
-     * 
+     *
      * @param datasetArg can either be the ExpressionExperiment ID or its short name (e.g. GSE1234). Retrieval by ID
      *                   is more efficient. Only datasets that user has access to will be available.
      */
@@ -277,7 +277,7 @@ public class DatasetsWebService extends
             @Context final HttpServletResponse sr // The servlet response, needed for response code setting.
     ) {
         ExpressionExperiment ee = datasetArg.getPersistentObject( expressionExperimentService );
-        return Responder.autoCode(new Boolean(this.auditEventService.hasEvent( ee, BatchInformationFetchingEvent.class )), sr);
+        return Responder.autoCode( new Boolean( this.auditEventService.hasEvent( ee, BatchInformationFetchingEvent.class ) ), sr );
     }
 
     /**
@@ -344,9 +344,9 @@ public class DatasetsWebService extends
             @Context final HttpServletResponse sr // The servlet response, needed for response code setting.
     ) {
         return Responder.autoCode( processedExpressionDataVectorService
-                .getExpressionLevels( datasets.getPersistentObjects( expressionExperimentService ),
-                        genes.getPersistentObjects( geneService ), keepNonSpecific.getValue(),
-                        consolidate == null ? null : consolidate.getValue() ),
+                        .getExpressionLevels( datasets.getPersistentObjects( expressionExperimentService ),
+                                genes.getPersistentObjects( geneService ), keepNonSpecific.getValue(),
+                                consolidate == null ? null : consolidate.getValue() ),
                 sr );
     }
 
@@ -387,9 +387,9 @@ public class DatasetsWebService extends
     ) {
         this.checkReqArg( component, "component" );
         return Responder.autoCode( processedExpressionDataVectorService
-                .getExpressionLevelsPca( datasets.getPersistentObjects( expressionExperimentService ), limit.getValue(),
-                        component.getValue(), keepNonSpecific.getValue(),
-                        consolidate == null ? null : consolidate.getValue() ),
+                        .getExpressionLevelsPca( datasets.getPersistentObjects( expressionExperimentService ), limit.getValue(),
+                                component.getValue(), keepNonSpecific.getValue(),
+                                consolidate == null ? null : consolidate.getValue() ),
                 sr );
     }
 
@@ -433,9 +433,9 @@ public class DatasetsWebService extends
     ) {
         this.checkReqArg( diffExSet, "diffExSet" );
         return Responder.autoCode( processedExpressionDataVectorService
-                .getExpressionLevelsDiffEx( datasets.getPersistentObjects( expressionExperimentService ),
-                        diffExSet.getValue(), threshold.getValue(), limit.getValue(), keepNonSpecific.getValue(),
-                        consolidate == null ? null : consolidate.getValue() ),
+                        .getExpressionLevelsDiffEx( datasets.getPersistentObjects( expressionExperimentService ),
+                                diffExSet.getValue(), threshold.getValue(), limit.getValue(), keepNonSpecific.getValue(),
+                                consolidate == null ? null : consolidate.getValue() ),
                 sr );
     }
 
@@ -480,7 +480,7 @@ public class DatasetsWebService extends
     }
 
     @SuppressWarnings("unused") // Used for json serialization
-    private class SimpleSVDValueObject {
+    private static class SimpleSVDValueObject {
         /**
          * Order same as the rows of the v matrix.
          */

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/PlatformsWebService.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/PlatformsWebService.java
@@ -231,7 +231,7 @@ public class PlatformsWebService extends WebServiceWithFiltering<ArrayDesign, Ar
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public ResponseDataObject platformElementGenes( // Params:
             @PathParam("platformArg") PlatformArg<Object> platformArg, // Required
-            @PathParam("probeArg") CompositeSequenceArg probeArg, // Required
+            @PathParam("probeArg") CompositeSequenceArg<Object> probeArg, // Required
             @QueryParam("offset") @DefaultValue("0") IntArg offset, // Optional, default 0
             @QueryParam("limit") @DefaultValue("20") IntArg limit, // Optional, default 20
             @Context final HttpServletResponse sr // The servlet response, needed for response code setting.

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/RootWebService.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/RootWebService.java
@@ -99,7 +99,7 @@ public class RootWebService extends WebService {
     }
 
     @SuppressWarnings("unused") // Getters used during RS serialization
-    private class ApiInfoValueObject {
+    private static class ApiInfoValueObject {
         private String welcome = MSG_WELCOME;
         private String version = WebService.API_VERSION;
         private String docs = APIDOCS_URL;

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/ResponseDataObject.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/ResponseDataObject.java
@@ -6,18 +6,18 @@ package ubic.gemma.web.services.rest.util;
  *
  * @author tesarst
  */
-public class ResponseDataObject {
+public class ResponseDataObject<T> {
 
-    private final Object data;
+    private final T data;
 
     /**
      * @param payload the data to be serialised and returned as the response payload.
      */
-    ResponseDataObject( Object payload ) {
+    ResponseDataObject( T payload ) {
         this.data = payload;
     }
 
-    public Object getData() {
+    public T getData() {
         return data;
     }
 }

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/RestAuthEntryPoint.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/RestAuthEntryPoint.java
@@ -1,6 +1,8 @@
 package ubic.gemma.web.services.rest.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 
@@ -10,6 +12,8 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 public class RestAuthEntryPoint extends BasicAuthenticationEntryPoint {
+
+    private static Log log = LogFactory.getLog( RestAuthEntryPoint.class );
 
     private static final String MESSAGE_401 = "Provided authentication credentials are invalid.";
 
@@ -25,7 +29,7 @@ public class RestAuthEntryPoint extends BasicAuthenticationEntryPoint {
         response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
         // using 'xBasic' instead of 'basic' to prevent default browser login popup
         response.addHeader( "WWW-Authenticate", "xBasic realm=" + getRealmName() + "" );
-        response.addHeader("Access-Control-Allow-Headers", "**Authorization**,authorization"); // necessary for vue gembrow access
+        response.addHeader( "Access-Control-Allow-Headers", "**Authorization**,authorization" ); // necessary for vue gembrow access
         response.setContentType( "application/json" );
 
         WellComposedErrorBody errorBody = new WellComposedErrorBody( Response.Status.UNAUTHORIZED, MESSAGE_401 );
@@ -36,7 +40,7 @@ public class RestAuthEntryPoint extends BasicAuthenticationEntryPoint {
             String jsonStr = mapperObj.writeValueAsString( errorObject );
             response.getWriter().println( jsonStr );
         } catch ( IOException e ) {
-            e.printStackTrace();
+            log.error( e );
         }
     }
 }

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/WebServiceWithFiltering.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/WebServiceWithFiltering.java
@@ -108,7 +108,7 @@ public abstract class WebServiceWithFiltering<O extends Identifiable, VO extends
      * result to
      * the value of the {@code limit} parameter.
      */
-    protected ResponseDataObject all( FilterArg filter, IntArg offset, IntArg limit, SortArg sort,
+    protected ResponseDataObject<?> all( FilterArg filter, IntArg offset, IntArg limit, SortArg sort,
             final HttpServletResponse sr ) {
         return this.callService( offset.getValue(), limit.getValue(), sort.getField(), sort.isAsc(),
                 filter.getObjectFilters(), sr );
@@ -126,13 +126,13 @@ public abstract class WebServiceWithFiltering<O extends Identifiable, VO extends
      * @param sr       see this#all
      * @return see this#all
      */
-    protected ResponseDataObject some( ArrayEntityArg<O, VO, S> arrayArg, FilterArg filter, IntArg offset, IntArg limit,
+    protected ResponseDataObject<?> some( ArrayEntityArg<O, VO, S> arrayArg, FilterArg filter, IntArg offset, IntArg limit,
             SortArg sort, final HttpServletResponse sr ) {
         return this.callService( offset.getValue(), limit.getValue(), sort.getField(), sort.isAsc(),
                 arrayArg.combineFilters( filter.getObjectFilters(), service ), sr );
     }
 
-    private ResponseDataObject callService( int offset, int limit, String orderBy, boolean asc,
+    private ResponseDataObject<?> callService( int offset, int limit, String orderBy, boolean asc,
             List<ObjectFilter[]> filter, final HttpServletResponse sr ) {
         try {
             return Responder.autoCode( service.loadValueObjectsPreFilter( offset, limit, orderBy, asc, filter ), sr );

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ArrayDatabaseEntryArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ArrayDatabaseEntryArg.java
@@ -1,0 +1,42 @@
+package ubic.gemma.web.services.rest.util.args;
+
+import com.google.common.base.Strings;
+import ubic.gemma.model.common.description.DatabaseEntry;
+import ubic.gemma.model.common.description.DatabaseEntryValueObject;
+import ubic.gemma.persistence.service.common.description.DatabaseEntryService;
+import ubic.gemma.persistence.util.ObjectFilter;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ArrayDatabaseEntryArg extends ArrayEntityArg<DatabaseEntry, DatabaseEntryValueObject, DatabaseEntryService> {
+
+    private static final String ERROR_MSG_DETAIL = "Provide a string that contains at least one ID or short name, or multiple, separated by (',') character. All identifiers must be same type, i.e. do not combine IDs and short names.";
+    private static final String ERROR_MSG = ArrayArg.ERROR_MSG + " Database entry identifiers";
+
+    private ArrayDatabaseEntryArg( List<String> values ) {
+        super( values, DatabaseEntryArg.class );
+    }
+
+    public ArrayDatabaseEntryArg( String format, IllegalArgumentException e ) {
+        super( format, e );
+    }
+
+    @Override
+    protected String getObjectDaoAlias() {
+        return ObjectFilter.DAO_DATABASE_ENTRY_ALIAS;
+    }
+
+    @Override
+    protected void setPropertyNameAndType( DatabaseEntryService service ) {
+
+    }
+
+    public static ArrayDatabaseEntryArg valueOf( final String s ) {
+        if ( Strings.isNullOrEmpty( s ) ) {
+            return new ArrayDatabaseEntryArg( String.format( ArrayDatabaseEntryArg.ERROR_MSG, s ),
+                    new IllegalArgumentException( ArrayDatabaseEntryArg.ERROR_MSG_DETAIL ) );
+        }
+        return new ArrayDatabaseEntryArg( Arrays.asList( ArrayEntityArg.splitString( s ) ) );
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/DatasetIdArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/DatasetIdArg.java
@@ -13,7 +13,7 @@ public class DatasetIdArg extends DatasetArg<Long> {
     /**
      * @param l intentionally primitive type, so the value property can never be null.
      */
-    DatasetIdArg( long l ) {
+    public DatasetIdArg( long l ) {
         this.value = l;
         setNullCause( "ID", "Dataset" );
     }

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ExpressionAnalysisResultSetArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ExpressionAnalysisResultSetArg.java
@@ -1,15 +1,13 @@
 package ubic.gemma.web.services.rest.util.args;
 
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
-import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
 
 /**
  * Represents an expression analysis result set identifier.
  */
 public class ExpressionAnalysisResultSetArg extends MutableArg<Long, ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject, ExpressionAnalysisResultSetService> {
-
-    private final long value;
 
     public ExpressionAnalysisResultSetArg( long value ) {
         this.value = value;
@@ -17,7 +15,8 @@ public class ExpressionAnalysisResultSetArg extends MutableArg<Long, ExpressionA
 
     @Override
     public ExpressionAnalysisResultSet getPersistentObject( ExpressionAnalysisResultSetService service ) {
-        return service.load( value );
+        ExpressionAnalysisResultSet result = service.load( value );
+        return result == null ? null : service.thaw( result );
     }
 
     @Override

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ExpressionAnalysisResultSetArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ExpressionAnalysisResultSetArg.java
@@ -1,0 +1,31 @@
+package ubic.gemma.web.services.rest.util.args;
+
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
+import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+
+/**
+ * Represents an expression analysis result set identifier.
+ */
+public class ExpressionAnalysisResultSetArg extends MutableArg<Long, ExpressionAnalysisResultSet, ExpressionAnalysisResultSetValueObject, ExpressionAnalysisResultSetService> {
+
+    private final long value;
+
+    public ExpressionAnalysisResultSetArg( long value ) {
+        this.value = value;
+    }
+
+    @Override
+    public ExpressionAnalysisResultSet getPersistentObject( ExpressionAnalysisResultSetService service ) {
+        return service.load( value );
+    }
+
+    @Override
+    public String getPropertyName( ExpressionAnalysisResultSetService service ) {
+        return null;
+    }
+
+    public static ExpressionAnalysisResultSetArg valueOf( String s ) {
+        return new ExpressionAnalysisResultSetArg( Long.parseLong( s ) );
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ExpressionAnalysisResultSetFilterArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/ExpressionAnalysisResultSetFilterArg.java
@@ -1,0 +1,40 @@
+package ubic.gemma.web.services.rest.util.args;
+
+import com.google.common.base.Strings;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
+import ubic.gemma.persistence.util.ObjectFilter;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ExpressionAnalysisResultSetFilterArg extends FilterArg {
+
+    private static final String ERROR_INVALID_PROPERTY = "Given filter property does not exist in expression analysis result sets.";
+    private static final String ERROR_PARSE_ERROR = "Filter argument parsing error.";
+
+    ExpressionAnalysisResultSetFilterArg( List<String[]> propertyNames, List<String[]> propertyValues, List<String[]> propertyOperators, List<Class[]> propertyTypes ) {
+        super( propertyNames, propertyValues, propertyOperators, propertyTypes, ObjectFilter.DAO_EARS_ALIAS );
+    }
+
+    public ExpressionAnalysisResultSetFilterArg( String s, Exception e ) {
+        super( s, e );
+    }
+
+    public static ExpressionAnalysisResultSetFilterArg valueOf( String s ) {
+        if ( Strings.isNullOrEmpty( s ) )
+            return new ExpressionAnalysisResultSetFilterArg( null, null, null, null );
+        List<String[]> propertyNames = new LinkedList<>();
+        List<String[]> propertyValues = new LinkedList<>();
+        List<String[]> propertyOperators = new LinkedList<>();
+        List<Class[]> propertyTypes;
+        try {
+            parseFilterString( s, propertyNames, propertyValues, propertyOperators );
+            propertyTypes = getPropertiesTypes( propertyNames, ExpressionAnalysisResultSet.class );
+        } catch ( IllegalArgumentException e ) {
+            return new ExpressionAnalysisResultSetFilterArg( ERROR_PARSE_ERROR, e );
+        } catch ( NoSuchFieldException e ) {
+            return new ExpressionAnalysisResultSetFilterArg( ERROR_INVALID_PROPERTY, e );
+        }
+        return new ExpressionAnalysisResultSetFilterArg( propertyNames, propertyValues, propertyOperators, propertyTypes );
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/FactorValueArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/FactorValueArg.java
@@ -1,0 +1,20 @@
+package ubic.gemma.web.services.rest.util.args;
+
+import ubic.gemma.model.expression.experiment.FactorValue;
+import ubic.gemma.model.expression.experiment.FactorValueValueObject;
+import ubic.gemma.persistence.service.expression.experiment.FactorValueService;
+
+/**
+ * Represents an API arguments that maps to a {@link FactorValue} by its ID or name.
+ * @author poirigui
+ */
+public abstract class FactorValueArg<A> extends MutableArg<A, FactorValue, FactorValueValueObject, FactorValueService> {
+
+    public static FactorValueArg<?> valueOf( String value ) {
+        try {
+            return new FactorValueIdArg( Long.valueOf( value ) );
+        } catch ( NumberFormatException e ) {
+            return new FactorValueValueArg( value );
+        }
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/FactorValueIdArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/FactorValueIdArg.java
@@ -1,0 +1,25 @@
+package ubic.gemma.web.services.rest.util.args;
+
+import ubic.gemma.model.expression.experiment.FactorValue;
+import ubic.gemma.persistence.service.expression.experiment.FactorValueService;
+
+/**
+ * Maps a long identifier to a {@link FactorValue}.
+ * @author poirigui
+ */
+public class FactorValueIdArg extends FactorValueArg<Long> {
+
+    public FactorValueIdArg( Long value ) {
+        this.value = value;
+    }
+
+    @Override
+    public FactorValue getPersistentObject( FactorValueService service ) {
+        return service.load( this.value );
+    }
+
+    @Override
+    public String getPropertyName( FactorValueService service ) {
+        return "factorValueId";
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/FactorValueValueArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/FactorValueValueArg.java
@@ -1,0 +1,25 @@
+package ubic.gemma.web.services.rest.util.args;
+
+import ubic.gemma.model.expression.experiment.FactorValue;
+import ubic.gemma.persistence.service.expression.experiment.FactorValueService;
+
+/**
+ * Maps {@link FactorValue} by its factor value.
+ * @author poirigui
+ */
+public class FactorValueValueArg extends FactorValueArg<String> {
+
+    public FactorValueValueArg( String value ) {
+        this.value = value;
+    }
+
+    @Override
+    public FactorValue getPersistentObject( FactorValueService service ) {
+        return service.findByValue( value ).stream().findFirst().get();
+    }
+
+    @Override
+    public String getPropertyName( FactorValueService service ) {
+        return "factorValueValue";
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/IntArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/IntArg.java
@@ -22,7 +22,7 @@ public class IntArg extends MalformableArg {
 
     @Override
     public String toString() {
-        if(this.value == null) return "";
+        if ( this.value == null ) return "";
         return String.valueOf( this.value );
     }
 

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/MutableArg.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/util/args/MutableArg.java
@@ -28,7 +28,7 @@ public abstract class MutableArg<A, O extends Identifiable, VO extends Identifia
      * Should only be used by the implementations of this class, which is why there is no setter for it,
      * as the whole reason behind this class is to delegate the functionality from the web service controllers.
      */
-    A value;
+    protected A value;
 
     String nullCause = "No cause specified.";
 

--- a/gemma-web/src/test/java/ubic/gemma/web/services/rest/AnalysisResultSetsWebServiceTest.java
+++ b/gemma-web/src/test/java/ubic/gemma/web/services/rest/AnalysisResultSetsWebServiceTest.java
@@ -1,22 +1,33 @@
 package ubic.gemma.web.services.rest;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.analysis.Analysis;
-import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
+import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
+import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSetValueObject;
+import ubic.gemma.model.common.description.DatabaseEntry;
+import ubic.gemma.model.common.description.ExternalDatabase;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisDao;
+import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisService;
+import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetDao;
+import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
+import ubic.gemma.persistence.service.common.description.DatabaseEntryService;
+import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.web.services.rest.util.GemmaApiException;
 import ubic.gemma.web.services.rest.util.ResponseDataObject;
-import ubic.gemma.web.services.rest.util.args.DatabaseEntryArg;
-import ubic.gemma.web.services.rest.util.args.ExpressionAnalysisResultSetArg;
-import ubic.gemma.web.services.rest.util.args.DatasetArg;
-import ubic.gemma.web.services.rest.util.args.DatasetIdArg;
+import ubic.gemma.web.services.rest.util.args.*;
 import ubic.gemma.web.util.BaseSpringWebTest;
 
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.WebApplicationException;
-import java.util.*;
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -25,56 +36,147 @@ public class AnalysisResultSetsWebServiceTest extends BaseSpringWebTest {
     @Autowired
     private AnalysisResultSetsWebService service;
 
+    @Autowired
+    private ExpressionExperimentService expressionExperimentService;
+
+    @Autowired
+    private DifferentialExpressionAnalysisService differentialExpressionAnalysisService;
+
+    @Autowired
+    private ExpressionAnalysisResultSetService expressionAnalysisResultSetService;
+
+    @Autowired
+    private DatabaseEntryService databaseEntryService;
+
+    /* fixtures */
+    private ExpressionExperiment ee;
+    private DifferentialExpressionAnalysis dea;
+    private ExpressionAnalysisResultSet dears;
+    private DatabaseEntry databaseEntry;
+    private DatabaseEntry databaseEntry2;
+
+    @Before
+    public void setUp() {
+        ee = getTestPersistentBasicExpressionExperiment();
+
+        dea = new DifferentialExpressionAnalysis();
+        dea.setExperimentAnalyzed( ee );
+        dea = differentialExpressionAnalysisService.create( dea );
+
+        dears = new ExpressionAnalysisResultSet();
+        dears.setAnalysis( dea );
+        dears = expressionAnalysisResultSetService.create( dears );
+
+        ExternalDatabase geo = externalDatabaseService.findByName( "GEO" );
+        assertNotNull( geo );
+        assertEquals( geo.getName(), "GEO" );
+
+        databaseEntry = DatabaseEntry.Factory.newInstance();
+        databaseEntry.setAccession( "GEO123123" );
+        databaseEntry.setExternalDatabase( geo );
+        databaseEntry = databaseEntryService.create( databaseEntry );
+
+        databaseEntry2 = DatabaseEntry.Factory.newInstance();
+        databaseEntry2.setAccession( "GEO1213121" );
+        databaseEntry2.setExternalDatabase( geo );
+        databaseEntry2 = databaseEntryService.create( databaseEntry2 );
+    }
+
+    @After
+    public void tearDown() {
+        expressionAnalysisResultSetService.remove( dears );
+        differentialExpressionAnalysisService.remove( dea );
+        expressionExperimentService.remove( ee );
+        databaseEntryService.remove( databaseEntry2 );
+    }
+
     @Test
     public void testFindAllWhenNoDatasetsAreProvidedThenReturnLatestAnalysisResults() {
         HttpServletResponse response = new MockHttpServletResponse();
-        service.findAll( null,
+        ResponseDataObject<?> result = service.findAll( null,
                 null,
+                IntArg.valueOf( "0" ),
+                IntArg.valueOf( "10" ),
+                SortArg.valueOf( "+id" ),
                 response );
         assertEquals( response.getStatus(), 200 );
+        List<ExpressionAnalysisResultSetValueObject> results = ( List<ExpressionAnalysisResultSetValueObject> ) result.getData();
+        assertEquals( results.size(), 1 );
     }
 
     @Test
     public void testFindAllWithDatasetIdsThenReturnLatestAnalysisResults() {
         HttpServletResponse response = new MockHttpServletResponse();
-        ExpressionExperiment ee = getTestPersistentExpressionExperiment();
-        Collection<Analysis> analyses = addTestAnalyses( ee );
-        assertFalse( ee.getBioAssays().isEmpty() );
-        Set<DatasetArg<?>> datasetIds = Collections.singleton( new DatasetIdArg( ee.getId() ) );
-        ResponseDataObject<List<AnalysisResultSetValueObject>> result = service.findAll(
-                datasetIds,
+        ArrayDatasetArg datasets = ArrayDatasetArg.valueOf( String.valueOf( ee.getId() ) );
+        ResponseDataObject<?> result = service.findAll(
+                datasets,
                 null,
+                IntArg.valueOf( "0" ),
+                IntArg.valueOf( "10" ),
+                SortArg.valueOf( "+id" ),
                 response );
-        assertFalse( result.getData().isEmpty() );
         assertEquals( response.getStatus(), 200 );
+        List<ExpressionAnalysisResultSetValueObject> results = ( List<ExpressionAnalysisResultSetValueObject> ) result.getData();
+        assertEquals( results.get( 0 ).getId(), dears.getId() );
     }
 
     @Test
-    public void testFindAllWithExternalIdsThenReturnLatestAnalysisResults() {
+    public void testFindAllWhenDatasetDoesNotExistThenRaise404NotFound() {
         HttpServletResponse response = new MockHttpServletResponse();
-        service.findAll( null,
-                new HashSet<>( Arrays.asList( DatabaseEntryArg.valueOf( "GEO123123" ), DatabaseEntryArg.valueOf( "GEO1213121" ) ) ),
+        GemmaApiException e = assertThrows( GemmaApiException.class, () -> service.findAll(
+                ArrayDatasetArg.valueOf( "GEO123124" ),
+                null,
+                IntArg.valueOf( "0" ),
+                IntArg.valueOf( "10" ),
+                SortArg.valueOf( "+id" ),
+                response ) );
+        assertEquals( e.getCode(), Response.Status.NOT_FOUND );
+    }
+
+    @Test
+    public void testFindAllWithDatabaseEntriesThenReturnLatestAnalysisResults() {
+        HttpServletResponse response = new MockHttpServletResponse();
+        ResponseDataObject<?> result = service.findAll( null,
+                ArrayDatabaseEntryArg.valueOf( ee.getAccession().getAccession() ),
+                IntArg.valueOf( "0" ),
+                IntArg.valueOf( "10" ),
+                SortArg.valueOf( "+id" ),
                 response );
         assertEquals( response.getStatus(), 200 );
+        List<ExpressionAnalysisResultSetValueObject> results = ( List<ExpressionAnalysisResultSetValueObject> ) result.getData();
+        assertEquals( results.get( 0 ).getId(), dears.getId() );
+    }
+
+    @Test
+    public void testFindAllWhenDatabaseEntryDoesNotExistThenRaise404NotFound() {
+        HttpServletResponse response = new MockHttpServletResponse();
+        GemmaApiException e = assertThrows( GemmaApiException.class, () -> service.findAll(
+                null,
+                ArrayDatabaseEntryArg.valueOf( "GEO123124,GEO1213121" ),
+                IntArg.valueOf( "0" ),
+                IntArg.valueOf( "10" ),
+                SortArg.valueOf( "+id" ),
+                response ) );
+        assertEquals( e.getCode(), Response.Status.NOT_FOUND );
     }
 
     @Test
     public void testFindByIdThenReturn200Success() {
-        ExpressionExperiment ee = getTestPersistentBasicExpressionExperiment();
-        Collection<Analysis> analyses = addTestAnalyses( ee );
-        Analysis firstAnalysis = analyses.stream().findFirst().get();
         HttpServletResponse response = new MockHttpServletResponse();
-        service.findById( new ExpressionAnalysisResultSetArg( firstAnalysis.getId() ), response );
+        ResponseDataObject<?> result = service.findById( new ExpressionAnalysisResultSetArg( dears.getId() ), response );
         assertEquals( response.getStatus(), 200 );
+        ExpressionAnalysisResultSetValueObject dearsVo = ( ExpressionAnalysisResultSetValueObject ) result.getData();
+        assertEquals( dearsVo.getId(), dears.getId() );
+        assertEquals( dearsVo.getAnalysis().getId(), dea.getId() );
     }
 
     @Test
     public void testFindByIdWhenResultSetDoesNotExistsThenReturn404NotFoundError() {
-        Long id = 1L;
+        Long id = 123129L;
         HttpServletResponse response = new MockHttpServletResponse();
         GemmaApiException e = assertThrows( GemmaApiException.class, () -> {
             service.findById( new ExpressionAnalysisResultSetArg( id ), response );
         } );
-        assertEquals( e.getCode(), 404 );
+        assertEquals( e.getCode(), Response.Status.NOT_FOUND );
     }
 }

--- a/gemma-web/src/test/java/ubic/gemma/web/services/rest/AnalysisResultSetsWebServiceTest.java
+++ b/gemma-web/src/test/java/ubic/gemma/web/services/rest/AnalysisResultSetsWebServiceTest.java
@@ -1,0 +1,80 @@
+package ubic.gemma.web.services.rest;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
+import ubic.gemma.model.analysis.Analysis;
+import ubic.gemma.model.analysis.AnalysisResultSetValueObject;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.web.services.rest.util.GemmaApiException;
+import ubic.gemma.web.services.rest.util.ResponseDataObject;
+import ubic.gemma.web.services.rest.util.args.DatabaseEntryArg;
+import ubic.gemma.web.services.rest.util.args.ExpressionAnalysisResultSetArg;
+import ubic.gemma.web.services.rest.util.args.DatasetArg;
+import ubic.gemma.web.services.rest.util.args.DatasetIdArg;
+import ubic.gemma.web.util.BaseSpringWebTest;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.WebApplicationException;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class AnalysisResultSetsWebServiceTest extends BaseSpringWebTest {
+
+    @Autowired
+    private AnalysisResultSetsWebService service;
+
+    @Test
+    public void testFindAllWhenNoDatasetsAreProvidedThenReturnLatestAnalysisResults() {
+        HttpServletResponse response = new MockHttpServletResponse();
+        service.findAll( null,
+                null,
+                response );
+        assertEquals( response.getStatus(), 200 );
+    }
+
+    @Test
+    public void testFindAllWithDatasetIdsThenReturnLatestAnalysisResults() {
+        HttpServletResponse response = new MockHttpServletResponse();
+        ExpressionExperiment ee = getTestPersistentExpressionExperiment();
+        Collection<Analysis> analyses = addTestAnalyses( ee );
+        assertFalse( ee.getBioAssays().isEmpty() );
+        Set<DatasetArg<?>> datasetIds = Collections.singleton( new DatasetIdArg( ee.getId() ) );
+        ResponseDataObject<List<AnalysisResultSetValueObject>> result = service.findAll(
+                datasetIds,
+                null,
+                response );
+        assertFalse( result.getData().isEmpty() );
+        assertEquals( response.getStatus(), 200 );
+    }
+
+    @Test
+    public void testFindAllWithExternalIdsThenReturnLatestAnalysisResults() {
+        HttpServletResponse response = new MockHttpServletResponse();
+        service.findAll( null,
+                new HashSet<>( Arrays.asList( DatabaseEntryArg.valueOf( "GEO123123" ), DatabaseEntryArg.valueOf( "GEO1213121" ) ) ),
+                response );
+        assertEquals( response.getStatus(), 200 );
+    }
+
+    @Test
+    public void testFindByIdThenReturn200Success() {
+        ExpressionExperiment ee = getTestPersistentBasicExpressionExperiment();
+        Collection<Analysis> analyses = addTestAnalyses( ee );
+        Analysis firstAnalysis = analyses.stream().findFirst().get();
+        HttpServletResponse response = new MockHttpServletResponse();
+        service.findById( new ExpressionAnalysisResultSetArg( firstAnalysis.getId() ), response );
+        assertEquals( response.getStatus(), 200 );
+    }
+
+    @Test
+    public void testFindByIdWhenResultSetDoesNotExistsThenReturn404NotFoundError() {
+        Long id = 1L;
+        HttpServletResponse response = new MockHttpServletResponse();
+        GemmaApiException e = assertThrows( GemmaApiException.class, () -> {
+            service.findById( new ExpressionAnalysisResultSetArg( id ), response );
+        } );
+        assertEquals( e.getCode(), 404 );
+    }
+}


### PR DESCRIPTION
The main idea is to add generic services that expose result sets form co-expression and expression analysis to fulfill the requirements from #127. For other issues, we need to take a similar approach by extending the service and DAO routines to accept more parameters to filter.

I've updated Jersey in the process which allow us to register and use parameter converters (yay!), which is much nicer than doing the conversion ourselves every time we pass parameters in the controller layer. I think we could take advantage of Jersy test framework to really test out the API via actual requests, but that will require some setup.

I'm not exactly looking for review, but I would really like to leave some notes here and there because there are some concepts that I really liked from using Spring Boot on another project that would be highly beneficial to our codebase. I took quite a big dive in the codebase to understand these changes.

Relates to #123, #126, #127 and #132