### PR TITLE
Add a flag for uploading a MultiQC report alongside RNA-Seq data

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
+++ b/gemma-cli/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
@@ -17,9 +17,12 @@ package ubic.gemma.core.apps;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.io.FileUtils;
 import ubic.basecode.dataStructure.matrix.DoubleMatrix;
 import ubic.basecode.io.reader.DoubleMatrixReader;
+import ubic.gemma.core.analysis.service.ExpressionDataFileService;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
+import ubic.gemma.core.expression.experiment.ExpressionExperimentMetaFileType;
 import ubic.gemma.core.loader.expression.DataUpdater;
 import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
@@ -29,7 +32,11 @@ import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.text.MessageFormat;
 import java.util.Collection;
 
 /**
@@ -43,6 +50,7 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     private static final String COUNT_FILE_OPT = "count";
     private static final String METADATAOPT = "rlen";
     private static final String RPKM_FILE_OPT = "rpkm";
+    private static final String MULTIQC_METADATA_FILE_OPT = "multiqc";
     private boolean allowMissingSamples = false;
     private String countFile = null;
     private boolean isPairedReads = false;
@@ -50,6 +58,7 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     private Integer readLength = null;
     private String rpkmFile = null;
     private boolean justbackfillLog2cpm = false;
+    private File qualityControlReportFile = null;
 
     @Override
     public CommandGroup getCommandGroup() {
@@ -70,6 +79,8 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
 
         options.addOption( "log2cpm", "Just compute log2cpm from the existing stored count data (backfill); batchmode OK, no other options needed" );
 
+        // RNA-Seq pipeline QC report
+        options.addOption( RNASeqDataAddCli.MULTIQC_METADATA_FILE_OPT, true, "File containing a MultiQC report" );
     }
 
     @Override
@@ -128,6 +139,12 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
 
         this.platformName = commandLine.getOptionValue( "a" );
 
+        if ( commandLine.hasOption( RNASeqDataAddCli.MULTIQC_METADATA_FILE_OPT ) ) {
+            qualityControlReportFile = new File( commandLine.getOptionValue( RNASeqDataAddCli.MULTIQC_METADATA_FILE_OPT ) );
+            if ( !qualityControlReportFile.isFile() || !qualityControlReportFile.canRead() ) {
+                throw new IllegalArgumentException( "The MultiQC report file must exist and be readable." );
+            }
+        }
     }
 
     @Override
@@ -138,6 +155,7 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     @Override
     protected void doWork() throws Exception {
         DataUpdater serv = this.getBean( DataUpdater.class );
+        ExpressionDataFileService expressionDataFileService = this.getBean( ExpressionDataFileService.class );
 
         if ( this.expressionExperiments.isEmpty() ) {
             throw new Exception( "No experiment to be processed. Check in the logs above for troubled experiments." );
@@ -194,6 +212,20 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
 
         } catch ( IOException e ) {
             throw new Exception( "Failed while processing " + ee, e );
+        }
+
+        /* copy metadata files */
+        if ( qualityControlReportFile != null ) {
+            File destinationFile = expressionDataFileService.getMetadataFile( ee, ExpressionExperimentMetaFileType.MUTLQC_REPORT );
+            if ( destinationFile.exists() ) {
+                log.warn( MessageFormat.format( "Replacing existing RNA-Seq quality control report located at {0}.", destinationFile ) );
+            }
+            try {
+                FileUtils.forceMkdirParent( destinationFile );
+                FileUtils.copyFile( qualityControlReportFile, destinationFile, StandardCopyOption.REPLACE_EXISTING );
+            } catch ( IOException e ) {
+                addErrorObject( ee, String.format( "Could not copy the MultiQC report from %s to %s", qualityControlReportFile, destinationFile ), e );
+            }
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
@@ -16,7 +16,7 @@ package ubic.gemma.core.analysis.service;
 
 import ubic.gemma.core.analysis.expression.diff.DifferentialExpressionAnalysisConfig;
 import ubic.gemma.core.analysis.preprocess.filter.FilteringException;
-import ubic.gemma.core.analysis.preprocess.filter.NoRowsLeftAfterFilteringException;
+import ubic.gemma.core.expression.experiment.ExpressionExperimentMetaFileType;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysisResult;
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
@@ -40,7 +40,6 @@ public interface ExpressionDataFileService extends TsvFileService<ExpressionExpe
 
     String DATA_ARCHIVE_FILE_SUFFIX = ".zip";
     String DATA_DIR = Settings.getString( "gemma.appdata.home" ) + File.separatorChar + "dataFiles" + File.separatorChar;
-    String METADATA_DIR = Settings.getString( "gemma.appdata.home" ) + File.separatorChar + "metadata" + File.separatorChar;
 
     String DATA_FILE_SUFFIX = ".data.txt";
 
@@ -106,6 +105,11 @@ public interface ExpressionDataFileService extends TsvFileService<ExpressionExpe
      * @return File, with location in the appropriate target directory.
      */
     File getOutputFile( String filename, boolean temporary );
+
+    /**
+     * Locate a metadata file.
+     */
+    File getMetadataFile( ExpressionExperiment ee, ExpressionExperimentMetaFileType type );
 
     /**
      * Create a data file containing the 'preferred and masked' expression data matrix, with filtering for low
@@ -226,5 +230,4 @@ public interface ExpressionDataFileService extends TsvFileService<ExpressionExpe
      */
     void writeDiffExArchiveFile( BioAssaySet ee, DifferentialExpressionAnalysis analysis,
             DifferentialExpressionAnalysisConfig config ) throws IOException;
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/ExpressionExperimentMetaFileType.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/ExpressionExperimentMetaFileType.java
@@ -1,0 +1,69 @@
+package ubic.gemma.core.expression.experiment;
+
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+
+import java.io.File;
+
+/**
+ * Types of metadata files that can be attached to an {@link ExpressionExperiment}.
+ */
+public enum ExpressionExperimentMetaFileType {
+
+    BASE_METADATA( 1, ".base.metadata", "Sequence analysis summary", ".seq.analysis.sum.txt", false, true ),
+
+    ALIGNMENT_METADATA( 2, ".alignment.metadata", "Alignment statistics", ".alignment.statistics.txt", false,
+            true ),
+
+    MUTLQC_REPORT( 3, "MultiQCReports" + File.separatorChar + "multiqc_report.html", "Multi-QC Report",
+            ".multiqc.report.html", false, false ),
+
+    ADDITIONAL_PIPELINE_CONFIGURATIONS( 4, "configurations" + File.separatorChar, "Additional pipeline configuration settings",
+            ".pipeline.config.txt", true, false );
+
+    private final int id;
+    private final String fileName;
+    private final String displayName;
+    private final String downloadName;
+    private final boolean isDirectory;
+    private final boolean isNamePrefixed;
+
+
+    /**
+     * @param id             the identifier of the meta file type.
+     * @param fileName       the name of the file in the filesystem.
+     * @param downloadName   the string that will be used as the file name when the user downloads it. This name will always be
+     *                       prefixed with the accession (sort name) of the experiment.
+     * @param displayName    the string that will be displayed publicly to describe this file.
+     * @param isDirectory    whether this file represents a directory.
+     * @param isNamePrefixed whether the fileName has to be prefixed with the experiment accession name.
+     */
+    ExpressionExperimentMetaFileType( int id, String fileName, String displayName, String downloadName, Boolean isDirectory,
+            Boolean isNamePrefixed ) {
+        this.id = id;
+        this.displayName = displayName;
+        this.fileName = fileName;
+        this.downloadName = downloadName;
+        this.isDirectory = isDirectory;
+        this.isNamePrefixed = isNamePrefixed;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getFileName( ExpressionExperiment ee ) {
+        return ( isNamePrefixed ? ee.getShortName() : "" ) + fileName;
+    }
+
+    public boolean isDirectory() {
+        return isDirectory;
+    }
+
+    public String getDownloadName( ExpressionExperiment ee ) {
+        return ee.getShortName() + downloadName;
+    }
+}

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceTest.java
@@ -1,0 +1,118 @@
+package ubic.gemma.core.analysis.service;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.PathUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import ubic.gemma.core.expression.experiment.ExpressionExperimentMetaFileType;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisService;
+import ubic.gemma.persistence.service.association.coexpression.CoexpressionService;
+import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
+import ubic.gemma.persistence.service.expression.bioAssayData.RawAndProcessedExpressionDataVectorService;
+import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.persistence.util.Settings;
+import ubic.gemma.persistence.util.TestComponent;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ContextConfiguration
+public class ExpressionDataFileServiceTest extends AbstractJUnit4SpringContextTests {
+
+    @Configuration
+    @TestComponent
+    static class ExpressionDataFileServiceTestContextConfiguration {
+
+        @Bean
+        public ExpressionDataFileService expressionDataFileService() {
+            return new ExpressionDataFileServiceImpl();
+        }
+
+        @Bean
+        public ArrayDesignService arrayDesignService() {
+            return mock( ArrayDesignService.class );
+        }
+
+        @Bean
+        public DifferentialExpressionAnalysisService differentialExpressionAnalysisService() {
+            return mock( DifferentialExpressionAnalysisService.class );
+        }
+
+        @Bean
+        public ExpressionDataMatrixService expressionDataMatrixService() {
+            return mock( ExpressionDataMatrixService.class );
+        }
+
+        @Bean
+        public ExpressionExperimentService expressionExperimentService() {
+            return mock( ExpressionExperimentService.class );
+        }
+
+        @Bean
+        public CoexpressionService gene2geneCoexpressionService() {
+            return mock( CoexpressionService.class );
+        }
+
+        @Bean
+        public RawAndProcessedExpressionDataVectorService rawAndProcessedExpressionDataVectorService() {
+            return mock( RawAndProcessedExpressionDataVectorService.class );
+        }
+    }
+
+    @Autowired
+    private ExpressionDataFileService expressionDataFileService;
+
+    private Object prevGemmaDataDir;
+    private Path tmpDir;
+
+    @Before
+    public void setUp() throws IOException {
+        tmpDir = Files.createTempDirectory( "gemmaData" );
+        prevGemmaDataDir = Settings.getProperty( "gemma.data.dir" );
+        Settings.setProperty( "gemma.data.dir", tmpDir.toAbsolutePath().toString() );
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        PathUtils.deleteDirectory( tmpDir );
+        Settings.setProperty( "gemma.data.dir", prevGemmaDataDir );
+    }
+
+    @Test
+    public void testGetMetadata() throws IOException {
+        ExpressionExperiment ee = new ExpressionExperiment();
+        ee.setShortName( "test" );
+        File reportFile = tmpDir.resolve( "appdata/metadata/test/MultiQCReports/multiqc_report.html" ).toFile();
+        FileUtils.forceMkdirParent( reportFile );
+        FileUtils.touch( reportFile );
+        assertThat( reportFile ).exists();
+
+        File f = expressionDataFileService.getMetadataFile( ee, ExpressionExperimentMetaFileType.MUTLQC_REPORT );
+        assertThat( f )
+                .exists()
+                .isEqualTo( reportFile );
+
+        ee.setShortName( "test.1" );
+        f = expressionDataFileService.getMetadataFile( ee, ExpressionExperimentMetaFileType.MUTLQC_REPORT );
+        assertThat( f )
+                .isEqualTo( reportFile );
+
+        ee.setShortName( "test.1.2" );
+        f = expressionDataFileService.getMetadataFile( ee, ExpressionExperimentMetaFileType.MUTLQC_REPORT );
+        assertThat( f )
+                .isEqualTo( tmpDir.resolve( "appdata/metadata/test.1/MultiQCReports/multiqc_report.html" ).toFile() );
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentDataFetchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentDataFetchController.java
@@ -34,6 +34,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 import ubic.gemma.core.analysis.preprocess.filter.FilteringException;
 import ubic.gemma.core.analysis.service.ExpressionDataFileService;
+import ubic.gemma.core.expression.experiment.ExpressionExperimentMetaFileType;
 import ubic.gemma.core.job.TaskResult;
 import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.AbstractTask;
@@ -58,15 +59,6 @@ import java.util.*;
 @SuppressWarnings("unused") // Called from JS
 @Controller
 public class ExpressionExperimentDataFetchController {
-
-    private static final MetaFileType[] META_FILE_TYPES = {
-            new MetaFileType( 1, ".base.metadata", "Sequence analysis summary", ".seq.analysis.sum.txt", false, true ),
-            new MetaFileType( 2, ".alignment.metadata", "Alignment statistics", ".alignment.statistics.txt", false,
-                    true ),
-            new MetaFileType( 3, "MultiQCReports" + File.separatorChar + "multiqc_report.html", "Multi-QC Report",
-                    ".multiqc.report.html", false, false ),
-            new MetaFileType( 4, "configurations" + File.separatorChar, "Additional pipeline configuration settings",
-                    ".pipeline.config.txt", true, false ) };
 
     @Autowired
     private TaskRunningService taskRunningService;
@@ -109,23 +101,12 @@ public class ExpressionExperimentDataFetchController {
             }
 
             ExpressionExperiment ee = expressionExperimentService.loadOrFail( Long.parseLong( eeId ) );
-            MetaFileType type = this.getType( Integer.parseInt( typeId ) );
+            ExpressionExperimentMetaFileType type = this.getType( Integer.parseInt( typeId ) );
             if ( type == null ) {
                 throw e;
             }
 
-            String dir = ExpressionDataFileService.METADATA_DIR + this.getEEFolderName( ee ) + File.separatorChar + type
-                    .getFileName( ee );
-
-            File file = new File( dir );
-
-            // If this is a directory, check if we can read the most recent file.
-            if ( type.isDirectory() ) {
-                File fNew = this.getNewestFile( file );
-                if ( fNew != null ) {
-                    file = fNew;
-                }
-            }
+            File file = expressionDataFileService.getMetadataFile( ee, type );
 
             this.download( response, file, type.getDownloadName( ee ) );
 
@@ -147,23 +128,16 @@ public class ExpressionExperimentDataFetchController {
             throw new IllegalArgumentException( "Experiment with given ID does not exist." );
         }
 
-        MetaFile[] metaFiles = new MetaFile[ExpressionExperimentDataFetchController.META_FILE_TYPES.length];
+        MetaFile[] metaFiles = new MetaFile[ExpressionExperimentMetaFileType.values().length];
 
         int i = 0;
-        for ( MetaFileType type : ExpressionExperimentDataFetchController.META_FILE_TYPES ) {
+        for ( ExpressionExperimentMetaFileType type : ExpressionExperimentMetaFileType.values() ) {
 
             // Some files are prefixed with the experiments accession
-            File file = new File(
-                    ExpressionDataFileService.METADATA_DIR + this.getEEFolderName( ee ) + File.separatorChar + type
-                            .getFileName( ee ) );
+            File file = expressionDataFileService.getMetadataFile( ee, type );
 
             // Check if we can read the file
             if ( !file.canRead() ) {
-                continue;
-            }
-
-            // If this is a directory, check if we can read the most recent file.
-            if ( type.isDirectory() && this.getNewestFile( file ) == null ) {
                 continue;
             }
 
@@ -220,41 +194,6 @@ public class ExpressionExperimentDataFetchController {
     }
 
     /**
-     * Forms a folder name where the given experiments metadata will be located (within the {@link ExpressionDataFileService#METADATA_DIR} directory).
-     *
-     * @param ee the experiment to get the folder name for.
-     * @return folder name based on the given experiments properties. Usually this will be the experiments short name,
-     * without any splitting suffixes (e.g. for GSE123.1 the folder name would be GSE123). If the short name is empty for
-     * any reason, the experiments ID will be used.
-     */
-    private String getEEFolderName( ExpressionExperiment ee ) {
-        String sName = ee.getShortName();
-        if ( StringUtils.isBlank( sName ) ) {
-            return ee.getId().toString();
-        }
-        return sName.replaceAll( "\\.\\d+$", "" );
-    }
-
-    /**
-     * @param file a directory to scan
-     * @return the file in the directory that was last modified, or null, if such file doesn't exist or is not readable.
-     */
-    private File getNewestFile( File file ) {
-        File[] files = file.listFiles();
-        if ( files != null && files.length > 0 ) {
-            List<File> fList = Arrays.asList( files );
-
-            // Sort by last modified, we only want the newest file
-            fList.sort( Comparator.comparingLong( File::lastModified ) );
-
-            if ( fList.get( 0 ).canRead() ) {
-                return fList.get( 0 );
-            }
-        }
-        return null;
-    }
-
-    /**
      * @param response     the http response to download to.
      * @param f            the file to download from
      * @param downloadName this string will be used as a download name for the downloaded file. If null, the filesystem name
@@ -281,8 +220,8 @@ public class ExpressionExperimentDataFetchController {
         }
     }
 
-    private MetaFileType getType( int id ) {
-        for ( MetaFileType t : ExpressionExperimentDataFetchController.META_FILE_TYPES ) {
+    private ExpressionExperimentMetaFileType getType( int id ) {
+        for ( ExpressionExperimentMetaFileType t : ExpressionExperimentMetaFileType.values() ) {
             if ( t.getId() == id )
                 return t;
         }
@@ -512,54 +451,5 @@ public class ExpressionExperimentDataFetchController {
 
     }
 
-}
-
-class MetaFileType {
-
-    private int id;
-    private String fileName;
-    private String displayName;
-    private String downloadName;
-    private Boolean isDirectory;
-    private Boolean isNamePrefixed;
-
-    /**
-     * @param id             the identifier of the meta file type.
-     * @param fileName       the name of the file in the filesystem.
-     * @param downloadName   the string that will be used as the file name when the user downloads it. This name will always be
-     *                       prefixed with the accession (sort name) of the experiment.
-     * @param displayName    the string that will be displayed publicly to describe this file.
-     * @param isDirectory    whether this file represents a directory.
-     * @param isNamePrefixed whether the fileName has to be prefixed with the experiment accession name.
-     */
-    MetaFileType( int id, String fileName, String displayName, String downloadName, Boolean isDirectory,
-            Boolean isNamePrefixed ) {
-        this.id = id;
-        this.displayName = displayName;
-        this.fileName = fileName;
-        this.downloadName = downloadName;
-        this.isDirectory = isDirectory;
-        this.isNamePrefixed = isNamePrefixed;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    String getDisplayName() {
-        return displayName;
-    }
-
-    String getFileName( ExpressionExperiment ee ) {
-        return ( isNamePrefixed ? ee.getShortName() : "" ) + fileName;
-    }
-
-    Boolean isDirectory() {
-        return isDirectory;
-    }
-
-    String getDownloadName( ExpressionExperiment ee ) {
-        return ee.getShortName() + downloadName;
-    }
 }
 


### PR DESCRIPTION
Address an issue raised in https://github.com/PavlidisLab/GemmaCuration/issues/127 regarding upload of QC reports from the RNA-Seq pipeline to Gemma.

Some changes were needed so that the CLI could be aware of where those files are to be created.