### PR TITLE
Refactor thaw into BaseDao and BaseService

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/coexpression/links/LinkAnalysisServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/coexpression/links/LinkAnalysisServiceImpl.java
@@ -113,7 +113,7 @@ public class LinkAnalysisServiceImpl implements LinkAnalysisService {
 
             Collection<ProcessedExpressionDataVector> dataVectors = processedExpressionDataVectorService
                     .getProcessedDataVectors( ee );
-            processedExpressionDataVectorService.thaw( dataVectors );
+            dataVectors = processedExpressionDataVectorService.thaw( dataVectors );
 
             LinkAnalysisServiceImpl.log.info( "Starting analysis" );
             this.analyze( ee, filterConfig, linkAnalysisConfig, la, dataVectors );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DiffExAnalyzer.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DiffExAnalyzer.java
@@ -28,6 +28,7 @@ import ubic.gemma.model.genome.Gene;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author paul
@@ -65,7 +66,7 @@ public interface DiffExAnalyzer {
      * @param results        results
      * @return hit list sizes
      */
-    Collection<HitListSize> computeHitListSizes( Collection<DifferentialExpressionAnalysisResult> results,
+    Set<HitListSize> computeHitListSizes( Collection<DifferentialExpressionAnalysisResult> results,
             Map<CompositeSequence, Collection<Gene>> probeToGeneMap );
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceImpl.java
@@ -78,7 +78,7 @@ public class DiffExMetaAnalyzerServiceImpl implements DiffExMetaAnalyzerService 
         /*
          * Second pass. Organize the results by gene
          */
-        Collection<DifferentialExpressionAnalysisResult> res2set = new HashSet<>();
+        Set<DifferentialExpressionAnalysisResult> res2set = new HashSet<>();
         Map<Gene, Collection<DifferentialExpressionAnalysisResult>> gene2result = this
                 .organizeResultsByGene( updatedResultSets, res2set );
 
@@ -418,7 +418,7 @@ public class DiffExMetaAnalyzerServiceImpl implements DiffExMetaAnalyzerService 
                 DiffExMetaAnalyzerServiceImpl.log.warn( "No diff ex result set with ID=" + analysisResultSetId );
                 throw new IllegalArgumentException( "No diff ex result set with ID=" + analysisResultSetId );
             }
-            expressionAnalysisResultSetService.thaw( expressionAnalysisResultSet );
+            expressionAnalysisResultSet = expressionAnalysisResultSetService.thaw( expressionAnalysisResultSet );
             resultSets.add( expressionAnalysisResultSet );
         }
         return resultSets;

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalysisUtil.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalysisUtil.java
@@ -315,7 +315,7 @@ public class DifferentialExpressionAnalysisUtil {
         int numHaveAny = 0;
         for ( BioMaterial b : biomaterials ) {
             Collection<FactorValue> biomaterialFactorValues = b.getFactorValues();
-            Collection<FactorValue> factorValuesToConsider = new HashSet<>( biomaterialFactorValues );
+            Set<FactorValue> factorValuesToConsider = new HashSet<>( biomaterialFactorValues );
             for ( FactorValue biomaterialFactorValue : biomaterialFactorValues ) {
                 numHaveAny++;
                 if ( !allFactorValuesFromGivenFactors.contains( biomaterialFactorValue ) ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceImpl.java
@@ -123,7 +123,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
          * One way to do this is redo without saving, and then copy the results over to the given result sets that
          * match. But that requires matching up old and new result sets.
          */
-        differentialExpressionAnalysisService.thaw( toUpdate );
+        toUpdate = differentialExpressionAnalysisService.thaw( toUpdate );
         DifferentialExpressionAnalysisConfig config = this.copyConfig( toUpdate );
 
         Collection<DifferentialExpressionAnalysis> results = this.redoWithoutSave( ee, toUpdate, config );
@@ -142,8 +142,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     public Collection<DifferentialExpressionAnalysis> getAnalyses( ExpressionExperiment expressionExperiment ) {
         Collection<DifferentialExpressionAnalysis> expressionAnalyses = differentialExpressionAnalysisService
                 .getAnalyses( expressionExperiment );
-        differentialExpressionAnalysisService.thaw( expressionAnalyses );
-        return expressionAnalyses;
+        return differentialExpressionAnalysisService.thaw( expressionAnalyses );
     }
 
     @Override
@@ -157,7 +156,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
                             + "Delete the constraining entity first." );
         }
 
-        differentialExpressionAnalysisService.thaw( copyMe );
+        copyMe = differentialExpressionAnalysisService.thaw( copyMe );
 
         DifferentialExpressionAnalyzerServiceImpl.log.info( "Will base analysis on old one: " + copyMe );
         DifferentialExpressionAnalysisConfig config = this.copyConfig( copyMe );
@@ -373,7 +372,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
             return;
         }
 
-        this.differentialExpressionAnalysisService.thaw( diffAnalyses );
+        diffAnalyses = this.differentialExpressionAnalysisService.thaw( diffAnalyses );
 
         for ( DifferentialExpressionAnalysis existingAnalysis : diffAnalyses ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceImpl.java
@@ -23,7 +23,8 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.basecode.io.ByteArrayConverter;
 import ubic.basecode.math.distribution.Histogram;
 import ubic.basecode.util.FileTools;
@@ -37,7 +38,6 @@ import ubic.gemma.model.common.auditAndSecurity.eventType.FailedDifferentialExpr
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.*;
 import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisService;
-import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionResultService;
 import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
 import ubic.gemma.persistence.service.common.auditAndSecurity.AuditTrailService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
@@ -54,7 +54,7 @@ import java.util.*;
  *
  * @author keshav
  */
-@Component
+@Service
 public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialExpressionAnalyzerService {
 
     private static final Log log = LogFactory.getLog( DifferentialExpressionAnalyzerServiceImpl.class );
@@ -74,6 +74,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     private ExpressionAnalysisResultSetService expressionAnalysisResultSetService;
 
     @Override
+    @Transactional
     public int deleteAnalyses( ExpressionExperiment expressionExperiment ) {
         Collection<DifferentialExpressionAnalysis> diffAnalysis = differentialExpressionAnalysisService
                 .findByInvestigation( expressionExperiment );
@@ -101,6 +102,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     }
 
     @Override
+    @Transactional
     public void deleteAnalysis( ExpressionExperiment expressionExperiment,
             DifferentialExpressionAnalysis existingAnalysis ) {
         DifferentialExpressionAnalyzerServiceImpl.log
@@ -113,6 +115,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     }
 
     @Override
+    @Transactional
     public Collection<ExpressionAnalysisResultSet> extendAnalysis( ExpressionExperiment ee,
             DifferentialExpressionAnalysis toUpdate ) {
 
@@ -135,6 +138,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<DifferentialExpressionAnalysis> getAnalyses( ExpressionExperiment expressionExperiment ) {
         Collection<DifferentialExpressionAnalysis> expressionAnalyses = differentialExpressionAnalysisService
                 .getAnalyses( expressionExperiment );
@@ -143,6 +147,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     }
 
     @Override
+    @Transactional
     public Collection<DifferentialExpressionAnalysis> redoAnalysis( ExpressionExperiment ee,
             DifferentialExpressionAnalysis copyMe, boolean persist ) {
 
@@ -167,6 +172,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
     }
 
     @Override
+    @Transactional
     public Collection<DifferentialExpressionAnalysis> runDifferentialExpressionAnalyses(
             ExpressionExperiment expressionExperiment, DifferentialExpressionAnalysisConfig config ) {
         try {
@@ -207,6 +213,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
      * @return DEA
      */
     @Override
+    @Transactional
     public DifferentialExpressionAnalysis persistAnalysis( ExpressionExperiment expressionExperiment,
             DifferentialExpressionAnalysis analysis, DifferentialExpressionAnalysisConfig config ) {
 
@@ -279,8 +286,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
      * @param ee       the experiment
      * @param analysis analysis
      */
-    @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
-    public void deleteStatistics( ExpressionExperiment ee, DifferentialExpressionAnalysis analysis ) {
+    private void deleteStatistics( ExpressionExperiment ee, DifferentialExpressionAnalysis analysis ) {
 
         File f = this.prepareDirectoryForDistributions( ee );
 
@@ -443,7 +449,7 @@ public class DifferentialExpressionAnalyzerServiceImpl implements DifferentialEx
             for ( ExpressionAnalysisResultSet oldrs : toUpdateResultSets ) {
 
                 assert oldrs.getId() != null;
-                expressionAnalysisResultSetService.thaw( oldrs );
+                oldrs = expressionAnalysisResultSetService.thaw( oldrs );
 
                 for ( ExpressionAnalysisResultSet temprs : a.getResultSets() ) {
                     /*

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessingException.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessingException.java
@@ -26,8 +26,8 @@ public class PreprocessingException extends Exception {
 
     private static final long serialVersionUID = -8463478950898408838L;
 
-    public PreprocessingException( Exception e ) {
-        super( e );
+    public PreprocessingException( Throwable cause ) {
+        super( cause );
     }
 
     public PreprocessingException( String message ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessorService.java
@@ -21,16 +21,28 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
  */
 public interface PreprocessorService {
 
+    /**
+     * Preprocess the given experiment, which consist of the following steps:
+     *
+     *  * remove invalidated date
+     *  * process missing values
+     *  * compute processed expression data
+     *  * perform batch correction and diagnostics
+     *  * recalculate experiment batch information
+     *
+     * @param ee an EE to be pre-processed
+     * @return a pre-processed EE which you should use as a replacement
+     * @throws PreprocessingException if any aforementioned step fails
+     */
     ExpressionExperiment process( ExpressionExperiment ee ) throws PreprocessingException;
 
     /**
+     * This is a light flavour of {@link #process(ExpressionExperiment)} used solely in {@link ubic.gemma.core.apps.TwoChannelMissingValueCLI}.
+     *
      * @param  ee                     the experiment
-     * @param  light                  if true, just do the bare minimum. The following are skipped: two-channel missing
-     *                                values; redoing
-     *                                differential expression; batch correction.
      * @throws PreprocessingException if there was a problem during the processing
      */
-    void process( ExpressionExperiment ee, boolean light ) throws PreprocessingException;
+    void processLight( ExpressionExperiment ee ) throws PreprocessingException;
 
     /**
      * If possible, batch correct the processed data vectors. This entails repeating the other preprocessing steps. But
@@ -50,9 +62,9 @@ public interface PreprocessorService {
     /**
      * Create or update the sample correlation, PCA and M-V data. This is also done as part of process so should only be
      * called if only a refresh is needed.
-     * 
+     *
      * @param ee to be processed
      */
-    void processDiagnostics( ExpressionExperiment ee );
+    void processDiagnostics( ExpressionExperiment ee ) throws PreprocessingException;
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessorServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessorServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.core.analysis.expression.diff.DifferentialExpressionAnalyzerService;
 import ubic.gemma.core.analysis.preprocess.batcheffects.ExpressionExperimentBatchCorrectionService;
-import ubic.gemma.core.analysis.preprocess.filter.NoRowsLeftAfterFilteringException;
 import ubic.gemma.core.analysis.preprocess.svd.SVDServiceHelper;
 import ubic.gemma.core.analysis.report.ExpressionExperimentReportService;
 import ubic.gemma.core.analysis.service.ExpressionDataFileService;

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessorServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/PreprocessorServiceImpl.java
@@ -110,7 +110,7 @@ public class PreprocessorServiceImpl implements PreprocessorService {
     private GeeqService geeqService;
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = PreprocessingException.class)
     public ExpressionExperiment process( ExpressionExperiment ee ) throws PreprocessingException {
 
         ee = expressionExperimentService.thaw( ee );
@@ -131,7 +131,7 @@ public class PreprocessorServiceImpl implements PreprocessorService {
      * Only used for TwoChannelMissingValueCLI? Possibly redundant? FIXME
      */
     @Override
-    @Transactional
+    @Transactional(rollbackFor = PreprocessingException.class)
     public void processLight( ExpressionExperiment ee ) throws PreprocessingException {
         try {
             // we dont do processForMissingValues missing values
@@ -149,7 +149,7 @@ public class PreprocessorServiceImpl implements PreprocessorService {
      * updated
      */
     @Override
-    @Transactional
+    @Transactional(rollbackFor = PreprocessingException.class)
     public void batchCorrect( ExpressionExperiment ee, boolean force ) throws PreprocessingException {
         String note = "ComBat batch correction";
         String detail = null;
@@ -277,7 +277,7 @@ public class PreprocessorServiceImpl implements PreprocessorService {
      * @param ee
      */
     @Override
-    @Transactional
+    @Transactional(rollbackFor = PreprocessingException.class)
     public void processDiagnostics( ExpressionExperiment ee ) throws PreprocessingException {
         this.processForSampleCorrelation( ee );
         this.processForMeanVarianceRelation( ee );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataVectorCreateHelperServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataVectorCreateHelperServiceImpl.java
@@ -254,11 +254,13 @@ public class ProcessedExpressionDataVectorCreateHelperServiceImpl
      * @return expression ranks based on computed intensities
      */
     @Override
+    @Transactional(readOnly = true)
     public ExpressionExperiment updateRanks( ExpressionExperiment ee ) {
 
-        ee = expressionExperimentDao.thaw( ee );
+        ee = expressionExperimentDao.load( ee.getId() );
+        expressionExperimentDao.thaw( ee );
         Collection<ProcessedExpressionDataVector> processedVectors = ee.getProcessedExpressionDataVectors();
-        processedExpressionDataVectorService.thaw( processedVectors );
+        processedVectors = processedExpressionDataVectorService.thaw( processedVectors );
         StopWatch timer = new StopWatch();
         timer.start();
         ExpressionDataDoubleMatrix intensities = this.loadIntensities( ee, processedVectors );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataVectorCreateHelperServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataVectorCreateHelperServiceImpl.java
@@ -328,7 +328,7 @@ public class ProcessedExpressionDataVectorCreateHelperServiceImpl
 
             ProcessedExpressionDataVectorCreateHelperServiceImpl.log.info( "Vectors loaded ..." );
 
-            Collection<DesignElementDataVector> vs = new HashSet<>( vectors );
+            Collection<? extends DesignElementDataVector> vs = new HashSet<>( vectors );
             rawExpressionDataVectorService.thawRawAndProcessed( vs );
             ExpressionDataMatrixBuilder builder = new ExpressionDataMatrixBuilder( processedVectors, vectors );
             intensities = builder.getIntensity();

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataVectorCreateHelperServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataVectorCreateHelperServiceImpl.java
@@ -254,7 +254,7 @@ public class ProcessedExpressionDataVectorCreateHelperServiceImpl
      * @return expression ranks based on computed intensities
      */
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public ExpressionExperiment updateRanks( ExpressionExperiment ee ) {
 
         ee = expressionExperimentDao.load( ee.getId() );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/SplitExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/SplitExperimentServiceImpl.java
@@ -1,8 +1,8 @@
 /*
  * The gemma-core project
- * 
+ *
  * Copyright (c) 2018 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,12 +19,7 @@
 
 package ubic.gemma.core.analysis.preprocess;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -60,11 +55,11 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentSetService;
 
 /**
- * 
+ *
  * Split an experiment into multiple experiments. This is needed when a load EE (e.g. from GEO) is better represented as
  * two more more distinct experiments. The decision of what to split is based on curation guidelines documented
  * elsewhere.
- * 
+ *
  * @author paul
  */
 @Service
@@ -98,11 +93,12 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService#split(ubic.gemma.model.
      * expression.experiment.ExpressionExperiment, ubic.gemma.model.expression.experiment.ExperimentalFactor)
      */
     @Override
+    @Transactional
     public Collection<ExpressionExperiment> split( ExpressionExperiment toSplit, ExperimentalFactor splitOn, boolean postProcess ) {
 
         toSplit = eeService.thawLite( toSplit );
@@ -137,7 +133,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
                 }
 
                 Collection<RawExpressionDataVector> vecs = rawExpressionDataVectorService.find( qt );
-                rawExpressionDataVectorService.thaw( vecs );
+                vecs = rawExpressionDataVectorService.thaw( vecs );
                 if ( vecs.isEmpty() ) {
                     // this is okay if the data is processed, or if we have stray orphaned QTs
                     log.debug( "No raw vectors for " + qt + "; preferred=" + qt.getIsPreferred() );
@@ -360,7 +356,6 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
         return result;
     }
 
-    @Transactional
     private void enforceOtherParts( Collection<ExpressionExperiment> result ) {
         // Enforce relation to other parts of the split.
         for ( ExpressionExperiment split : result ) {
@@ -374,7 +369,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
     /**
      * @param  experimentalDesign
      * @param  old2cloneFV
-     * @return                    non-persistent clone
+     * @return non-persistent clone
      */
     private ExperimentalDesign cloneExperimentalDesign( ExperimentalDesign experimentalDesign, Map<FactorValue, FactorValue> old2cloneFV ) {
         ExperimentalDesign clone = ExperimentalDesign.Factory.newInstance();
@@ -395,7 +390,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
      * @param  experimentalFactors
      * @param  experimentalDesign
      * @param  old2cloneFV
-     * @return                     non-persistent clones
+     * @return non-persistent clones
      */
     private Collection<ExperimentalFactor> cloneExperimentalFactors( Collection<ExperimentalFactor> experimentalFactors, ExperimentalDesign ed,
             Map<FactorValue, FactorValue> old2cloneFV ) {
@@ -418,7 +413,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
     /**
      * @param  factorValues
      * @param  old2cloneFV
-     * @return              non-persistent clone
+     * @return non-persistent clone
      */
     private Collection<FactorValue> cloneFactorValues( Collection<FactorValue> factorValues, ExperimentalFactor ef,
             Map<FactorValue, FactorValue> old2cloneFV ) {
@@ -439,7 +434,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * @param  measurement
-     * @return             non-persistent clone
+     * @return non-persistent clone
      */
     private Measurement cloneMeasurement( Measurement measurement ) {
 
@@ -456,7 +451,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * @param  qt
-     * @return    clone
+     * @return clone
      */
     private QuantitationType cloneQt( QuantitationType qt, ExpressionExperiment split ) {
         QuantitationType clone = QuantitationType.Factory.newInstance();
@@ -480,10 +475,10 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * @param  ch
-     * @return    clones
+     * @return clones
      */
-    private Collection<Characteristic> cloneCharacteristics( Collection<Characteristic> ch ) {
-        Collection<Characteristic> result = new HashSet<>();
+    private Set<Characteristic> cloneCharacteristics( Collection<Characteristic> ch ) {
+        Set<Characteristic> result = new HashSet<>();
         for ( Characteristic c : ch ) {
             Characteristic clone = cloneCharacteristic( c );
 
@@ -495,7 +490,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * @param  c
-     * @return   clone
+     * @return clone
      */
     private Characteristic cloneCharacteristic( Characteristic c ) {
         Characteristic clone = Characteristic.Factory.newInstance( c.getName(), c.getDescription(), c.getValue(), c.getValueUri(),
@@ -505,9 +500,9 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * Deeply clone a bioAssay
-     * 
+     *
      * @param  ba
-     * @return    non-persistent clone
+     * @return non-persistent clone
      */
     private BioAssay cloneBioAssay( BioAssay ba ) {
         BioAssay clone = BioAssay.Factory.newInstance();
@@ -532,7 +527,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * @param  de databse entry
-     * @return    non-persistent clone
+     * @return non-persistent clone
      */
     private DatabaseEntry cloneAccession( DatabaseEntry de ) {
         if ( de == null ) return null;
@@ -543,7 +538,7 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
     /**
      * @param  bm biomaterial
      * @param  ba bioassay
-     * @return    non-persistent clone
+     * @return non-persistent clone
      */
     private BioMaterial cloneBioMaterial( BioMaterial bm, BioAssay ba ) {
         BioMaterial clone = BioMaterial.Factory.newInstance();
@@ -563,10 +558,10 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
 
     /**
      * @param  treatments
-     * @return            non-persistent clones
+     * @return non-persistent clones
      */
-    private Collection<Treatment> cloneTreatments( Collection<Treatment> ts ) {
-        Collection<Treatment> result = new HashSet<>();
+    private Set<Treatment> cloneTreatments( Collection<Treatment> ts ) {
+        Set<Treatment> result = new HashSet<>();
         for ( Treatment t : ts ) {
             Treatment clone = Treatment.Factory.newInstance();
             clone.setDescription( t.getDescription() );
@@ -579,10 +574,10 @@ public class SplitExperimentServiceImpl implements SplitExperimentService {
     }
 
     /**
-     * 
+     *
      * @param  samplesToUse (cloned)
      * @param  ee
-     * @return              non-persistent populated BAD
+     * @return non-persistent populated BAD
      */
     private BioAssayDimension makeBioAssayDimension( List<BioMaterial> samplesToUse, ExpressionExperiment ee ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/TwoChannelMissingValuesImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/TwoChannelMissingValuesImpl.java
@@ -112,9 +112,9 @@ public class TwoChannelMissingValuesImpl implements TwoChannelMissingValues {
 
         if ( rawVectors.isEmpty() ) {
             procVectors = processedExpressionDataVectorService.find( usefulQuantitationTypes );
-            processedExpressionDataVectorService.thaw( procVectors );
+            procVectors = processedExpressionDataVectorService.thaw( procVectors );
         } else {
-            rawExpressionDataVectorService.thaw( rawVectors );
+            rawVectors = rawExpressionDataVectorService.thaw( rawVectors );
         }
 
         timer.stop();

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/VectorMergingServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/VectorMergingServiceImpl.java
@@ -111,7 +111,7 @@ public class VectorMergingServiceImpl extends ExpressionExperimentVectorManipula
         /*
          * Load all the bioassay dimensions, which will be merged.
          */
-        Collection<BioAssayDimension> allOldBioAssayDims = new HashSet<>();
+        Set<BioAssayDimension> allOldBioAssayDims = new HashSet<>();
         for ( BioAssay ba : ee.getBioAssays() ) {
             Collection<BioAssayDimension> oldBioAssayDims = bioAssayService.findBioAssayDimensions( ba );
             for ( BioAssayDimension bioAssayDim : oldBioAssayDims ) {
@@ -437,7 +437,7 @@ public class VectorMergingServiceImpl extends ExpressionExperimentVectorManipula
             throw new IllegalStateException( "No vectors" );
         }
 
-        rawExpressionDataVectorService.thaw( oldVectors );
+        oldVectors = rawExpressionDataVectorService.thaw( oldVectors );
         Map<QuantitationType, Collection<RawExpressionDataVector>> qt2Vec = new HashMap<>();
         Collection<QuantitationType> qtsToAdd = new HashSet<>();
         for ( RawExpressionDataVector v : oldVectors ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/batcheffects/BatchInfoPopulationServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/batcheffects/BatchInfoPopulationServiceImpl.java
@@ -35,6 +35,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.core.analysis.util.ExperimentalDesignUtils;
 import ubic.gemma.core.loader.expression.geo.fetcher.RawDataFetcher;
 import ubic.gemma.model.common.auditAndSecurity.AuditEvent;
@@ -64,7 +66,7 @@ import ubic.gemma.persistence.util.Settings;
  *
  * @author paul
  */
-@Component
+@Service
 public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationService {
 
     /**
@@ -87,7 +89,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
 
     /**
      * @param  ef ef
-     * @return    true if the factor seems to be a 'batch' factor.
+     * @return true if the factor seems to be a 'batch' factor.
      */
     public static boolean isBatchFactor( ExperimentalFactor ef ) {
         Characteristic c = ef.getCategory();
@@ -125,6 +127,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
     private ExpressionExperimentService expressionExperimentService = null;
 
     @Override
+    @Transactional
     public void fillBatchInformation( ExpressionExperiment ee, boolean force ) throws BatchInfoPopulationException {
 
         boolean isRNASeq = expressionExperimentService.isRNASeq( ee );
@@ -169,7 +172,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
      * Exposed for testing
      *
      * @param  accession             GEO accession
-     * @return                       map of GEO id to headers, including the platform ID
+     * @return map of GEO id to headers, including the platform ID
      * @throws IOException
      * @throws FileNotFoundException
      */
@@ -177,7 +180,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
         Map<String, String> result = new HashMap<>();
         File headerFile = new File( Settings.getString( GEMMA_FASTQ_HEADERS_DIR_CONFIG ) + File.separator
                 + accession + FASTQHEADERSFILE_SUFFIX );
-        try (BufferedReader br = new BufferedReader( new FileReader( headerFile ) )) {
+        try ( BufferedReader br = new BufferedReader( new FileReader( headerFile ) ) ) {
             String line = null;
             while ( ( line = br.readLine() ) != null ) {
 
@@ -203,7 +206,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
      * Currently only supports GEO
      *
      * @param  ee ee
-     * @return    local file
+     * @return local file
      */
     private Collection<LocalFile> fetchRawDataFiles( ExpressionExperiment ee ) {
         RawDataFetcher fetcher = new RawDataFetcher();
@@ -261,7 +264,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
      *
      * @param  files Local copies of raw data files obtained from the data provider (e.g. GEO), adds audit event.
      * @param  ee    ee
-     * @return       boolean
+     * @return boolean
      */
     private void getBatchDataFromRawFiles( ExpressionExperiment ee, Collection<LocalFile> files ) throws BatchInfoPopulationException {
         BatchInfoParser batchInfoParser = new BatchInfoParser();
@@ -309,7 +312,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
      * Finds FASTQ headers
      *
      * @param  ee          experiment
-     * @return             map of Biomaterial to header
+     * @return map of Biomaterial to header
      * @throws IOException if any files could not be read
      */
     private Map<BioMaterial, String> getFastqHeaders( ExpressionExperiment ee ) throws IOException {
@@ -372,7 +375,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
     /**
      * @param  ee     ee
      * @param  rnaSeq if the data set is RNAseq
-     * @return        true if it needs processing and data is available
+     * @return true if it needs processing and data is available
      */
     private boolean needToRun( ExpressionExperiment ee, boolean rnaSeq ) {
 
@@ -432,7 +435,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
      * </pre>
      *
      * @param  ee experiment
-     * @return    map of GEO id to headers, including the platform ID
+     * @return map of GEO id to headers, including the platform ID
      */
     private Map<String, String> readFastqHeaders( ExpressionExperiment ee ) throws IOException {
         String accession = ee.getAccession().getAccession();

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/batcheffects/BatchInfoPopulationServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/batcheffects/BatchInfoPopulationServiceImpl.java
@@ -127,7 +127,7 @@ public class BatchInfoPopulationServiceImpl implements BatchInfoPopulationServic
     private ExpressionExperimentService expressionExperimentService = null;
 
     @Override
-    @Transactional
+    @Transactional(rollbackFor = BatchInfoPopulationException.class)
     public void fillBatchInformation( ExpressionExperiment ee, boolean force ) throws BatchInfoPopulationException {
 
         boolean isRNASeq = expressionExperimentService.isRNASeq( ee );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/batcheffects/ExpressionExperimentBatchCorrectionServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/batcheffects/ExpressionExperimentBatchCorrectionServiceImpl.java
@@ -156,7 +156,7 @@ public class ExpressionExperimentBatchCorrectionServiceImpl implements Expressio
          */
         Collection<ProcessedExpressionDataVector> vectos = processedExpressionDataVectorService
                 .getProcessedDataVectors( ee );
-        processedExpressionDataVectorService.thaw( vectos );
+        vectos = processedExpressionDataVectorService.thaw( vectos );
         ExpressionDataDoubleMatrix mat = new ExpressionDataDoubleMatrix( vectos );
 
         return this.comBat( mat );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/svd/SVDServiceHelperImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/svd/SVDServiceHelperImpl.java
@@ -87,7 +87,7 @@ public class SVDServiceHelperImpl implements SVDServiceHelper {
 
     /**
      * Retrieve relationships between factors, biomaterials and factorvalues.
-     * 
+     *
      * @param bioMaterialFactorMap to be populated, of experimental factor -> biomaterial ID -> ID of the factor value
      *                             (just an indicator)
      * @param biomaterial          to populate for
@@ -159,7 +159,7 @@ public class SVDServiceHelperImpl implements SVDServiceHelper {
             throw new IllegalArgumentException( "Experiment must have processed data already to do SVD" );
         }
 
-        processedExpressionDataVectorService.thaw( vectors );
+        vectors = processedExpressionDataVectorService.thaw( vectors );
         ExpressionDataDoubleMatrix mat = new ExpressionDataDoubleMatrix( vectors );
 
         SVDServiceHelperImpl.log.info( "Starting SVD" );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/svd/SVDServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/preprocess/svd/SVDServiceImpl.java
@@ -1,13 +1,13 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2011 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -57,11 +57,11 @@ public class SVDServiceImpl implements SVDService {
     @Override
     public Map<ProbeLoading, DoubleVectorValueObject> getTopLoadedVectors( Long eeId, int component, int count ) {
 
-        ExpressionExperiment ee = expressionExperimentService.load( eeId );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawBioAssays( eeId );
 
         if ( ee == null ) return null;
 
-        return svdServiceHelper.getTopLoadedVectors( expressionExperimentService.thawBioAssays( ee ), component, count );
+        return svdServiceHelper.getTopLoadedVectors( ee, component, count );
 
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/report/ExpressionExperimentReportServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/report/ExpressionExperimentReportServiceImpl.java
@@ -450,7 +450,7 @@ public class ExpressionExperimentReportServiceImpl implements ExpressionExperime
         Long id = eeVo.getId();
         assert id != null;
 
-        Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> analysis = differentialExpressionAnalysisService
+        Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> analysis = differentialExpressionAnalysisService
                 .getAnalysesByExperiment( Collections.singleton( id ) );
         if ( analysis != null && analysis.containsKey( eeVo ) ) {
             eeVo.setDifferentialExpressionAnalyses( analysis.get( eeVo ) );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/sequence/ArrayDesignMapResultServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/sequence/ArrayDesignMapResultServiceImpl.java
@@ -189,7 +189,7 @@ public class ArrayDesignMapResultServiceImpl implements ArrayDesignMapResultServ
             summary.setBlatResults( blats );
 
             Collection<BlatAssociation> maps = blatAssociationService.find( bioSequence );
-            blatAssociationService.thaw( maps );
+            maps = blatAssociationService.thaw( maps );
             for ( BlatAssociation association : maps ) {
                 summary.getGeneProducts().add( association.getGeneProduct() );
                 summary.getGenes().add( association.getGeneProduct().getGene() );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionAnalysisResultSetFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionAnalysisResultSetFileServiceImpl.java
@@ -30,10 +30,10 @@ public class ExpressionAnalysisResultSetFileServiceImpl extends AbstractTsvFileS
         // we need to peek in the contrast result to understand factor value interactions
         // i.e. interaction between genotype and time point might result in a contrast_male_3h column, although we would
         // use factor value IDs in the actual column name which might result in something like contrast_1292_2938
-        final Collection<ContrastResult> firstContrastResults = analysisResultSet.getResults().stream()
+        final Set<ContrastResult> firstContrastResults = analysisResultSet.getResults().stream()
                 .findFirst()
                 .map( DifferentialExpressionAnalysisResult::getContrasts )
-                .orElse( Collections.emptyList() );
+                .orElse( Collections.emptySet() );
 
         // this is the order the factor values are displayed
         Comparator<ContrastResult> contrastResultComparator = Comparator

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
@@ -77,36 +77,6 @@ public interface ExpressionDataFileService extends TsvFileService<ExpressionExpe
     File getDiffExpressionAnalysisArchiveFile( Long analysisId, boolean forceCreate );
 
     /**
-     * @param ee       the experiment
-     * @param filtered if the data matrix is filtered
-     * @return file
-     */
-    File getOutputFile( ExpressionExperiment ee, boolean filtered );
-
-    /**
-     * @param filtered   if the data matrix is filtered
-     * @param compressed if the filename should have a .gz extension
-     * @param temporary  if you want the file to be saved in the configuration file temporary location
-     * @param ee         the experiment
-     * @return file
-     */
-    File getOutputFile( ExpressionExperiment ee, boolean filtered, boolean compressed, boolean temporary );
-
-    /**
-     * @param filename without the path - that is, just the name of the file
-     * @return File, with location in the appropriate target directory.
-     */
-    File getOutputFile( String filename );
-
-    /**
-     * @param filename   without the path - that is, just the name of the file
-     * @param temporary, if this is true then the file gets saved to the temporary location from the
-     *                   configuration file
-     * @return File, with location in the appropriate target directory.
-     */
-    File getOutputFile( String filename, boolean temporary );
-
-    /**
      * Create a data file containing the 'preferred and masked' expression data matrix, with filtering for low
      * expression applied (currently supports default settings only).
      *

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -31,7 +31,6 @@ import ubic.gemma.core.analysis.expression.diff.DifferentialExpressionAnalysisCo
 import ubic.gemma.core.analysis.preprocess.ExpressionDataMatrixBuilder;
 import ubic.gemma.core.analysis.preprocess.filter.FilterConfig;
 import ubic.gemma.core.analysis.preprocess.filter.FilteringException;
-import ubic.gemma.core.analysis.preprocess.filter.NoRowsLeftAfterFilteringException;
 import ubic.gemma.core.datastructure.matrix.ExperimentalDesignWriter;
 import ubic.gemma.core.datastructure.matrix.ExpressionDataDoubleMatrix;
 import ubic.gemma.core.datastructure.matrix.ExpressionDataMatrix;
@@ -103,6 +102,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     private RawExpressionDataVectorService rawExpressionDataVectorService;
 
     @Override
+    @Transactional(readOnly = true)
     public void analysisResultSetsToString( Collection<ExpressionAnalysisResultSet> results,
             Map<Long, String[]> geneAnnotations, StringBuilder buf ) {
         Map<Long, StringBuilder> probe2String = new HashMap<>();
@@ -137,6 +137,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<DifferentialExpressionAnalysisResult> analysisResultSetToString( ExpressionAnalysisResultSet ears,
             Map<Long, String[]> geneAnnotations, StringBuilder buf, Map<Long, StringBuilder> probe2String,
             List<DifferentialExpressionAnalysisResult> sortedFirstColumnOfResults ) {
@@ -202,6 +203,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
 
 
     @Override
+    @Transactional(readOnly = true)
     public void deleteAllFiles( ExpressionExperiment ee ) {
         ee = this.expressionExperimentService.thawLite( ee );
 
@@ -230,18 +232,17 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File getDiffExpressionAnalysisArchiveFile( Long analysisId, boolean forceCreate ) {
         DifferentialExpressionAnalysis analysis = this.differentialExpressionAnalysisService.load( analysisId );
         return getDiffExpressionAnalysisArchiveFile( analysis, forceCreate );
     }
 
-    @Override
-    public File getOutputFile( ExpressionExperiment ee, boolean filtered ) {
+    private File getOutputFile( ExpressionExperiment ee, boolean filtered ) {
         return this.getOutputFile( ee, filtered, true, false );
     }
 
-    @Override
-    public File getOutputFile( ExpressionExperiment ee, boolean filtered, boolean compressed, boolean temporary ) {
+    private File getOutputFile( ExpressionExperiment ee, boolean filtered, boolean compressed, boolean temporary ) {
         String filteredAdd = "";
         if ( !filtered ) {
             filteredAdd = ".unfilt";
@@ -266,14 +267,12 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
         return this.getOutputFile( filename, temporary );
     }
 
-    @Override
-    public File getOutputFile( String filename ) {
+    private File getOutputFile( String filename ) {
         return this.getOutputFile( filename, false );
 
     }
 
-    @Override
-    public File getOutputFile( String filename, boolean temporary ) {
+    private File getOutputFile( String filename, boolean temporary ) {
         String fullFilePath;
         if ( temporary ) {
             fullFilePath = ExpressionDataFileService.TMP_DATA_DIR + filename;
@@ -291,6 +290,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeDataFile( ExpressionExperiment ee, boolean filtered, String fileName, boolean compress )
             throws IOException, FilteringException {
         File f = new File( fileName );
@@ -298,6 +298,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void writeDiffExArchiveFile( BioAssaySet experimentAnalyzed, DifferentialExpressionAnalysis analysis,
             DifferentialExpressionAnalysisConfig config ) throws IOException {
         Collection<ArrayDesign> arrayDesigns = this.expressionExperimentService
@@ -344,6 +345,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeOrLocateCoexpressionDataFile( ExpressionExperiment ee, boolean forceWrite ) {
 
         ee = expressionExperimentService.thawLite( ee );
@@ -364,6 +366,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeOrLocateDataFile( ExpressionExperiment ee, boolean forceWrite, boolean filtered ) throws FilteringException {
         try {
             File f = this.getOutputFile( ee, filtered );
@@ -381,6 +384,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeOrLocateDataFile( QuantitationType type, boolean forceWrite ) {
 
         try {
@@ -410,6 +414,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeOrLocateDesignFile( ExpressionExperiment ee, boolean forceWrite ) {
         ee = expressionExperimentService.thawLite( ee );
         try {
@@ -428,6 +433,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<File> writeOrLocateDiffExpressionDataFiles( ExpressionExperiment ee, boolean forceWrite ) {
 
         ee = this.expressionExperimentService.thawLite( ee );
@@ -445,6 +451,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeOrLocateJSONDataFile( ExpressionExperiment ee, boolean forceWrite, boolean filtered ) throws FilteringException {
 
         try {
@@ -465,6 +472,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File writeOrLocateJSONDataFile( QuantitationType type, boolean forceWrite ) {
 
         try {

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -317,7 +317,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
             zipOut.closeEntry();
 
             if ( analysis.getId() != null ) // might be transient if using -nodb from CLI
-                differentialExpressionAnalysisService.thaw( analysis );
+                analysis = differentialExpressionAnalysisService.thaw( analysis );
 
             // Add a file for each result set with contrasts information.
             int i = 0;
@@ -870,7 +870,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
             DifferentialExpressionAnalysisConfig config ) {
 
         if ( analysis.getId() != null ) // It might not be a persistent analysis: using -nodb
-            differentialExpressionAnalysisService.thaw( analysis );
+            analysis = differentialExpressionAnalysisService.thaw( analysis );
 
         StringBuilder buf = new StringBuilder();
 

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.basecode.util.FileTools;
 import ubic.basecode.util.StringUtil;
 import ubic.gemma.core.analysis.expression.diff.DifferentialExpressionAnalysisConfig;

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -397,7 +397,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
             ExpressionDataFileServiceImpl.log
                     .info( "Creating new quantitation type expression data file: " + f.getName() );
 
-            Collection<DesignElementDataVector> vectors = rawExpressionDataVectorService.findRawAndProcessed( type );
+            Collection<? extends DesignElementDataVector> vectors = rawExpressionDataVectorService.findRawAndProcessed( type );
             Collection<ArrayDesign> arrayDesigns = this.getArrayDesigns( vectors );
             Map<CompositeSequence, String[]> geneAnnotations = this.getGeneAnnotationsAsStringsByProbe( arrayDesigns );
 
@@ -484,7 +484,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
 
             ExpressionDataFileServiceImpl.log.info( "Creating new quantitation type  JSON data file: " + f.getName() );
 
-            Collection<DesignElementDataVector> vectors = rawExpressionDataVectorService.findRawAndProcessed( type );
+            Collection<? extends DesignElementDataVector> vectors = rawExpressionDataVectorService.findRawAndProcessed( type );
 
             if ( vectors.size() == 0 ) {
                 ExpressionDataFileServiceImpl.log.warn( "No vectors for " + type );
@@ -1092,7 +1092,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
         return file;
     }
 
-    private void writeJson( File file, Collection<DesignElementDataVector> vectors ) throws IOException {
+    private void writeJson( File file, Collection<? extends DesignElementDataVector> vectors ) throws IOException {
         this.rawExpressionDataVectorService.thawRawAndProcessed( vectors );
         ExpressionDataMatrix<?> expressionDataMatrix = ExpressionDataMatrixBuilder.getMatrix( vectors );
         try ( Writer writer = new OutputStreamWriter( new GZIPOutputStream( new FileOutputStream( file ) ) ) ) {
@@ -1131,7 +1131,7 @@ public class ExpressionDataFileServiceImpl extends AbstractTsvFileService<Expres
 
     }
 
-    private void writeVectors( File file, Collection<DesignElementDataVector> vectors,
+    private void writeVectors( File file, Collection<? extends DesignElementDataVector> vectors,
             Map<CompositeSequence, String[]> geneAnnotations ) throws IOException {
         this.rawExpressionDataVectorService.thawRawAndProcessed( vectors );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataMatrixServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataMatrixServiceImpl.java
@@ -21,14 +21,14 @@ package ubic.gemma.core.analysis.service;
 import cern.colt.list.DoubleArrayList;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.basecode.dataStructure.matrix.DenseDoubleMatrix;
 import ubic.basecode.dataStructure.matrix.DoubleMatrix;
 import ubic.basecode.math.DescriptiveWithMissing;
 import ubic.gemma.core.analysis.preprocess.filter.ExpressionExperimentFilter;
 import ubic.gemma.core.analysis.preprocess.filter.FilterConfig;
 import ubic.gemma.core.analysis.preprocess.filter.FilteringException;
-import ubic.gemma.core.analysis.preprocess.filter.NoRowsLeftAfterFilteringException;
 import ubic.gemma.core.datastructure.matrix.ExpressionDataDoubleMatrix;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.bioAssayData.ProcessedExpressionDataVector;
@@ -49,7 +49,7 @@ import java.util.Map;
  *
  * @author keshav
  */
-@Component
+@Service
 public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixService {
 
     @Autowired
@@ -62,6 +62,7 @@ public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixServ
     private ArrayDesignService arrayDesignService;
 
     @Override
+    @Transactional(readOnly = true)
     public ExpressionDataDoubleMatrix getFilteredMatrix( ExpressionExperiment ee, FilterConfig filterConfig ) throws FilteringException {
         Collection<ProcessedExpressionDataVector> dataVectors = processedExpressionDataVectorService
                 .getProcessedDataVectors( ee );
@@ -69,6 +70,7 @@ public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixServ
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ExpressionDataDoubleMatrix getFilteredMatrix( ExpressionExperiment ee, FilterConfig filterConfig,
             Collection<ProcessedExpressionDataVector> dataVectors ) throws FilteringException {
         Collection<ArrayDesign> arrayDesignsUsed = expressionExperimentService.getArrayDesignsUsed( ee );
@@ -76,6 +78,7 @@ public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixServ
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ExpressionDataDoubleMatrix getFilteredMatrix( String arrayDesignName, FilterConfig filterConfig,
             Collection<ProcessedExpressionDataVector> dataVectors ) throws FilteringException {
         ArrayDesign ad = arrayDesignService.findByShortName( arrayDesignName );
@@ -88,6 +91,7 @@ public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixServ
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ExpressionDataDoubleMatrix getProcessedExpressionDataMatrix( ExpressionExperiment ee ) {
         Collection<ProcessedExpressionDataVector> dataVectors = this.processedExpressionDataVectorService
                 .getProcessedDataVectors( ee );
@@ -95,11 +99,12 @@ public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixServ
             throw new IllegalArgumentException(
                     "There are no ProcessedExpressionDataVectors for " + ee + ", they must be created first" );
         }
-        this.processedExpressionDataVectorService.thaw( dataVectors );
+        dataVectors = this.processedExpressionDataVectorService.thaw( dataVectors );
         return new ExpressionDataDoubleMatrix( dataVectors );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public DoubleMatrix<Gene, ExpressionExperiment> getRankMatrix( Collection<Gene> genes,
             Collection<ExpressionExperiment> ees, ProcessedExpressionDataVectorDao.RankMethod method ) {
 
@@ -144,7 +149,7 @@ public class ExpressionDataMatrixServiceImpl implements ExpressionDataMatrixServ
         if ( dataVectors == null || dataVectors.isEmpty() )
             throw new IllegalArgumentException( "Vectors must be provided" );
         ExpressionExperimentFilter filter = new ExpressionExperimentFilter( arrayDesignsUsed, filterConfig );
-        this.processedExpressionDataVectorService.thaw( dataVectors );
+        dataVectors = this.processedExpressionDataVectorService.thaw( dataVectors );
         return filter.getFilteredMatrix( dataVectors );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceService.java
@@ -126,9 +126,4 @@ public interface BibliographicReferenceService
     List<BibliographicReferenceValueObject> search( SearchSettingsValueObject settings );
 
     List<BibliographicReferenceValueObject> search( String query );
-
-    BibliographicReference thaw( BibliographicReference bibliographicReference );
-
-    Collection<BibliographicReference> thaw( Collection<BibliographicReference> bibliographicReferences );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceServiceImpl.java
@@ -69,11 +69,13 @@ public class BibliographicReferenceServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public BibliographicReferenceValueObject loadValueObject( BibliographicReference entity ) {
         return this.loadMultipleValueObjectsFromObjects( Collections.singleton( entity ) ).iterator().next();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<BibliographicReferenceValueObject> loadAllValueObjects() {
         return this.loadMultipleValueObjectsFromObjects( this.loadAll() );
     }
@@ -97,7 +99,7 @@ public class BibliographicReferenceServiceImpl
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public BibliographicReference findByExternalId( String id ) {
 
         return this.bibliographicReferenceDao
@@ -106,7 +108,7 @@ public class BibliographicReferenceServiceImpl
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public BibliographicReference findByExternalId( String id, String databaseName ) {
 
         return this.bibliographicReferenceDao.findByExternalId( id, databaseName );
@@ -134,7 +136,7 @@ public class BibliographicReferenceServiceImpl
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public Map<ExpressionExperiment, BibliographicReference> getAllExperimentLinkedReferences() {
         return this.bibliographicReferenceDao.getAllExperimentLinkedReferences();
     }
@@ -282,18 +284,6 @@ public class BibliographicReferenceServiceImpl
 
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public BibliographicReference thaw( BibliographicReference bibliographicReference ) {
-        return this.bibliographicReferenceDao.thaw( bibliographicReference );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Collection<BibliographicReference> thaw( Collection<BibliographicReference> bibliographicReferences ) {
-        return this.bibliographicReferenceDao.thaw( bibliographicReferences );
-    }
-
     private List<BibliographicReferenceValueObject> loadMultipleValueObjectsFromObjects(
             Collection<BibliographicReference> bibRefs ) {
         if ( bibRefs.isEmpty() ) {
@@ -316,7 +306,7 @@ public class BibliographicReferenceServiceImpl
 
         Collection<PhenotypeAssociation> phenotypeAssociations = this.phenotypeAssociationService
                 .findPhenotypesForBibliographicReference( bibRefVO.getPubAccession() );
-        Collection<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = BibliographicPhenotypesValueObject
+        Set<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = BibliographicPhenotypesValueObject
                 .phenotypeAssociations2BibliographicPhenotypesValueObjects( phenotypeAssociations );
         bibRefVO.setBibliographicPhenotypes( bibliographicPhenotypesValueObjects );
     }
@@ -332,9 +322,9 @@ public class BibliographicReferenceServiceImpl
             BibliographicReferenceValueObject bibRefVO ) {
         Collection<ExpressionExperiment> relatedExperiments = this.getRelatedExperiments( bibRef );
         if ( relatedExperiments.isEmpty() ) {
-            bibRefVO.setExperiments( new ArrayList<ExpressionExperimentValueObject>() );
+            bibRefVO.setExperiments( new HashSet<>() );
         } else {
-            bibRefVO.setExperiments( expressionExperimentService.loadValueObjects( relatedExperiments ) );
+            bibRefVO.setExperiments( new HashSet<>( expressionExperimentService.loadValueObjects( relatedExperiments ) ) );
         }
 
     }
@@ -346,7 +336,7 @@ public class BibliographicReferenceServiceImpl
         for ( BibliographicReference bibref : bibRefs ) {
             BibliographicReferenceValueObject vo = idToBibRefVO.get( bibref.getId() );
             if ( relatedExperiments.containsKey( bibref ) ) {
-                vo.setExperiments( expressionExperimentService.loadValueObjects( relatedExperiments.get( bibref ) ) );
+                vo.setExperiments( new HashSet<>( expressionExperimentService.loadValueObjects( relatedExperiments.get( bibref ) ) ) );
             }
         }
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceServiceImpl.java
@@ -287,7 +287,7 @@ public class BibliographicReferenceServiceImpl
     private List<BibliographicReferenceValueObject> loadMultipleValueObjectsFromObjects(
             Collection<BibliographicReference> bibRefs ) {
         if ( bibRefs.isEmpty() ) {
-            Collections.emptyList();
+            return Collections.emptyList();
         }
         Map<Long, BibliographicReferenceValueObject> idToBibRefVO = new HashMap<>();
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignAlternativePopulateCli.java
@@ -98,7 +98,7 @@ public class ArrayDesignAlternativePopulateCli extends AbstractCLIContextCLI {
                 if ( fromAD.equals( toAD ) )
                     continue; // no need to self-map?
 
-                arrayDesignService.thawLite( fromAD );
+                fromAD = arrayDesignService.thawLite( fromAD );
                 if ( fromAD.getAlternativeTo() != null ) {
                     log.info( "Already has an alternative mapped: " + from );
                     continue;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ArrayDesignProbeMapperCli.java
@@ -527,6 +527,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
         if ( this.taxon == null ) {
             assert arrayDesign != null;
             Taxon t = getArrayDesignService().getTaxon( arrayDesign.getId() );
+            t = taxonService.thaw( t );
             isRat = t.getCommonName().equals( "rat" );
         } else {
             isRat = taxon.getCommonName().equals( "rat" );
@@ -655,7 +656,7 @@ public class ArrayDesignProbeMapperCli extends ArrayDesignSequenceManipulatingCl
                 continue;
             }
 
-            compositeSequenceService.thaw( Collections.singleton( probe ) );
+            probe = compositeSequenceService.thaw( probe );
 
             Map<String, Collection<BlatAssociation>> results = this.arrayDesignProbeMapperService
                     .processCompositeSequence( this.config, taxon, null, probe );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BioSequenceCleanupCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BioSequenceCleanupCli.java
@@ -332,7 +332,7 @@ public class BioSequenceCleanupCli extends ArrayDesignSequenceManipulatingCli {
         // all composite sequences for bs2 will be switched to bs1.
         Collection<CompositeSequence> usingDuplicatedSequence = css.findByBioSequence( toRemove );
 
-        css.thaw( usingDuplicatedSequence );
+        usingDuplicatedSequence = css.thaw( usingDuplicatedSequence );
 
         for ( CompositeSequence sequence : usingDuplicatedSequence ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/BlacklistCli.java
@@ -34,8 +34,8 @@ import ubic.gemma.model.expression.BlacklistedEntity;
 import ubic.gemma.model.expression.arrayDesign.BlacklistedPlatform;
 import ubic.gemma.model.expression.experiment.BlacklistedExperiment;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
-import ubic.gemma.persistence.service.common.description.ExternalDatabaseDao;
-import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityDao;
+import ubic.gemma.persistence.service.common.description.ExternalDatabaseService;
+import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 
 import java.io.BufferedReader;
@@ -98,10 +98,10 @@ public class BlacklistCli extends AbstractCLIContextCLI {
 
     @Override
     protected void doWork() throws Exception {
-        BlacklistedEntityDao blacklistedEntityDao = this.getBean( BlacklistedEntityDao.class );
-        ExternalDatabaseDao externalDatabaseDao = this.getBean( ExternalDatabaseDao.class );
+        BlacklistedEntityService blacklistedEntityService = this.getBean( BlacklistedEntityService.class );
+        ExternalDatabaseService externalDatabaseService = this.getBean( ExternalDatabaseService.class );
 
-        ExternalDatabase geo = externalDatabaseDao.findByName( "GEO" );
+        ExternalDatabase geo = externalDatabaseService.findByName( "GEO" );
 
         if ( geo == null )
             throw new IllegalStateException( "GEO not found as an external database in the system" );
@@ -112,7 +112,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
             return;
         }
 
-        try (BufferedReader in = new BufferedReader( new FileReader( fileName ) )) {
+        try ( BufferedReader in = new BufferedReader( new FileReader( fileName ) ) ) {
             while ( in.ready() ) {
                 String line = in.readLine().trim();
                 if ( line.startsWith( "#" ) ) {
@@ -131,13 +131,13 @@ public class BlacklistCli extends AbstractCLIContextCLI {
 
                 String accession = split[0];
 
-                boolean alreadyBlacklisted = blacklistedEntityDao.isBlacklisted( accession );
+                boolean alreadyBlacklisted = blacklistedEntityService.isBlacklisted( accession );
                 if ( remove ) {
                     if ( !alreadyBlacklisted ) {
                         log.warn( "Attempting to de-blacklist " + accession + " but it is not blacklisted" );
                         continue;
                     }
-                    blacklistedEntityDao.remove( blacklistedEntityDao.findByAccession( accession ) );
+                    blacklistedEntityService.remove( blacklistedEntityService.findByAccession( accession ) );
                     log.info( "De-blacklisted " + accession );
                     continue;
                 } else if ( alreadyBlacklisted ) {
@@ -159,7 +159,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
                     throw new IllegalArgumentException( "A reason for blacklisting must be provided for " + accession );
                 }
 
-                if ( blacklistedEntityDao.findByAccession( accession ) != null ) {
+                if ( blacklistedEntityService.findByAccession( accession ) != null ) {
                     log.warn( accession + " is already on the blacklist, skipping" );
                     continue;
                 }
@@ -181,7 +181,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
                     blee.setDescription( split[3] );
                 }
 
-                blacklistedEntityDao.create( blee );
+                blacklistedEntityService.create( blee );
 
                 log.info( "Blacklisted " + accession );
             }
@@ -192,16 +192,16 @@ public class BlacklistCli extends AbstractCLIContextCLI {
     }
 
     /**
-     * 
+     *
      */
     private void proactivelyBlacklistExperiments( ExternalDatabase geo ) throws Exception {
         GeoBrowser gbs = new GeoBrowser();
-        BlacklistedEntityDao blacklistedEntityDao = this.getBean( BlacklistedEntityDao.class );
+        BlacklistedEntityService blacklistedEntityService = this.getBean( BlacklistedEntityService.class );
 
         Collection<String> candidates = new ArrayList<>();
         int numChecked = 0;
         int numBlacklisted = 0;
-        for ( BlacklistedEntity be : blacklistedEntityDao.loadAll() ) {
+        for ( BlacklistedEntity be : blacklistedEntityService.loadAll() ) {
             if ( be instanceof BlacklistedPlatform ) {
 
                 if ( platformsToScreen == null || !platformsToScreen.isEmpty()
@@ -213,13 +213,13 @@ public class BlacklistCli extends AbstractCLIContextCLI {
 
             if ( candidates.size() == 5 ) { // too many will break eutils query
                 log.info( "Looking for batch of candidates using: " + StringUtils.join( candidates, "," ) );
-                numBlacklisted += fetchAndBlacklist( geo, gbs, blacklistedEntityDao, candidates );
+                numBlacklisted += fetchAndBlacklist( geo, gbs, blacklistedEntityService, candidates );
                 candidates.clear();
             }
         }
 
         // finish the last batch
-        fetchAndBlacklist( geo, gbs, blacklistedEntityDao, candidates );
+        fetchAndBlacklist( geo, gbs, blacklistedEntityService, candidates );
 
         log.info( "Checked " + numChecked + " blacklisted platforms for experiment in GEO, blacklisted " + numBlacklisted + " GSEs" );
 
@@ -228,12 +228,12 @@ public class BlacklistCli extends AbstractCLIContextCLI {
     /**
      * @param  geo
      * @param  gbs
-     * @param  blacklistedEntityDao
+     * @param  blacklistedEntityService
      * @param  candidates
-     * @return                      number of actually blacklisted experiments in this batch.
+     * @return number of actually blacklisted experiments in this batch.
      * @throws InterruptedException
      */
-    private int fetchAndBlacklist( ExternalDatabase geo, GeoBrowser gbs, BlacklistedEntityDao blacklistedEntityDao, Collection<String> candidates )
+    private int fetchAndBlacklist( ExternalDatabase geo, GeoBrowser gbs, BlacklistedEntityService blacklistedEntityService, Collection<String> candidates )
             throws InterruptedException {
         int start = 0;
 
@@ -270,7 +270,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
             for ( GeoRecord geoRecord : recs ) {
                 boolean skip = false;
                 String eeAcc = geoRecord.getGeoAccession();
-                if ( null != blacklistedEntityDao.findByAccession( eeAcc ) ) {
+                if ( null != blacklistedEntityService.findByAccession( eeAcc ) ) {
                     log.debug( "Already blacklisted: " + eeAcc );
                     continue;
                 }
@@ -278,7 +278,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
                 String[] platforms = geoRecord.getPlatform().split( ";" );
                 for ( String p : platforms ) {
 
-                    BlacklistedEntity bli = blacklistedEntityDao.findByAccession( p );
+                    BlacklistedEntity bli = blacklistedEntityService.findByAccession( p );
 
                     if ( bli == null ) {
                         // then at least one platform it uses isn't blacklisted, we won't blacklist the experiment
@@ -304,7 +304,7 @@ public class BlacklistCli extends AbstractCLIContextCLI {
                 b.setDescription( geoRecord.getTitle() );
                 b.setReason( "Unsupported platform" );
 
-                blacklistedEntityDao.create( b );
+                blacklistedEntityService.create( b );
                 numBlacklisted++;
 
             }

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentManipulatingCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExpressionExperimentManipulatingCLI.java
@@ -275,7 +275,7 @@ public abstract class ExpressionExperimentManipulatingCLI extends AbstractCLICon
                 AbstractCLI.log.warn( shortName + " not found" );
                 continue;
             }
-            eeService.thawLite( expressionExperiment );
+            expressionExperiment = eeService.thawLite( expressionExperiment );
             expressionExperiments.add( expressionExperiment );
         }
         if ( expressionExperiments.size() == 0 ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/GeoGrabberCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/GeoGrabberCli.java
@@ -167,12 +167,11 @@ public class GeoGrabberCli extends AbstractCLIContextCLI {
         File outputFile = new File( outputFileName );
         log.info( "Writing output to " + outputFile.getPath() );
 
-        if ( outputFile.exists() ) {
-            log.warn( "Overwriting existing file ..." );
+        if ( !outputFile.createNewFile() ) {
+            log.warn( "Overwriting existing file..." );
+            // FIXME: is this really necessary?
             Thread.sleep( 500 );
         }
-
-        outputFile.createNewFile();
 
         if ( getPlatforms ) {
             Collection<GeoRecord> allGEOPlatforms = gbs.getAllGEOPlatforms();

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/LoadSimpleExpressionDataCli.java
@@ -273,7 +273,9 @@ public class LoadSimpleExpressionDataCli extends AbstractCLIContextCLI {
             this.configureQuantitationType( fields, metaData );
 
             ExpressionExperiment ee = eeLoaderService.create( metaData, data );
-            this.eeService.thawLite( ee );
+            // FIXME: is that really necessary?
+            //noinspection UnusedAssignment
+            ee = this.eeService.thawLite( ee );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/TwoChannelMissingValueCLI.java
@@ -43,6 +43,7 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * CLI for computing and persisting the 'present' calls for two-channel data -- AND creates the processed data vectors
@@ -53,7 +54,7 @@ import java.util.HashSet;
 public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingCLI {
 
     private static final String MISSING_VALUE_OPTION = "mvind";
-    private final Collection<Double> extraMissingValueIndicators = new HashSet<>();
+    private final Set<Double> extraMissingValueIndicators = new HashSet<>();
     private RawExpressionDataVectorService rawService;
     private ProcessedExpressionDataVectorService procService;
     private PreprocessorService preprocessorService;
@@ -184,7 +185,7 @@ public class TwoChannelMissingValueCLI extends ExpressionExperimentManipulatingC
         }
 
         try {
-            preprocessorService.process( ee, true );
+            preprocessorService.processLight( ee );
         } catch ( PreprocessingException e ) {
             AbstractCLI.log
                     .error( "Error during postprocessing of " + ee + " , make sure additional steps are completed", e );

--- a/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssoManagerServiceHelperImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssoManagerServiceHelperImpl.java
@@ -210,7 +210,7 @@ public class PhenotypeAssoManagerServiceHelperImpl implements PhenotypeAssoManag
 
     /**
      * @param  evidenceValueObject the evidence we want to convert
-     * @return                     PhenotypeAssociation the entity created from the ValueObject
+     * @return PhenotypeAssociation the entity created from the ValueObject
      */
     private PhenotypeAssociation conversion2DifferentialExpressionEvidence(
             DiffExpressionEvidenceValueObject evidenceValueObject ) {
@@ -232,7 +232,7 @@ public class PhenotypeAssoManagerServiceHelperImpl implements PhenotypeAssoManag
 
     /**
      * @param  evidenceValueObject the evidence we want to convert
-     * @return                     PhenotypeAssociation the entity created from the ValueObject
+     * @return PhenotypeAssociation the entity created from the ValueObject
      */
     private PhenotypeAssociation conversion2ExperimentalEvidence(
             ExperimentalEvidenceValueObject evidenceValueObject ) {
@@ -330,7 +330,7 @@ public class PhenotypeAssoManagerServiceHelperImpl implements PhenotypeAssoManag
             }
 
             genericExperiment
-                    .setOtherRelevantPublications( this.findOrCreateBibliographicReference( relevantPubmedId ) );
+                    .setOtherRelevantPublications( new HashSet<>( this.findOrCreateBibliographicReference( relevantPubmedId ) ) );
 
             // characteristics for an experiment
             Collection<Characteristic> characteristics = new HashSet<>();
@@ -357,7 +357,7 @@ public class PhenotypeAssoManagerServiceHelperImpl implements PhenotypeAssoManag
 
     /**
      * @param  evidenceValueObject the evidence we want to convert
-     * @return                     PhenotypeAssociation the entity created from the ValueObject
+     * @return PhenotypeAssociation the entity created from the ValueObject
      */
     private PhenotypeAssociation conversion2GenericEvidence( GenericEvidenceValueObject evidenceValueObject ) {
 
@@ -372,7 +372,7 @@ public class PhenotypeAssoManagerServiceHelperImpl implements PhenotypeAssoManag
 
     /**
      * @param  evidenceValueObject the evidence we want to convert
-     * @return                     PhenotypeAssociation the entity created from the ValueObject
+     * @return PhenotypeAssociation the entity created from the ValueObject
      */
     private PhenotypeAssociation conversion2LiteratureEvidence( LiteratureEvidenceValueObject evidenceValueObject ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssociationManagerServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssociationManagerServiceImpl.java
@@ -152,7 +152,7 @@ public class PhenotypeAssociationManagerServiceImpl implements PhenotypeAssociat
             Collection<PhenotypeAssociation> phenotypeAssociations = this.phenoAssocService
                     .findPhenotypesForBibliographicReference( pubMedId );
 
-            Collection<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = BibliographicPhenotypesValueObject
+            Set<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = BibliographicPhenotypesValueObject
                     .phenotypeAssociations2BibliographicPhenotypesValueObjects( phenotypeAssociations );
 
             // set phenotypes associated with this bibliographic reference
@@ -163,7 +163,7 @@ public class PhenotypeAssociationManagerServiceImpl implements PhenotypeAssociat
                     .getRelatedExperiments( bibliographicReference );
 
             if ( experiments != null && !experiments.isEmpty() ) {
-                bibliographicReferenceVO.setExperiments( expressionExperimentService.loadValueObjects( experiments ) );
+                bibliographicReferenceVO.setExperiments( new HashSet<>( expressionExperimentService.loadValueObjects( experiments ) ) );
             }
 
             return bibliographicReferenceVO;

--- a/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/ExpressionExperimentSetValueObjectHelperImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/ExpressionExperimentSetValueObjectHelperImpl.java
@@ -51,6 +51,7 @@ import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class will handle population of ExpressionExperimentSetValueObjects. Services need to be accessed in order to
@@ -99,7 +100,7 @@ public class ExpressionExperimentSetValueObjectHelperImpl implements ExpressionE
                     "The value object must have some experiments associated before it can be converted and persisted" );
         }
 
-        Collection<BioAssaySet> bas = new HashSet<BioAssaySet>( experiments );
+        Set<BioAssaySet> bas = new HashSet<BioAssaySet>( experiments );
         entity.setExperiments( bas );
         entity.setName( setVO.getName() );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/service/ExpressionExperimentSearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/service/ExpressionExperimentSearchServiceImpl.java
@@ -235,7 +235,7 @@ public class ExpressionExperimentSearchServiceImpl implements ExpressionExperime
                 .findByName( "Master set for " + taxon.getCommonName().toLowerCase() );
         SearchResultDisplayObject newSRDO;
         for ( ExpressionExperimentSet set : sets ) {
-            expressionExperimentSetService.thaw( set );
+            set = expressionExperimentSetService.thaw( set );
             if ( set.getTaxon().getId().equals( taxonId ) ) {
                 ExpressionExperimentSetValueObject eevo = expressionExperimentSetService.loadValueObject( set );
                 newSRDO = new SearchResultDisplayObject( eevo );

--- a/gemma-core/src/main/java/ubic/gemma/core/externalDb/GoldenPathSequenceAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/externalDb/GoldenPathSequenceAnalysis.java
@@ -105,7 +105,7 @@ public class GoldenPathSequenceAnalysis extends GoldenPath {
         /*
          * These are transient instances only
          */
-        Collection<GeneProduct> geneProducts = new HashSet<>();
+        Set<GeneProduct> geneProducts = new HashSet<>();
 
         if ( config.isUseRefGene() ) {
             // starting with refgene means we can get the correct transcript name etc.
@@ -120,7 +120,7 @@ public class GoldenPathSequenceAnalysis extends GoldenPath {
         if ( geneProducts.size() == 0 )
             return null;
 
-        Collection<BlatAssociation> results = new HashSet<>();
+        Set<BlatAssociation> results = new HashSet<>();
         for ( GeneProduct geneProduct : geneProducts ) {
             if ( GoldenPath.log.isDebugEnabled() )
                 GoldenPath.log.debug( geneProduct );
@@ -937,7 +937,7 @@ public class GoldenPathSequenceAnalysis extends GoldenPath {
         Collection<PhysicalLocation> exons = this.blocksToPhysicalLocations( exonSizeInts, exonStartInts, chromosome );
         gp.setExons( exons );
         gp.setName( gene.getNcbiGeneId().toString() ); // this isn't right?
-        Collection<GeneProduct> products = new HashSet<>();
+        Set<GeneProduct> products = new HashSet<>();
         products.add( gp );
         gene.setProducts( products );
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/FreeTextGeneResultsValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/FreeTextGeneResultsValueObject.java
@@ -37,7 +37,7 @@
 
 package ubic.gemma.core.genome.gene;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * *
@@ -59,8 +59,7 @@ public class FreeTextGeneResultsValueObject extends SessionBoundGeneSetValueObje
 
     /**
      * Method to create a display object from scratch
-     *
-     * @param name        cannot be null
+     *  @param name        cannot be null
      * @param description should not be null
      * @param taxonId     can be null
      * @param taxonName   can be null
@@ -68,7 +67,7 @@ public class FreeTextGeneResultsValueObject extends SessionBoundGeneSetValueObje
      * @param queryString the query string
      */
     public FreeTextGeneResultsValueObject( String name, String description, Long taxonId, String taxonName,
-            Collection<Long> geneIds, String queryString ) {
+            Set<Long> geneIds, String queryString ) {
 
         this.setName( name );
         this.setDescription( description );

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GOGroupValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GOGroupValueObject.java
@@ -37,7 +37,7 @@
 
 package ubic.gemma.core.genome.gene;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author tvrossum
@@ -65,7 +65,7 @@ public class GOGroupValueObject extends SessionBoundGeneSetValueObject {
      * @param goId        go ID
      */
     public GOGroupValueObject( String name, String description, Long taxonId, String taxonName,
-            Collection<Long> memberIds, String goId, String searchTerm ) {
+            Set<Long> memberIds, String goId, String searchTerm ) {
 
         this.setName( name );
         this.setDescription( description );

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GeneSetValueObjectHelper.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GeneSetValueObjectHelper.java
@@ -16,6 +16,7 @@ package ubic.gemma.core.genome.gene;
 
 import ubic.gemma.model.genome.gene.DatabaseBackedGeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneSet;
+import ubic.gemma.model.genome.gene.GeneSetValueObject;
 
 import java.util.Collection;
 import java.util.List;

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GeneSetValueObjectHelper.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GeneSetValueObjectHelper.java
@@ -16,7 +16,6 @@ package ubic.gemma.core.genome.gene;
 
 import ubic.gemma.model.genome.gene.DatabaseBackedGeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneSet;
-import ubic.gemma.model.genome.gene.GeneSetValueObject;
 
 import java.util.Collection;
 import java.util.List;

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GeneSetValueObjectHelperImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/GeneSetValueObjectHelperImpl.java
@@ -80,7 +80,7 @@ public class GeneSetValueObjectHelperImpl implements GeneSetValueObjectHelper {
         DatabaseBackedGeneSetValueObject dbgsvo = convertToLightValueObject( gs );
 
         Collection<Long> ids = EntityUtils
-                .getIds( this.geneSetService.getGenesInGroup( new GeneSetValueObject( gs.getId() ) ) );
+                .getIds( this.geneSetService.getGenesInGroup( gs ) );
         dbgsvo.getGeneIds().addAll( ids );
         dbgsvo.setSize( ids.size() );
 
@@ -103,7 +103,7 @@ public class GeneSetValueObjectHelperImpl implements GeneSetValueObjectHelper {
      * @param  geneSets                gene sets
      * @param  includeOnesWithoutGenes should empty sets get removed?
      * @param  light                   Don't fill in the gene ids. Should be faster
-     * @return                         list of gene set value objects
+     * @return list of gene set value objects
      */
     private List<DatabaseBackedGeneSetValueObject> convertToLightValueObjects( Collection<GeneSet> geneSets,
             boolean includeOnesWithoutGenes, boolean light ) {
@@ -145,10 +145,10 @@ public class GeneSetValueObjectHelperImpl implements GeneSetValueObjectHelper {
             sbgsvo.setSize( gs.getMembers() != null ? gs.getMembers().size() : 0 );
         } else {// this case may never happen as this is only called from convertToGoValueObject() leaving here in case
             // this method is ever called from somewhere else
-            sbgsvo.setSize( this.geneSetService.getSize( new GeneSetValueObject( gs.getId() ) ) );
+            sbgsvo.setSize( this.geneSetService.getSize( gs ) );
         }
 
-        Collection<Long> gids = new HashSet<>();
+        Set<Long> gids = new HashSet<>();
         for ( GeneSetMember gm : gs.getMembers() ) {
             gids.add( gm.getGene().getId() );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/PhenotypeGroupValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/PhenotypeGroupValueObject.java
@@ -39,7 +39,7 @@ package ubic.gemma.core.genome.gene;
 
 import ubic.gemma.model.genome.gene.GeneSetValueObject;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author tvrossum
@@ -58,18 +58,17 @@ public class PhenotypeGroupValueObject extends SessionBoundGeneSetValueObject {
 
     /**
      * Method to create a display object from scratch
-     *
-     * @param name              cannot be null
+     *  @param name              cannot be null
      * @param description       should not be null
      * @param taxonId           can be null
      * @param taxonName         can be null
      * @param memberIds         can be null; for a gene this is a collection just containing their id
-     * @param searchTerm        search term
-     * @param phenotypeCategory phenotype category
      * @param phenotypeName     phenotype name
+     * @param phenotypeCategory phenotype category
+     * @param searchTerm        search term
      */
     public PhenotypeGroupValueObject( String name, String description, Long taxonId, String taxonName,
-            Collection<Long> memberIds, String phenotypeName, String phenotypeCategory, String searchTerm ) {
+            Set<Long> memberIds, String phenotypeName, String phenotypeCategory, String searchTerm ) {
 
         this.setName( name );
         this.setDescription( description );

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneSearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneSearchServiceImpl.java
@@ -217,7 +217,7 @@ public class GeneSearchServiceImpl implements GeneSearchService {
             // convert result object to a value object
             for ( SearchResult sr : taxonCheckedSets ) {
                 GeneSet g = ( GeneSet ) sr.getResultObject();
-                DatabaseBackedGeneSetValueObject gsVo = geneSetValueObjectHelper.convertToValueObject( g );
+                GeneSetValueObject gsVo = geneSetValueObjectHelper.convertToValueObject( g );
                 sr.setResultObject( gsVo );
             }
             geneSets = SearchResultDisplayObject.convertSearchResults2SearchResultDisplayObjects( taxonCheckedSets );
@@ -524,7 +524,7 @@ public class GeneSearchServiceImpl implements GeneSearchService {
 
                 newTaxonSet.setName( gs.getName() );
                 newTaxonSet.setDescription( gs.getDescription() );
-                Collection<GeneSetMember> members = new ArrayList<>();
+                Set<GeneSetMember> members = new HashSet<>();
                 members.add( geneMember );
 
                 newTaxonSet.setMembers( members );
@@ -747,12 +747,12 @@ public class GeneSearchServiceImpl implements GeneSearchService {
         List<SearchResultDisplayObject> displayResultsPublic = new ArrayList<>();
         SearchResultDisplayObject newSrDo;
 
-        List<DatabaseBackedGeneSetValueObject> valueObjects = geneSetValueObjectHelper
+        List<? extends GeneSetValueObject> valueObjects = geneSetValueObjectHelper
                 .convertToValueObjects( sets, false );
         if ( watch.getTime() > 500 )
             GeneSearchServiceImpl.log.info( "Database stage done: " + watch.getTime() + "ms" );
 
-        for ( DatabaseBackedGeneSetValueObject set : valueObjects ) {
+        for ( GeneSetValueObject set : valueObjects ) {
             newSrDo = new SearchResultDisplayObject( set );
             newSrDo.setTaxonId( ( ( GeneSetValueObject ) newSrDo.getResultValueObject() ).getTaxonId() );
             newSrDo.setTaxonName( ( ( GeneSetValueObject ) newSrDo.getResultValueObject() ).getTaxonName() );

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneService.java
@@ -32,6 +32,7 @@ import ubic.gemma.model.genome.gene.GeneValueObject;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 import ubic.gemma.persistence.service.FilteringVoEnabledService;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -196,15 +197,19 @@ public interface GeneService extends FilteringVoEnabledService<Gene, GeneValueOb
      * @return thaw the Aliases, very light version
      */
     @Deprecated
+    @CheckReturnValue
     Gene thawAliases( Gene gene );
 
     @Deprecated
+    @CheckReturnValue
     Collection<Gene> thawLite( Collection<Gene> genes );
 
     @Deprecated
+    @CheckReturnValue
     Gene thawLite( Gene gene );
 
     @Deprecated
+    @CheckReturnValue
     Gene thawLiter( Gene gene );
 
     Collection<GeneValueObject> searchGenes( String query, Long taxonId );

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneService.java
@@ -191,18 +191,20 @@ public interface GeneService extends FilteringVoEnabledService<Gene, GeneValueOb
 
     Collection<GeneValueObject> loadValueObjectsByIdsLiter( Collection<Long> ids );
 
-    Gene thaw( Gene gene );
-
     /**
      * @param gene gene
      * @return thaw the Aliases, very light version
      */
+    @Deprecated
     Gene thawAliases( Gene gene );
 
+    @Deprecated
     Collection<Gene> thawLite( Collection<Gene> genes );
 
+    @Deprecated
     Gene thawLite( Gene gene );
 
+    @Deprecated
     Gene thawLiter( Gene gene );
 
     Collection<GeneValueObject> searchGenes( String query, Long taxonId );

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneServiceImpl.java
@@ -305,7 +305,7 @@ public class GeneServiceImpl extends AbstractFilteringVoEnabledService<Gene, Gen
         if ( gene == null ) {
             return null;
         }
-        gene = this.geneDao.thaw( gene );
+        this.geneDao.thaw( gene );
 
         GeneValueObject gvo = GeneValueObject.convert2ValueObject( gene );
 
@@ -430,7 +430,7 @@ public class GeneServiceImpl extends AbstractFilteringVoEnabledService<Gene, Gen
         Gene g = this.geneDao.load( id );
         if ( g == null )
             return null;
-        g = this.geneDao.thaw( g );
+        this.geneDao.thaw( g );
         return GeneValueObject.convert2ValueObject( g );
     }
 
@@ -449,32 +449,31 @@ public class GeneServiceImpl extends AbstractFilteringVoEnabledService<Gene, Gen
     }
 
     @Override
-    public Gene thaw( Gene gene ) {
-        return this.geneDao.thaw( gene );
-    }
-
-    @Override
     @Transactional(readOnly = true)
     public Gene thawAliases( Gene gene ) {
-        return this.geneDao.thawAliases( gene );
+        this.geneDao.thawAliases( gene );
+        return gene;
     }
 
     @Override
     @Transactional(readOnly = true)
     public Collection<Gene> thawLite( final Collection<Gene> genes ) {
-        return this.geneDao.thawLite( genes );
+        this.geneDao.thawLite( genes );
+        return genes;
     }
 
     @Override
     @Transactional(readOnly = true)
     public Gene thawLite( Gene gene ) {
-        return this.geneDao.thawLite( gene );
+        this.geneDao.thawLite( gene );
+        return gene;
     }
 
     @Override
     @Transactional(readOnly = true)
     public Gene thawLiter( Gene gene ) {
-        return this.geneDao.thawLiter( gene );
+        this.geneDao.thawLiter( gene );
+        return gene;
     }
 
     /**
@@ -484,6 +483,7 @@ public class GeneServiceImpl extends AbstractFilteringVoEnabledService<Gene, Gen
      * @return Collection of Gene entity objects
      */
     @Override
+    @Transactional(readOnly = true)
     public Collection<GeneValueObject> searchGenes( String query, Long taxonId ) {
 
         Taxon taxon = null;

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneSetService.java
@@ -51,37 +51,38 @@ public interface GeneSetService {
      * {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  gene gene
-     * @return      gene sets
+     * @return gene sets
      * @see         GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> findByGene( Gene gene );
-
-    /**
-     * The ids of member genes will not be filled in
-     *
-     * @param  ids ids
-     * @return     gene set value object
-     */
-    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
-    Collection<? extends DatabaseBackedGeneSetValueObject> loadValueObjectsLite( Collection<Long> ids );
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_READ" })
     DatabaseBackedGeneSetValueObject loadValueObject( GeneSet geneSet );
 
     /**
+     * The ids of member genes will not be filled in
+     *
+     * @param  ids ids
+     * @return gene set value object
+     */
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
+    Collection<DatabaseBackedGeneSetValueObject> loadValueObjectsLite( Collection<Long> ids );
+
+
+    /**
      * Ids of member genes will be filled in
      *
      * @param  ids ids
-     * @return     gene set value object
+     * @return gene set value object
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
-    Collection<? extends DatabaseBackedGeneSetValueObject> loadValueObjects( Collection<Long> ids );
+    Collection<DatabaseBackedGeneSetValueObject> loadValueObjects( Collection<Long> ids );
 
     /**
      * Security filtering done at DAO level see {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  name name
-     * @return      gene sets
+     * @return gene sets
      * @see         GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> findByName( String name );
@@ -91,7 +92,7 @@ public interface GeneSetService {
      *
      * @param  name  name
      * @param  taxon taxon
-     * @return       gene sets
+     * @return gene sets
      * @see          GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> findByName( String name, Taxon taxon );
@@ -101,7 +102,7 @@ public interface GeneSetService {
      * {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  ids ids
-     * @return     gene sets
+     * @return gene sets
      * @see        GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> load( Collection<Long> ids );
@@ -111,7 +112,7 @@ public interface GeneSetService {
      * {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  id id
-     * @return    geneSet with he given ID or null
+     * @return geneSet with he given ID or null
      * @see       GeneSetDao GeneSetDao for security filtering
      */
     GeneSet load( Long id );
@@ -129,7 +130,7 @@ public interface GeneSetService {
      * Security filtering done at DAO level see {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  tax taxon
-     * @return     gene sets
+     * @return gene sets
      * @see        GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> loadAll( Taxon tax );
@@ -151,7 +152,7 @@ public interface GeneSetService {
      * Security filtering done at DAO level see {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  tax taxon
-     * @return     gene sets
+     * @return gene sets
      * @see        GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> loadMyGeneSets( Taxon tax );
@@ -168,7 +169,7 @@ public interface GeneSetService {
      * Security filtering done at DAO level see {@link ubic.gemma.persistence.service.genome.gene.GeneSetDao}
      *
      * @param  tax taxon
-     * @return     gene sets
+     * @return gene sets
      * @see        GeneSetDao GeneSetDao for security filtering
      */
     Collection<GeneSet> loadMySharedGeneSets( Taxon tax );
@@ -213,7 +214,7 @@ public interface GeneSetService {
      * Get a value object for the id param
      *
      * @param  id id
-     * @return    null if id doesn't match an genes set
+     * @return null if id doesn't match an genes set
      */
     DatabaseBackedGeneSetValueObject getValueObject( Long id );
 
@@ -221,25 +222,25 @@ public interface GeneSetService {
      * create an entity in the database based on the value object parameter
      *
      * @param  gsvo gene set value object
-     * @return      value object converted from the newly created entity
+     * @return value object converted from the newly created entity
      */
-    GeneSetValueObject createDatabaseEntity( GeneSetValueObject gsvo );
+    DatabaseBackedGeneSetValueObject createDatabaseEntity( GeneSetValueObject gsvo );
 
     /**
      * Given a Gemma Gene Id, find all the gene groups it is a member of (filtering is handled when gene sets are
      * loaded)
      *
      * @param  geneId gene id
-     * @return        collection of geneSetValueObject
+     * @return collection of geneSetValueObject
      */
-    Collection<GeneSetValueObject> findGeneSetsByGene( Long geneId );
+    Collection<DatabaseBackedGeneSetValueObject> findGeneSetsByGene( Long geneId );
 
     /**
      * AJAX Updates the database entity (permission permitting) with the name and description fields of the param value
      * object
      *
      * @param  geneSetVO gene set value object
-     * @return           value objects for the updated entities
+     * @return value objects for the updated entities
      */
     DatabaseBackedGeneSetValueObject updateDatabaseEntityNameDesc( DatabaseBackedGeneSetValueObject geneSetVO );
 
@@ -256,7 +257,7 @@ public interface GeneSetService {
      * AJAX Updates the database entity (permission permitting) with the fields of the param value object
      *
      * @param  geneSetVos gene sets
-     * @return            value objects for the updated entities
+     * @return value objects for the updated entities
      */
     Collection<DatabaseBackedGeneSetValueObject> updateDatabaseEntity(
             Collection<DatabaseBackedGeneSetValueObject> geneSetVos );
@@ -281,7 +282,7 @@ public interface GeneSetService {
      *                          null)
      * @param  sharedPublicOnly if true, the only public sets returned will be those that are owned by the user or have
      *                          been shared with the user. If param privateOnly is true, this will have no effect.
-     * @return                  all the gene sets user can see, with optional restrictions based on taxon and whether
+     * @return all the gene sets user can see, with optional restrictions based on taxon and whether
      *                          the set is public
      *                          or private
      */
@@ -293,16 +294,19 @@ public interface GeneSetService {
      *
      * @param  privateOnly only private
      * @param  taxonId     if non-null, restrict the groups by ones which have genes in the given taxon.
-     * @return             gene set value objects
+     * @return gene set value objects
      */
     @Secured({ "GROUP_USER", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
     Collection<DatabaseBackedGeneSetValueObject> getUsersGeneGroupsValueObjects( boolean privateOnly, Long taxonId );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    Collection<Gene> getGenesInGroup( GeneSet gs );
 
     /**
      * Get the gene value objects for the members of the group param
      *
      * @param  object can be just a wrapper to trigger security
-     * @return        gene value object
+     * @return gene value object
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     Collection<GeneValueObject> getGenesInGroup( GeneSetValueObject object );
@@ -311,22 +315,25 @@ public interface GeneSetService {
     Collection<Long> getGeneIdsInGroup( GeneSetValueObject geneSetVO );
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
-    int getSize( GeneSetValueObject geneSetVO );
+    int getSize( GeneSet gs );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    int getSize( DatabaseBackedGeneSetValueObject geneSetVO );
 
     /**
      * @param  query   string to match to gene sets
      * @param  taxonId taxon id
-     * @return         collection of GeneSetValueObjects that match name query
+     * @return collection of GeneSetValueObjects that match name query
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
-    Collection<GeneSetValueObject> findGeneSetsByName( String query, Long taxonId );
+    Collection<DatabaseBackedGeneSetValueObject> findGeneSetsByName( String query, Long taxonId );
 
     /**
      * get the taxon for the gene set parameter, assumes that the taxon of the first gene will be representational of
      * all the genes
      *
      * @param  geneSetVO gene set value object
-     * @return           the taxon or null if the gene set param was null
+     * @return the taxon or null if the gene set param was null
      */
     TaxonValueObject getTaxonVOforGeneSetVO( SessionBoundGeneSetValueObject geneSetVO );
 
@@ -335,14 +342,10 @@ public interface GeneSetService {
      * all the genes
      *
      * @param  geneSet gene set
-     * @return         the taxon or null if the gene set param was null
+     * @return the taxon or null if the gene set param was null
      */
     Taxon getTaxon( GeneSet geneSet );
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
     Collection<DatabaseBackedGeneSetValueObject> getValueObjects( Collection<Long> id );
-
-    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
-    void thaw( GeneSet geneSet );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedXMLParser.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/entrez/pubmed/PubMedXMLParser.java
@@ -202,8 +202,8 @@ public class PubMedXMLParser {
         return result;
     }
 
-    private Collection<Compound> extractChemicals( Node chemNodes ) {
-        Collection<Compound> compounds = new HashSet<>();
+    private Set<Compound> extractChemicals( Node chemNodes ) {
+        Set<Compound> compounds = new HashSet<>();
         NodeList childNodes = chemNodes.getChildNodes();
         for ( int i = 0; i < childNodes.getLength(); i++ ) {
             Node chemNode = childNodes.item( i );
@@ -309,8 +309,8 @@ public class PubMedXMLParser {
         }
     }
 
-    private Collection<Keyword> extractKeywords( Node keywordNode ) {
-        Collection<Keyword> keywords = new HashSet<>();
+    private Set<Keyword> extractKeywords( Node keywordNode ) {
+        Set<Keyword> keywords = new HashSet<>();
         NodeList childNodes = keywordNode.getChildNodes();
         for ( int i = 0; i < childNodes.getLength(); i++ ) {
             Node item = childNodes.item( i );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/ExpressionExperimentPlatformSwitchService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/ExpressionExperimentPlatformSwitchService.java
@@ -553,7 +553,7 @@ public class ExpressionExperimentPlatformSwitchService extends ExpressionExperim
                     + " to " + arrayDesign.getShortName()
                     + ( targetBioAssayDimension == null ? "" : ", BioAssayDimension=" + targetBioAssayDimension ) );
 
-            rawExpressionDataVectorService.thaw( vecsForQt );
+            vecsForQt = rawExpressionDataVectorService.thaw( vecsForQt );
 
             int numwarns = 0;
             int maxwarns = 30;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/arrayDesign/ArrayDesignParser.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/arrayDesign/ArrayDesignParser.java
@@ -26,6 +26,7 @@ import ubic.gemma.model.genome.Taxon;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Parse ArrayDesigns from a flat file. This is used to seed the system from our legacy data. (probably not used)
@@ -45,7 +46,7 @@ import java.util.HashSet;
 @Deprecated
 public class ArrayDesignParser extends BasicLineParser<ArrayDesign> {
 
-    private final Collection<ArrayDesign> results = new HashSet<>();
+    private final Set<ArrayDesign> results = new HashSet<>();
 
     @Override
     public Collection<ArrayDesign> getResults() {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/arrayDesign/CompositeSequenceParser.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/arrayDesign/CompositeSequenceParser.java
@@ -27,6 +27,7 @@ import ubic.gemma.model.genome.biosequence.BioSequence;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Parse the "old" array description format. This has three columns, with probe id, a genbank id, and a description.
@@ -36,7 +37,7 @@ import java.util.HashSet;
  */
 public class CompositeSequenceParser extends BasicLineParser<CompositeSequence> {
 
-    private final Collection<CompositeSequence> results = new HashSet<>();
+    private final Set<CompositeSequence> results = new HashSet<>();
 
     @Override
     public Collection<CompositeSequence> getResults() {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/GeoConverterImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/GeoConverterImpl.java
@@ -291,6 +291,8 @@ public class GeoConverterImpl implements GeoConverter {
 
         GeoConverterImpl.log.debug( platformTaxa.size() + " taxa in GEO platform" );
         // check if they share a common parent taxon to use as primary taxa.
+        // thaw to get parent taxon
+        platformTaxa = this.taxonService.thaw( platformTaxa );
         // calculate based on probe taxa:
 
         GeoConverterImpl.log.debug( "Looking at probe taxa to determine 'primary' taxon" );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/GeoFamilyParser.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/GeoFamilyParser.java
@@ -63,8 +63,8 @@ public class GeoFamilyParser implements Parser<Object> {
     /*
      * Elements seen for the 'current sample'.
      */
-    private final Collection<String> processedDesignElements = new HashSet<>();
-    private final Collection<Integer> wantedQuantitationTypes = new HashSet<>();
+    private final Set<String> processedDesignElements = new HashSet<>();
+    private final Set<Integer> wantedQuantitationTypes = new HashSet<>();
     private boolean alreadyWarnedAboutClobbering = false;
     private boolean alreadyWarnedAboutInconsistentColumnOrder = false;
     private boolean alreadyWarnedAboutDuplicateColumnName = false;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoChannel.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoChannel.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2006 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import ubic.gemma.model.common.description.Characteristic;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents data for one channel on a microarray in GEO. Corresponds (roughly) to a BioMaterial in Gemma.
@@ -32,7 +33,7 @@ import java.util.HashSet;
 public class GeoChannel {
 
     String sourceName = "";
-    Collection<String> characteristics = new HashSet<>();
+    Set<String> characteristics = new HashSet<>();
     String bioMaterialProvider = "";
     String growthProtocol = "";
     String treatmentProtocol = "";
@@ -97,14 +98,14 @@ public class GeoChannel {
     /**
      * @return Returns the characteristic.
      */
-    public Collection<String> getCharacteristic() {
+    public Set<String> getCharacteristic() {
         return this.characteristics;
     }
 
     /**
      * @param characteristics The characteristics to set.
      */
-    public void setCharacteristic( Collection<String> characteristics ) {
+    public void setCharacteristic( Set<String> characteristics ) {
         this.characteristics = characteristics;
     }
 
@@ -271,14 +272,14 @@ public class GeoChannel {
     /**
      * @return Returns the characteristics.
      */
-    public Collection<String> getCharacteristics() {
+    public Set<String> getCharacteristics() {
         return this.characteristics;
     }
 
     /**
      * @param characteristics The characteristics to set.
      */
-    public void setCharacteristics( Collection<String> characteristics ) {
+    public void setCharacteristics( Set<String> characteristics ) {
         this.characteristics = characteristics;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoPlatform.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoPlatform.java
@@ -97,7 +97,7 @@ public class GeoPlatform extends GeoData {
     }
 
     /**
-     * 
+     *
      * @param geoPlatformId (GPL)
      * @return true if we recognize it as an Affymetrix platform. Depends on our mappings, if an error is spotted let us
      *         know.
@@ -109,11 +109,11 @@ public class GeoPlatform extends GeoData {
     /**
      * Refers to a list of platforms for which the data from GEO is usually not usable and/or which we always reanalyze
      * from CEL files - exon arrays.
-     * 
+     *
      * Logic: if this was run on an Affymetrix exon array we won't use the data from GEO, even if it was already using
      * the gene-level version of the platform, because there are several variant versions that just muck up the system
      * with useless probes (we have gone back and forth on this a bit...)
-     * 
+     *
      * Note that we endeavour to reanalyze all Affy data sets at the CEL file level.
      *
      * @param geoPlatformId (GPL)
@@ -137,11 +137,11 @@ public class GeoPlatform extends GeoData {
 
     }
 
-    private Collection<String> catalogNumbers = new HashSet<>();
+    private Set<String> catalogNumbers = new HashSet<>();
     private String coating = "";
-    private Collection<String> contributer = new HashSet<>();
+    private Set<String> contributer = new HashSet<>();
     private String description = "";
-    private final Collection<String> designElements = new HashSet<>();
+    private final Set<String> designElements = new HashSet<>();
     private String distribution = "";
     private String lastUpdateDate = "";
     private String manufactureProtocol = "";
@@ -228,7 +228,7 @@ public class GeoPlatform extends GeoData {
     /**
      * @return Returns the catalogNumbers.
      */
-    public Collection<String> getCatalogNumbers() {
+    public Set<String> getCatalogNumbers() {
         return this.catalogNumbers;
     }
 
@@ -269,7 +269,7 @@ public class GeoPlatform extends GeoData {
     /**
      * @return Returns the contributer.
      */
-    public Collection<String> getContributer() {
+    public Set<String> getContributer() {
         return this.contributer;
     }
 
@@ -399,7 +399,7 @@ public class GeoPlatform extends GeoData {
     /**
      * @param catalogNumbers The catalogNumbers to set.
      */
-    public void setCatalogNumbers( Collection<String> catalogNumbers ) {
+    public void setCatalogNumbers( Set<String> catalogNumbers ) {
         this.catalogNumbers = catalogNumbers;
     }
 
@@ -413,7 +413,7 @@ public class GeoPlatform extends GeoData {
     /**
      * @param contributer The contributer to set.
      */
-    public void setContributer( Collection<String> contributer ) {
+    public void setContributer( Set<String> contributer ) {
         this.contributer = contributer;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoSample.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoSample.java
@@ -21,10 +21,7 @@ package ubic.gemma.core.loader.expression.geo.model;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 /**
  * Represents a sample (GSM) in GEO. The channels correspond to BioMaterials; the sample itself corresponds to a
@@ -55,7 +52,7 @@ public class GeoSample extends GeoData implements Comparable<GeoData> {
     private Collection<GeoPlatform> platforms;
     private final Collection<GeoReplication> replicates;
     private String scanProtocol = "";
-    private Collection<String> seriesAppearsIn = new HashSet<>();
+    private Set<String> seriesAppearsIn = new HashSet<>();
     private String supplementaryFile = "";
     private int tagCount;
     private int tagLength;
@@ -282,7 +279,7 @@ public class GeoSample extends GeoData implements Comparable<GeoData> {
         return this.scanProtocol;
     }
 
-    public Collection<String> getSeriesAppearsIn() {
+    public Set<String> getSeriesAppearsIn() {
         return seriesAppearsIn;
     }
 
@@ -415,7 +412,7 @@ public class GeoSample extends GeoData implements Comparable<GeoData> {
         this.scanProtocol = scanProtocol;
     }
 
-    public void setSeriesAppearsIn( Collection<String> otherSeriesAppearsIn ) {
+    public void setSeriesAppearsIn( Set<String> otherSeriesAppearsIn ) {
         this.seriesAppearsIn = otherSeriesAppearsIn;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoSeries.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoSeries.java
@@ -36,7 +36,7 @@ public class GeoSeries extends GeoData {
     private static final Logger log = LoggerFactory.getLogger( GeoSeries.class );
     private static final long serialVersionUID = -1058350558444775537L;
     private final Collection<GeoSample> samples;
-    private final Collection<SeriesType> seriesTypes = new HashSet<>();
+    private final Set<SeriesType> seriesTypes = new HashSet<>();
     private final Collection<String> subSeries;
     private final Map<Integer, GeoVariable> variables;
     private Collection<GeoContact> contributers;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoValues.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/model/GeoValues.java
@@ -45,9 +45,9 @@ import java.util.Map.Entry;
 public class GeoValues implements Serializable {
 
     private static final long serialVersionUID = 3748363645735281578L;
-    private static final Collection<String> aggressivelyRemovedQuantitationTypes = new HashSet<>();
+    private static final Set<String> aggressivelyRemovedQuantitationTypes = new HashSet<>();
     private static final Log log = LogFactory.getLog( GeoValues.class.getName() );
-    private static final Collection<String> skippableQuantitationTypes = new HashSet<>();
+    private static final Set<String> skippableQuantitationTypes = new HashSet<>();
 
     // private Map<Object, String> quantitationTypeMap = new HashMap<Object, String>();
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/simple/SimpleExpressionDataLoaderServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/simple/SimpleExpressionDataLoaderServiceImpl.java
@@ -101,15 +101,15 @@ public class SimpleExpressionDataLoaderServiceImpl implements SimpleExpressionDa
         QuantitationType quantitationType = this.convertQuantitationType( metaData );
 
         /* set the quantitation types on the experiment */
-        Collection<QuantitationType> qTypes = new HashSet<>();
+        Set<QuantitationType> qTypes = new HashSet<>();
         qTypes.add( quantitationType );
         experiment.setQuantitationTypes( qTypes );
 
         Collection<ArrayDesign> arrayDesigns = this.convertArrayDesigns( metaData, matrix );
 
         // Divide up multiple array designs into multiple BioAssayDimensions.
-        Collection<RawExpressionDataVector> allVectors = new HashSet<>();
-        Collection<BioAssay> allBioAssays = new HashSet<>();
+        Set<RawExpressionDataVector> allVectors = new HashSet<>();
+        Set<BioAssay> allBioAssays = new HashSet<>();
         Collection<Object> usedDesignElements = new HashSet<>();
         for ( ArrayDesign design : arrayDesigns ) {
             SimpleExpressionDataLoaderServiceImpl.log.info( "Processing " + design );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/SwissProtParser.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/SwissProtParser.java
@@ -23,6 +23,7 @@ import ubic.gemma.core.loader.util.parser.RecordParser;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This does a very minimal parse of Swissprot records, just to get mRNAs associated with a single protein.
@@ -31,7 +32,7 @@ import java.util.HashSet;
  */
 public class SwissProtParser extends RecordParser<Object> {
 
-    private final Collection<Object> results = new HashSet<>();
+    private final Set<Object> results = new HashSet<>();
 
     @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
     public SwissProtParser() {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGene2AccessionParser.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGene2AccessionParser.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 
 /**
@@ -46,7 +47,7 @@ public class NcbiGene2AccessionParser extends BasicLineParser<NCBIGene2Accession
      */
     private static final int NCBI_GENE2ACCESSION_FIELDS_PER_ROW = 13;
 
-    private final Collection<NCBIGene2Accession> results = new HashSet<>();
+    private final Set<NCBIGene2Accession> results = new HashSet<>();
     Map<String, NCBIGeneInfo> geneInfo = null;
     private BlockingQueue<NcbiGeneData> queue = null;
     private String lastGeneId = null;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneConverter.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneConverter.java
@@ -40,6 +40,7 @@ import ubic.gemma.persistence.util.SequenceBinUtils;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
 
@@ -226,7 +227,7 @@ public class NcbiGeneConverter implements Converter<Object, Object> {
         // grab all accessions and fill in GeneProduct/DatabaseEntry
         // and associate with Gene
         Collection<NCBIGene2Accession> gene2accession = data.getAccessions();
-        Collection<GeneProduct> geneProducts = new HashSet<>();
+        Set<GeneProduct> geneProducts = new HashSet<>();
 
         for ( NCBIGene2Accession acc : gene2accession ) {
             geneProducts.addAll( this.convert( acc, gene ) );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/model/NCBIGeneInfo.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/model/NCBIGeneInfo.java
@@ -2,10 +2,7 @@ package ubic.gemma.core.loader.genome.gene.ncbi.model;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 /**
  * <p>
@@ -65,7 +62,7 @@ import java.util.Map;
 @SuppressWarnings("unused") // Possible external use
 public class NCBIGeneInfo {
 
-    private final Collection<String> synonyms = new HashSet<>();
+    private final Set<String> synonyms = new HashSet<>();
     private final Map<String, String> dbXrefs = new HashMap<>();
     private int taxId;
     private String geneId;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/biomart/Ensembl2NcbiValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/biomart/Ensembl2NcbiValueObject.java
@@ -21,6 +21,7 @@ package ubic.gemma.core.loader.util.biomart;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Value object that represents a file record line from BioMart as configured with query parameters. Which follows the
@@ -33,7 +34,7 @@ import java.util.HashSet;
 public class Ensembl2NcbiValueObject implements Serializable {
 
     private static final long serialVersionUID = -859220901359582113L;
-    private final Collection<String> ncbiGenes = new HashSet<>();
+    private final Set<String> ncbiGenes = new HashSet<>();
     private String enemblTranscriptId = "";
     private String ensembleGeneId = "";
     private String ensemblPeptideId = "";

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyServiceImpl.java
@@ -611,7 +611,7 @@ public class OntologyServiceImpl implements OntologyService {
         Set<Characteristic> chars = new HashSet<>();
         chars.add( vc );
 
-        Collection<Characteristic> current = bm.getCharacteristics();
+        Set<Characteristic> current = bm.getCharacteristics();
         if ( current == null )
             current = new HashSet<>( chars );
         else

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceImpl.java
@@ -130,7 +130,7 @@ public class GeneOntologyServiceImpl implements GeneOntologyService {
      */
     private final Map<Gene, Collection<OntologyTerm>> goTerms = new HashMap<>();
 
-    private final Collection<SearchIndex> indices = new HashSet<>();
+    private final Set<SearchIndex> indices = new HashSet<>();
 
     private OntModel model;
 

--- a/gemma-core/src/main/java/ubic/gemma/core/search/GeneSetSearchImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/GeneSetSearchImpl.java
@@ -34,10 +34,7 @@ import ubic.gemma.core.genome.gene.service.GeneSetService;
 import ubic.gemma.core.ontology.providers.GeneOntologyService;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
-import ubic.gemma.model.genome.gene.GeneSet;
-import ubic.gemma.model.genome.gene.GeneSetMember;
-import ubic.gemma.model.genome.gene.GeneSetValueObject;
-import ubic.gemma.model.genome.gene.GeneValueObject;
+import ubic.gemma.model.genome.gene.*;
 import ubic.gemma.model.genome.gene.phenotype.valueObject.CharacteristicValueObject;
 import ubic.gemma.persistence.service.association.Gene2GOAssociationService;
 import ubic.gemma.persistence.service.genome.taxon.TaxonService;
@@ -249,11 +246,11 @@ public class GeneSetSearchImpl implements GeneSetSearch {
 
             Collection<Long> geneIds = EntityUtils.getIds( gvos );
 
-            GeneSetValueObject transientGeneSet = new GeneSetValueObject();
+            GeneSetValueObject transientGeneSet = new TransientGeneSetValueObject();
 
             transientGeneSet.setName( this.uri2phenoID( uris.get( uri ) ) );
             transientGeneSet.setDescription( uris.get( uri ).getValue() );
-            transientGeneSet.setGeneIds( geneIds );
+            transientGeneSet.setGeneIds( new HashSet<>( geneIds ) );
 
             transientGeneSet.setTaxonId( gvos.iterator().next().getTaxonId() );
             transientGeneSet.setTaxonName( gvos.iterator().next().getTaxonCommonName() );
@@ -299,7 +296,7 @@ public class GeneSetSearchImpl implements GeneSetSearch {
         allMatches.add( term );
         assert term instanceof OntologyTerm;
         allMatches.addAll( this.geneOntologyService.getAllChildren( ( OntologyTerm ) term ) );
-       // GeneSetSearchImpl.log.info( term );
+        // GeneSetSearchImpl.log.info( term );
         /*
          * Gather up uris
          */

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
@@ -66,7 +66,7 @@ import ubic.gemma.persistence.service.BaseVoEnabledService;
 import ubic.gemma.persistence.service.common.description.CharacteristicService;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 import ubic.gemma.persistence.service.expression.designElement.CompositeSequenceService;
-import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityDao;
+import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentSetService;
 import ubic.gemma.persistence.service.genome.biosequence.BioSequenceService;
@@ -153,9 +153,8 @@ public class SearchServiceImpl implements SearchService {
     @Autowired
     private CompositeSequenceService compositeSequenceService;
 
-    // TODO: use services instead of DAO here
     @Autowired
-    private BlacklistedEntityDao blackListDao;
+    private BlacklistedEntityService blacklistService;
     @Autowired
     private TaxonService taxonService;
 
@@ -596,7 +595,7 @@ public class SearchServiceImpl implements SearchService {
             return results;
         }
 
-        BlacklistedEntity b = blackListDao.findByAccession( searchString );
+        BlacklistedEntity b = blacklistService.findByAccession( searchString );
         if ( b != null ) {
             // FIXME: I'm not sure the ID is a good thing to put here
             results.add( new SearchResult<>( ArrayDesign.class, b.getId(), 1.0, "Blacklisted accessions are not loaded into Gemma" ) );
@@ -1106,7 +1105,7 @@ public class SearchServiceImpl implements SearchService {
                 return results;
             }
 
-            BlacklistedEntity b = blackListDao.findByAccession( settings.getQuery() );
+            BlacklistedEntity b = blacklistService.findByAccession( settings.getQuery() );
             if ( b != null ) {
                 results.add( new SearchResult<>( ExpressionExperiment.class, b.getId(), 1.0, "Blacklisted accessions are not loaded into Gemma" ) );
                 return results;

--- a/gemma-core/src/main/java/ubic/gemma/core/tasks/analysis/expression/PreprocessTaskImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/tasks/analysis/expression/PreprocessTaskImpl.java
@@ -39,14 +39,15 @@ public class PreprocessTaskImpl
     @Override
     public TaskResult execute() {
         ExpressionExperiment ee = taskCommand.getExpressionExperiment();
-        if ( taskCommand.diagnosticsOnly() ) {
-            preprocessorService.processDiagnostics( ee );
-            return new TaskResult( taskCommand, "Diagnostics updated" );
-        }
 
         try {
-            preprocessorService.process( ee );
-            return new TaskResult( taskCommand, "Preprocessing completed" );
+            if ( taskCommand.diagnosticsOnly() ) {
+                preprocessorService.processDiagnostics( ee );
+                return new TaskResult( taskCommand, "Diagnostics updated" );
+            } else {
+                preprocessorService.process( ee );
+                return new TaskResult( taskCommand, "Preprocessing completed" );
+            }
         } catch ( PreprocessingException e ) {
             return new TaskResult( taskCommand, "Failed: " + e.getMessage() );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/tasks/visualization/DifferentialExpressionSearchTaskImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/tasks/visualization/DifferentialExpressionSearchTaskImpl.java
@@ -130,7 +130,7 @@ public class DifferentialExpressionSearchTaskImpl
         DifferentialExpressionSearchTaskImpl.log.info( "Loading " + experimentGroupName + " experiments..." );
 
         // database hit: important that this be fast.
-        Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> analyses = differentialExpressionAnalysisService
+        Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> analyses = differentialExpressionAnalysisService
                 .getAnalysesByExperiment( EntityUtils.getIds( experimentGroup ) );
 
         experiment:

--- a/gemma-core/src/main/java/ubic/gemma/model/IdentifiableValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/IdentifiableValueObject.java
@@ -26,10 +26,18 @@ public abstract class IdentifiableValueObject<O extends Identifiable> implements
         this.id = id;
     }
 
+    /**
+     * Constructor from an existing {@link Identifiable} that sets the ID.
+     * @param identifiable an identifiable used to set this VO's ID
+     */
     protected IdentifiableValueObject( O identifiable ) {
         this( identifiable.getId() );
     }
 
+    /**
+     * Copy constructor from an existing {@link IdentifiableValueObject}.
+     * @param vo a VO whose ID will be copied over this newly created identifiable VO
+     */
     protected IdentifiableValueObject( IdentifiableValueObject vo ) {
         this( vo.getId() );
     }

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/Investigation.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/Investigation.java
@@ -27,6 +27,7 @@ import ubic.gemma.model.common.description.Characteristic;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * An abstract concept of a scientific study
@@ -35,19 +36,19 @@ public abstract class Investigation extends AbstractAuditable implements Securab
 
     private static final long serialVersionUID = -5191564466698945873L;
 
-    private Collection<Characteristic> characteristics = new HashSet<>();
-    private Collection<BibliographicReference> otherRelevantPublications = new HashSet<>();
+    private Set<Characteristic> characteristics = new HashSet<>();
+    private Set<BibliographicReference> otherRelevantPublications = new HashSet<>();
     private Contact owner;
     private BibliographicReference primaryPublication;
 
     /**
      * @return Annotations that describe the experiment as a whole, for example "tumor" or "brain".
      */
-    public Collection<Characteristic> getCharacteristics() {
+    public Set<Characteristic> getCharacteristics() {
         return this.characteristics;
     }
 
-    public void setCharacteristics( Collection<Characteristic> characteristics ) {
+    public void setCharacteristics( Set<Characteristic> characteristics ) {
         this.characteristics = characteristics;
     }
 
@@ -56,11 +57,11 @@ public abstract class Investigation extends AbstractAuditable implements Securab
      *         data but
      *         are not the primary publication for the investigation).
      */
-    public Collection<BibliographicReference> getOtherRelevantPublications() {
+    public Set<BibliographicReference> getOtherRelevantPublications() {
         return this.otherRelevantPublications;
     }
 
-    public void setOtherRelevantPublications( Collection<BibliographicReference> otherRelevantPublications ) {
+    public void setOtherRelevantPublications( Set<BibliographicReference> otherRelevantPublications ) {
         this.otherRelevantPublications = otherRelevantPublications;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/ExpressionExperimentSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/ExpressionExperimentSet.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import ubic.gemma.model.genome.Taxon;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A grouping of expression studies.
@@ -39,7 +40,7 @@ public class ExpressionExperimentSet extends AbstractAuditable implements Secura
      */
     private static final long serialVersionUID = -1034074709420077917L;
     private ubic.gemma.model.genome.Taxon taxon;
-    private Collection<BioAssaySet> experiments = new HashSet<>();
+    private Set<BioAssaySet> experiments = new HashSet<>();
 
     /**
      * No-arg constructor added to satisfy javabean contract
@@ -47,11 +48,11 @@ public class ExpressionExperimentSet extends AbstractAuditable implements Secura
     public ExpressionExperimentSet() {
     }
 
-    public Collection<BioAssaySet> getExperiments() {
+    public Set<BioAssaySet> getExperiments() {
         return this.experiments;
     }
 
-    public void setExperiments( Collection<BioAssaySet> experiments ) {
+    public void setExperiments( Set<BioAssaySet> experiments ) {
         this.experiments = experiments;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/FactorAssociatedAnalysisResultSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/FactorAssociatedAnalysisResultSet.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 public abstract class FactorAssociatedAnalysisResultSet<R extends AnalysisResult> extends AnalysisResultSet<R> {
 
@@ -32,7 +33,7 @@ public abstract class FactorAssociatedAnalysisResultSet<R extends AnalysisResult
      */
     private static final long serialVersionUID = 821072688513147160L;
 
-    private Collection<ExperimentalFactor> experimentalFactors = new HashSet<>();
+    private Set<ExperimentalFactor> experimentalFactors = new HashSet<>();
 
     /**
      * No-arg constructor added to satisfy javabean contract
@@ -42,11 +43,11 @@ public abstract class FactorAssociatedAnalysisResultSet<R extends AnalysisResult
     public FactorAssociatedAnalysisResultSet() {
     }
 
-    public Collection<ExperimentalFactor> getExperimentalFactors() {
+    public Set<ExperimentalFactor> getExperimentalFactors() {
         return this.experimentalFactors;
     }
 
-    public void setExperimentalFactors( Collection<ExperimentalFactor> experimentalFactors ) {
+    public void setExperimentalFactors( Set<ExperimentalFactor> experimentalFactors ) {
         this.experimentalFactors = experimentalFactors;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DiffExResultSetSummaryValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DiffExResultSetSummaryValueObject.java
@@ -27,6 +27,7 @@ import ubic.gemma.persistence.util.EntityUtils;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Summary of a result set.
@@ -48,7 +49,7 @@ public class DiffExResultSetSummaryValueObject implements java.io.Serializable {
 
     private Integer downregulatedCount;
 
-    private Collection<ExperimentalFactorValueObject> experimentalFactors = new HashSet<>();
+    private Set<ExperimentalFactorValueObject> experimentalFactors = new HashSet<>();
 
     private Collection<Long> factorIds;
 
@@ -151,7 +152,7 @@ public class DiffExResultSetSummaryValueObject implements java.io.Serializable {
         this.downregulatedCount = downregulatedCount;
     }
 
-    public Collection<ExperimentalFactorValueObject> getExperimentalFactors() {
+    public Set<ExperimentalFactorValueObject> getExperimentalFactors() {
         return experimentalFactors;
     }
 
@@ -256,7 +257,7 @@ public class DiffExResultSetSummaryValueObject implements java.io.Serializable {
         return Objects.equals( id, other.id );
     }
 
-    public void setExperimentalFactorsByValueObject( Collection<ExperimentalFactorValueObject> experimentalFactors ) {
+    public void setExperimentalFactorsByValueObject( Set<ExperimentalFactorValueObject> experimentalFactors ) {
         this.experimentalFactors = experimentalFactors;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysis.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,6 +23,7 @@ import ubic.gemma.model.expression.experiment.FactorValue;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * An analysis of changes in expression levels across experimental conditions
@@ -31,7 +32,7 @@ public class DifferentialExpressionAnalysis extends SingleExperimentAnalysis {
 
     private static final long serialVersionUID = -7855180617739271699L;
     private FactorValue subsetFactorValue;
-    private Collection<ExpressionAnalysisResultSet> resultSets = new HashSet<>();
+    private Set<ExpressionAnalysisResultSet> resultSets = new HashSet<>();
 
     /**
      * Groups of results produced by this ExpressionAnalysis. For example, in a two-way ANOVA, the model has 2 or 3
@@ -41,11 +42,11 @@ public class DifferentialExpressionAnalysis extends SingleExperimentAnalysis {
      *
      * @return the result sets
      */
-    public Collection<ExpressionAnalysisResultSet> getResultSets() {
+    public Set<ExpressionAnalysisResultSet> getResultSets() {
         return this.resultSets;
     }
 
-    public void setResultSets( Collection<ExpressionAnalysisResultSet> resultSets ) {
+    public void setResultSets( Set<ExpressionAnalysisResultSet> resultSets ) {
         this.resultSets = resultSets;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResult.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResult.java
@@ -24,6 +24,7 @@ import ubic.gemma.model.expression.designElement.CompositeSequence;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Result of an analysis of differences in expression levels -- a single test (e.g., for one gene or one probe), for one
@@ -44,7 +45,7 @@ public class DifferentialExpressionAnalysisResult extends AnalysisResult impleme
     private Double rank;
     private Integer correctedPValueBin;
     private Long id;
-    private Collection<ContrastResult> contrasts = new HashSet<>();
+    private Set<ContrastResult> contrasts = new HashSet<>();
     private ExpressionAnalysisResultSet resultSet;
     private CompositeSequence probe;
 
@@ -113,11 +114,11 @@ public class DifferentialExpressionAnalysisResult extends AnalysisResult impleme
      * @return Contrasts for this result. Depending on configuration, this might only be stored if the Result itself is
      * significant at some given threshold (e.g., nominal p-value of 0.05) (but default is to store everything)
      */
-    public Collection<ContrastResult> getContrasts() {
+    public Set<ContrastResult> getContrasts() {
         return this.contrasts;
     }
 
-    public void setContrasts( Collection<ContrastResult> contrasts ) {
+    public void setContrasts( Set<ContrastResult> contrasts ) {
         this.contrasts = contrasts;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisValueObject.java
@@ -19,10 +19,7 @@ import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
 import ubic.gemma.model.expression.experiment.FactorValueValueObject;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Summary of a differential expression analysis
@@ -37,7 +34,7 @@ public class DifferentialExpressionAnalysisValueObject extends AnalysisValueObje
     private static final long serialVersionUID = 622877438067070041L;
 
     private Map<Long, Collection<FactorValueValueObject>> factorValuesUsed = new HashMap<>();
-    private Collection<DiffExResultSetSummaryValueObject> resultSets = new HashSet<>();
+    private Set<DiffExResultSetSummaryValueObject> resultSets = new HashSet<>();
     private Collection<Long> arrayDesignsUsed = null;
     private Long bioAssaySetId;
     private Long sourceExperiment;
@@ -89,11 +86,11 @@ public class DifferentialExpressionAnalysisValueObject extends AnalysisValueObje
         this.factorValuesUsed = factorValuesUsed;
     }
 
-    public Collection<DiffExResultSetSummaryValueObject> getResultSets() {
+    public Set<DiffExResultSetSummaryValueObject> getResultSets() {
         return resultSets;
     }
 
-    public void setResultSets( Collection<DiffExResultSetSummaryValueObject> resultSets ) {
+    public void setResultSets( Set<DiffExResultSetSummaryValueObject> resultSets ) {
         this.resultSets = resultSets;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionValueObject.java
@@ -25,6 +25,7 @@ import ubic.gemma.model.genome.gene.GeneValueObject;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents the results for one probe. Fairly heavy-weight.
@@ -37,7 +38,7 @@ public class DifferentialExpressionValueObject {
     private final ContrastsValueObject contrasts;
     private Double corrP;
     private Direction direction;
-    private Collection<ExperimentalFactorValueObject> experimentalFactors = new HashSet<>();
+    private Set<ExperimentalFactorValueObject> experimentalFactors = new HashSet<>();
     private ExpressionExperimentValueObject expressionExperiment;
     private Boolean fisherContribution = false;
     private GeneValueObject gene;
@@ -100,11 +101,11 @@ public class DifferentialExpressionValueObject {
         this.direction = direction;
     }
 
-    public Collection<ExperimentalFactorValueObject> getExperimentalFactors() {
+    public Set<ExperimentalFactorValueObject> getExperimentalFactors() {
         return experimentalFactors;
     }
 
-    public void setExperimentalFactors( Collection<ExperimentalFactorValueObject> experimentalFactors ) {
+    public void setExperimentalFactors( Set<ExperimentalFactorValueObject> experimentalFactors ) {
         this.experimentalFactors = experimentalFactors;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ExpressionAnalysisResultSet.java
@@ -28,6 +28,7 @@ import ubic.gemma.model.genome.Gene;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A group of results for an ExpressionExperiment.
@@ -41,7 +42,7 @@ public class ExpressionAnalysisResultSet extends FactorAssociatedAnalysisResultS
     private Collection<DifferentialExpressionAnalysisResult> results = new java.util.HashSet<>();
     private DifferentialExpressionAnalysis analysis;
     private PvalueDistribution pvalueDistribution;
-    private Collection<HitListSize> hitListSizes = new HashSet<>();
+    private Set<HitListSize> hitListSizes = new HashSet<>();
 
     @Override
     public String toString() {
@@ -100,11 +101,11 @@ public class ExpressionAnalysisResultSet extends FactorAssociatedAnalysisResultS
         this.baselineGroup = baselineGroup;
     }
 
-    public Collection<HitListSize> getHitListSizes() {
+    public Set<HitListSize> getHitListSizes() {
         return this.hitListSizes;
     }
 
-    public void setHitListSizes( Collection<HitListSize> hitListSizes ) {
+    public void setHitListSizes( Set<HitListSize> hitListSizes ) {
         this.hitListSizes = hitListSizes;
     }
 
@@ -154,10 +155,10 @@ public class ExpressionAnalysisResultSet extends FactorAssociatedAnalysisResultS
             return new ExpressionAnalysisResultSet();
         }
 
-        public static ExpressionAnalysisResultSet newInstance( Collection<ExperimentalFactor> experimentalFactors,
+        public static ExpressionAnalysisResultSet newInstance( Set<ExperimentalFactor> experimentalFactors,
                 Integer numberOfProbesTested, java.lang.Integer numberOfGenesTested, FactorValue baselineGroup,
                 Collection<DifferentialExpressionAnalysisResult> results, DifferentialExpressionAnalysis analysis,
-                PvalueDistribution pvalueDistribution, Collection<HitListSize> hitListSizes ) {
+                PvalueDistribution pvalueDistribution, Set<HitListSize> hitListSizes ) {
             final ExpressionAnalysisResultSet entity = new ExpressionAnalysisResultSet();
             entity.setExperimentalFactors( experimentalFactors );
             entity.setNumberOfProbesTested( numberOfProbesTested );

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/GeneDifferentialExpressionMetaAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/GeneDifferentialExpressionMetaAnalysis.java
@@ -23,6 +23,7 @@ import ubic.gemma.model.analysis.expression.ExpressionAnalysis;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents an analysis that combines the results of other analyses of differential expression.
@@ -32,8 +33,8 @@ public class GeneDifferentialExpressionMetaAnalysis extends ExpressionAnalysis i
     private static final long serialVersionUID = -2588180973962410595L;
     private Integer numGenesAnalyzed;
     private Double qvalueThresholdForStorage;
-    private Collection<ExpressionAnalysisResultSet> resultSetsIncluded = new HashSet<>();
-    private Collection<GeneDifferentialExpressionMetaAnalysisResult> results = new HashSet<>();
+    private Set<ExpressionAnalysisResultSet> resultSetsIncluded = new HashSet<>();
+    private Set<GeneDifferentialExpressionMetaAnalysisResult> results = new HashSet<>();
 
     /**
      * @return How many genes were included in the meta-analysis. This does not mean that all genes were analyzed in all the
@@ -58,19 +59,19 @@ public class GeneDifferentialExpressionMetaAnalysis extends ExpressionAnalysis i
         this.qvalueThresholdForStorage = qvalueThresholdForStorage;
     }
 
-    public Collection<GeneDifferentialExpressionMetaAnalysisResult> getResults() {
+    public Set<GeneDifferentialExpressionMetaAnalysisResult> getResults() {
         return this.results;
     }
 
-    public void setResults( Collection<GeneDifferentialExpressionMetaAnalysisResult> results ) {
+    public void setResults( Set<GeneDifferentialExpressionMetaAnalysisResult> results ) {
         this.results = results;
     }
 
-    public Collection<ExpressionAnalysisResultSet> getResultSetsIncluded() {
+    public Set<ExpressionAnalysisResultSet> getResultSetsIncluded() {
         return this.resultSetsIncluded;
     }
 
-    public void setResultSetsIncluded( Collection<ExpressionAnalysisResultSet> resultSetsIncluded ) {
+    public void setResultSetsIncluded( Set<ExpressionAnalysisResultSet> resultSetsIncluded ) {
         this.resultSetsIncluded = resultSetsIncluded;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/GeneDifferentialExpressionMetaAnalysisResult.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/GeneDifferentialExpressionMetaAnalysisResult.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import ubic.gemma.model.genome.Gene;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 @SuppressWarnings("unused") // Possible external usage
 public class GeneDifferentialExpressionMetaAnalysisResult implements java.io.Serializable {
@@ -37,7 +38,7 @@ public class GeneDifferentialExpressionMetaAnalysisResult implements java.io.Ser
     private Boolean upperTail;
     private Long id;
     private Gene gene;
-    private Collection<DifferentialExpressionAnalysisResult> resultsUsed = new HashSet<>();
+    private Set<DifferentialExpressionAnalysisResult> resultsUsed = new HashSet<>();
 
     public Gene getGene() {
         return this.gene;
@@ -97,11 +98,11 @@ public class GeneDifferentialExpressionMetaAnalysisResult implements java.io.Ser
     /**
      * @return The underlying differential expression results that contributed to the meta-analysis result.
      */
-    public Collection<DifferentialExpressionAnalysisResult> getResultsUsed() {
+    public Set<DifferentialExpressionAnalysisResult> getResultsUsed() {
         return this.resultsUsed;
     }
 
-    public void setResultsUsed( Collection<DifferentialExpressionAnalysisResult> resultsUsed ) {
+    public void setResultsUsed( Set<DifferentialExpressionAnalysisResult> resultsUsed ) {
         this.resultsUsed = resultsUsed;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/pca/PrincipalComponentAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/pca/PrincipalComponentAnalysis.java
@@ -34,9 +34,9 @@ public class PrincipalComponentAnalysis extends SingleExperimentAnalysis {
     private Integer numComponentsStored;
     private Integer maxNumProbesPerComponent;
     private BioAssayDimension bioAssayDimension;
-    private Collection<ProbeLoading> probeLoadings = new HashSet<>();
-    private Collection<Eigenvalue> eigenValues = new HashSet<>();
-    private Collection<Eigenvector> eigenVectors = new HashSet<>();
+    private Set<ProbeLoading> probeLoadings = new HashSet<>();
+    private Set<Eigenvalue> eigenValues = new HashSet<>();
+    private Set<Eigenvector> eigenVectors = new HashSet<>();
 
     public ubic.gemma.model.expression.bioAssayData.BioAssayDimension getBioAssayDimension() {
         return this.bioAssayDimension;
@@ -46,19 +46,19 @@ public class PrincipalComponentAnalysis extends SingleExperimentAnalysis {
         this.bioAssayDimension = bioAssayDimension;
     }
 
-    public Collection<Eigenvalue> getEigenValues() {
+    public Set<Eigenvalue> getEigenValues() {
         return this.eigenValues;
     }
 
-    public void setEigenValues( Collection<Eigenvalue> eigenValues ) {
+    public void setEigenValues( Set<Eigenvalue> eigenValues ) {
         this.eigenValues = eigenValues;
     }
 
-    public Collection<Eigenvector> getEigenVectors() {
+    public Set<Eigenvector> getEigenVectors() {
         return this.eigenVectors;
     }
 
-    public void setEigenVectors( Collection<Eigenvector> eigenVectors ) {
+    public void setEigenVectors( Set<Eigenvector> eigenVectors ) {
         this.eigenVectors = eigenVectors;
     }
 
@@ -84,11 +84,11 @@ public class PrincipalComponentAnalysis extends SingleExperimentAnalysis {
         this.numComponentsStored = numComponentsStored;
     }
 
-    public Collection<ProbeLoading> getProbeLoadings() {
+    public Set<ProbeLoading> getProbeLoadings() {
         return this.probeLoadings;
     }
 
-    public void setProbeLoadings( Collection<ProbeLoading> probeLoadings ) {
+    public void setProbeLoadings( Set<ProbeLoading> probeLoadings ) {
         this.probeLoadings = probeLoadings;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/association/phenotype/PhenotypeAssociation.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/association/phenotype/PhenotypeAssociation.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import ubic.gemma.model.genome.Gene;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents abstract evidence for the association of a gene with a phenotype.
@@ -45,11 +46,11 @@ public abstract class PhenotypeAssociation extends AbstractAuditable implements 
     private String score;
     private Double strength;
     private Gene gene;
-    private Collection<Characteristic> phenotypes = new HashSet<>();
+    private Set<Characteristic> phenotypes = new HashSet<>();
     private Characteristic associationType;
     private DatabaseEntry evidenceSource;
     private QuantitationType scoreType;
-    private Collection<PhenotypeAssociationPublication> phenotypeAssociationPublications = new HashSet<>();
+    private Set<PhenotypeAssociationPublication> phenotypeAssociationPublications = new HashSet<>();
     private PhenotypeMappingType mappingType;
     private String originalPhenotype;
     private String relationship; // information for a gene-disease relationship
@@ -117,11 +118,11 @@ public abstract class PhenotypeAssociation extends AbstractAuditable implements 
      * @return The phenotype this association is about. A phenotype is (basically) a term from a controlled vocabulary such as a
      * disease.
      */
-    public Collection<Characteristic> getPhenotypes() {
+    public Set<Characteristic> getPhenotypes() {
         return this.phenotypes;
     }
 
-    public void setPhenotypes( Collection<Characteristic> phenotypes ) {
+    public void setPhenotypes( Set<Characteristic> phenotypes ) {
         this.phenotypes = phenotypes;
     }
 
@@ -160,12 +161,12 @@ public abstract class PhenotypeAssociation extends AbstractAuditable implements 
         this.strength = strength;
     }
 
-    public Collection<PhenotypeAssociationPublication> getPhenotypeAssociationPublications() {
+    public Set<PhenotypeAssociationPublication> getPhenotypeAssociationPublications() {
         return phenotypeAssociationPublications;
     }
 
     public void setPhenotypeAssociationPublications(
-            Collection<PhenotypeAssociationPublication> phenotypeAssociationPublications ) {
+            Set<PhenotypeAssociationPublication> phenotypeAssociationPublications ) {
         this.phenotypeAssociationPublications = phenotypeAssociationPublications;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/common/auditAndSecurity/AuditEventValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/auditAndSecurity/AuditEventValueObject.java
@@ -56,7 +56,7 @@ public class AuditEventValueObject extends IdentifiableValueObject<AuditEvent> i
     }
 
     public AuditEventValueObject( AuditEvent ae ) {
-        super( ae.getId() );
+        super( ae );
         if ( ae.getPerformer() != null )
             this.setPerformer( ae.getPerformer().getUserName() );
         if ( ae.getAction() != null )

--- a/gemma-core/src/main/java/ubic/gemma/model/common/description/BibliographicReference.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/description/BibliographicReference.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import ubic.gemma.model.expression.biomaterial.Compound;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 
 public class BibliographicReference extends Describable {
 
@@ -48,14 +49,14 @@ public class BibliographicReference extends Describable {
     private Boolean retracted = false;
 
     /**
-     * @deprecated  never used
+     * @deprecated never used
      */
     @Deprecated
-    private Collection<Characteristic> annotations = new HashSet<>();
+    private Set<Characteristic> annotations = new HashSet<>();
 
-    private Collection<MedicalSubjectHeading> meshTerms = new HashSet<>();
-    private Collection<Keyword> keywords = new HashSet<>();
-    private Collection<Compound> chemicals = new HashSet<>();
+    private Set<MedicalSubjectHeading> meshTerms = new HashSet<>();
+    private Set<Keyword> keywords = new HashSet<>();
+    private Set<Compound> chemicals = new HashSet<>();
 
     public String getAbstractText() {
         return this.abstractText;
@@ -77,12 +78,12 @@ public class BibliographicReference extends Describable {
     }
 
     // never used
-    public Collection<Characteristic> getAnnotations() {
+    public Set<Characteristic> getAnnotations() {
         return this.annotations;
     }
 
     // never used
-    public void setAnnotations( Collection<Characteristic> annotations ) {
+    public void setAnnotations( Set<Characteristic> annotations ) {
         this.annotations = annotations;
     }
 
@@ -94,11 +95,11 @@ public class BibliographicReference extends Describable {
         this.authorList = authorList;
     }
 
-    public Collection<Compound> getChemicals() {
+    public Set<Compound> getChemicals() {
         return this.chemicals;
     }
 
-    public void setChemicals( Collection<ubic.gemma.model.expression.biomaterial.Compound> chemicals ) {
+    public void setChemicals( Set<ubic.gemma.model.expression.biomaterial.Compound> chemicals ) {
         this.chemicals = chemicals;
     }
 
@@ -140,19 +141,19 @@ public class BibliographicReference extends Describable {
         this.issue = issue;
     }
 
-    public Collection<Keyword> getKeywords() {
+    public Set<Keyword> getKeywords() {
         return this.keywords;
     }
 
-    public void setKeywords( Collection<Keyword> keywords ) {
+    public void setKeywords( Set<Keyword> keywords ) {
         this.keywords = keywords;
     }
 
-    public Collection<MedicalSubjectHeading> getMeshTerms() {
+    public Set<MedicalSubjectHeading> getMeshTerms() {
         return this.meshTerms;
     }
 
-    public void setMeshTerms( Collection<MedicalSubjectHeading> meshTerms ) {
+    public void setMeshTerms( Set<MedicalSubjectHeading> meshTerms ) {
         this.meshTerms = meshTerms;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/common/description/BibliographicReferenceValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/description/BibliographicReferenceValueObject.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2007 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -37,7 +37,7 @@ public class BibliographicReferenceValueObject extends IdentifiableValueObject<B
     private String abstractText;
     private String authorList;
     private CitationValueObject citation;
-    private Collection<ExpressionExperimentValueObject> experiments = new HashSet<>();
+    private Set<ExpressionExperimentValueObject> experiments = new HashSet<>();
     private String issue;
     private String pages;
     private String pubAccession;
@@ -48,7 +48,7 @@ public class BibliographicReferenceValueObject extends IdentifiableValueObject<B
     private String volume;
     private Collection<String> meshTerms;
     private Collection<String> chemicalsTerms;
-    private Collection<BibliographicPhenotypesValueObject> bibliographicPhenotypes = new HashSet<>();
+    private Set<BibliographicPhenotypesValueObject> bibliographicPhenotypes = new HashSet<>();
     private boolean retracted = false;
 
     /**
@@ -87,7 +87,7 @@ public class BibliographicReferenceValueObject extends IdentifiableValueObject<B
 
     public BibliographicReferenceValueObject( Long id, String abstractText, String authorList, String issue,
             String pages, String pubAccession, String publication, Date publicationDate, String publisher, String title,
-            String volume, Collection<ExpressionExperimentValueObject> experiments ) {
+            String volume, Set<ExpressionExperimentValueObject> experiments ) {
         super( id );
         this.abstractText = abstractText;
         this.authorList = authorList;
@@ -158,11 +158,11 @@ public class BibliographicReferenceValueObject extends IdentifiableValueObject<B
         this.authorList = authorList;
     }
 
-    public Collection<BibliographicPhenotypesValueObject> getBibliographicPhenotypes() {
+    public Set<BibliographicPhenotypesValueObject> getBibliographicPhenotypes() {
         return this.bibliographicPhenotypes;
     }
 
-    public void setBibliographicPhenotypes( Collection<BibliographicPhenotypesValueObject> bibliographicPhenotypes ) {
+    public void setBibliographicPhenotypes( Set<BibliographicPhenotypesValueObject> bibliographicPhenotypes ) {
         this.bibliographicPhenotypes = bibliographicPhenotypes;
     }
 
@@ -190,14 +190,14 @@ public class BibliographicReferenceValueObject extends IdentifiableValueObject<B
     /**
      * @return the experiments
      */
-    public Collection<ExpressionExperimentValueObject> getExperiments() {
+    public Set<ExpressionExperimentValueObject> getExperiments() {
         return experiments;
     }
 
     /**
      * @param experiments the experiments to set
      */
-    public void setExperiments( Collection<ExpressionExperimentValueObject> experiments ) {
+    public void setExperiments( Set<ExpressionExperimentValueObject> experiments ) {
         this.experiments = experiments;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/arrayDesign/ArrayDesign.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/arrayDesign/ArrayDesign.java
@@ -30,6 +30,7 @@ import ubic.gemma.model.genome.Taxon;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents an assembly of design elements that are assayed all at once.
@@ -51,17 +52,17 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
      */
     private static final long serialVersionUID = -7566439134502613470L;
     private Integer advertisedNumberOfDesignElements;
-    private Collection<AlternateName> alternateNames = new HashSet<>();
+    private Set<AlternateName> alternateNames = new HashSet<>();
     private ArrayDesign alternativeTo; // for affymetrix
-    private Collection<CompositeSequence> compositeSequences = new HashSet<>();
+    private Set<CompositeSequence> compositeSequences = new HashSet<>();
     private CurationDetails curationDetails;
     private Contact designProvider;
-    private Collection<DatabaseEntry> externalReferences = new HashSet<>();
+    private Set<DatabaseEntry> externalReferences = new HashSet<>();
     private ArrayDesign mergedInto;
-    private Collection<ArrayDesign> mergees = new HashSet<>();
+    private Set<ArrayDesign> mergees = new HashSet<>();
     private Taxon primaryTaxon;
     private String shortName;
-    private Collection<ArrayDesign> subsumedArrayDesigns = new HashSet<>();
+    private Set<ArrayDesign> subsumedArrayDesigns = new HashSet<>();
     private ArrayDesign subsumingArrayDesign;
 
     private TechnologyType technologyType;
@@ -95,7 +96,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
         return this.advertisedNumberOfDesignElements;
     }
 
-    public Collection<AlternateName> getAlternateNames() {
+    public Set<AlternateName> getAlternateNames() {
         return this.alternateNames;
     }
 
@@ -107,7 +108,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
         return alternativeTo;
     }
 
-    public Collection<CompositeSequence> getCompositeSequences() {
+    public Set<CompositeSequence> getCompositeSequences() {
         return this.compositeSequences;
     }
 
@@ -123,7 +124,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
     /**
      * @return Accessions for this array design in other databases, e.g., GEO, ArrayExpression.
      */
-    public Collection<DatabaseEntry> getExternalReferences() {
+    public Set<DatabaseEntry> getExternalReferences() {
         return this.externalReferences;
     }
 
@@ -131,7 +132,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
         return this.mergedInto;
     }
 
-    public Collection<ArrayDesign> getMergees() {
+    public Set<ArrayDesign> getMergees() {
         return this.mergees;
     }
 
@@ -159,7 +160,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
      *         elements
      *         that are on the HG-U133A and HG-U133B, so they are subsumed by the HG-U133_Plus_2.
      */
-    public Collection<ArrayDesign> getSubsumedArrayDesigns() {
+    public Set<ArrayDesign> getSubsumedArrayDesigns() {
         return this.subsumedArrayDesigns;
     }
 
@@ -188,7 +189,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
         this.advertisedNumberOfDesignElements = advertisedNumberOfDesignElements;
     }
 
-    public void setAlternateNames( Collection<AlternateName> alternateNames ) {
+    public void setAlternateNames( Set<AlternateName> alternateNames ) {
         this.alternateNames = alternateNames;
     }
 
@@ -197,7 +198,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
     }
 
     public void setCompositeSequences(
-            Collection<CompositeSequence> compositeSequences ) {
+            Set<CompositeSequence> compositeSequences ) {
         this.compositeSequences = compositeSequences;
     }
 
@@ -211,7 +212,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
     }
 
     public void setExternalReferences(
-            Collection<DatabaseEntry> externalReferences ) {
+            Set<DatabaseEntry> externalReferences ) {
         this.externalReferences = externalReferences;
     }
 
@@ -219,7 +220,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
         this.mergedInto = mergedInto;
     }
 
-    public void setMergees( Collection<ArrayDesign> mergees ) {
+    public void setMergees( Set<ArrayDesign> mergees ) {
         this.mergees = mergees;
     }
 
@@ -232,7 +233,7 @@ public class ArrayDesign extends AbstractAuditable implements gemma.gsec.model.S
     }
 
     public void setSubsumedArrayDesigns(
-            Collection<ArrayDesign> subsumedArrayDesigns ) {
+            Set<ArrayDesign> subsumedArrayDesigns ) {
         this.subsumedArrayDesigns = subsumedArrayDesigns;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/biomaterial/BioMaterial.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/biomaterial/BioMaterial.java
@@ -30,6 +30,7 @@ import ubic.gemma.model.genome.Taxon;
 import javax.persistence.Transient;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * In MAGE, BioMaterial is an abstract class that represents the important substances such as cells, tissues, DNA,
@@ -41,25 +42,25 @@ public class BioMaterial extends Describable implements gemma.gsec.model.Secured
 
     private static final long serialVersionUID = 4374359557498220256L;
     private ubic.gemma.model.genome.Taxon sourceTaxon;
-    private Collection<FactorValue> factorValues = new HashSet<>();
-    private Collection<BioAssay> bioAssaysUsedIn = new HashSet<>();
-    private Collection<Treatment> treatments = new HashSet<>();
-    private Collection<Characteristic> characteristics = new HashSet<>();
+    private Set<FactorValue> factorValues = new HashSet<>();
+    private Set<BioAssay> bioAssaysUsedIn = new HashSet<>();
+    private Set<Treatment> treatments = new HashSet<>();
+    private Set<Characteristic> characteristics = new HashSet<>();
     private DatabaseEntry externalAccession;
 
-    public Collection<BioAssay> getBioAssaysUsedIn() {
+    public Set<BioAssay> getBioAssaysUsedIn() {
         return this.bioAssaysUsedIn;
     }
 
-    public void setBioAssaysUsedIn( Collection<BioAssay> bioAssaysUsedIn ) {
+    public void setBioAssaysUsedIn( Set<BioAssay> bioAssaysUsedIn ) {
         this.bioAssaysUsedIn = bioAssaysUsedIn;
     }
 
-    public Collection<Characteristic> getCharacteristics() {
+    public Set<Characteristic> getCharacteristics() {
         return this.characteristics;
     }
 
-    public void setCharacteristics( Collection<Characteristic> characteristics ) {
+    public void setCharacteristics( Set<Characteristic> characteristics ) {
         this.characteristics = characteristics;
     }
 
@@ -81,11 +82,11 @@ public class BioMaterial extends Describable implements gemma.gsec.model.Secured
     /**
      * @return The values that this BioAssay is associated with for the experiment.
      */
-    public Collection<FactorValue> getFactorValues() {
+    public Set<FactorValue> getFactorValues() {
         return this.factorValues;
     }
 
-    public void setFactorValues( Collection<FactorValue> factorValues ) {
+    public void setFactorValues( Set<FactorValue> factorValues ) {
         this.factorValues = factorValues;
     }
 
@@ -103,11 +104,11 @@ public class BioMaterial extends Describable implements gemma.gsec.model.Secured
         this.sourceTaxon = sourceTaxon;
     }
 
-    public Collection<Treatment> getTreatments() {
+    public Set<Treatment> getTreatments() {
         return this.treatments;
     }
 
-    public void setTreatments( Collection<Treatment> treatments ) {
+    public void setTreatments( Set<Treatment> treatments ) {
         this.treatments = treatments;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/biomaterial/BioMaterialValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/biomaterial/BioMaterialValueObject.java
@@ -40,11 +40,11 @@ public class BioMaterialValueObject extends IdentifiableValueObject<BioMaterial>
 
     private static final String CHARACTERISTIC_DELIMITER = "::::";
     private static final long serialVersionUID = -145137827948521045L;
-    private final Collection<FactorValueBasicValueObject> fVBasicVOs = new HashSet<>();
+    private final Set<FactorValueBasicValueObject> fVBasicVOs = new HashSet<>();
     private String assayDescription;
     private String assayName;
-    private Collection<Long> bioAssays = new HashSet<>();
-    private Collection<CharacteristicValueObject> characteristics = new HashSet<>();
+    private Set<Long> bioAssays = new HashSet<>();
+    private Set<CharacteristicValueObject> characteristics = new HashSet<>();
     private String description;
     /**
      * Map of factor ids (factor232) to factor value (id or the actual value) for this biomaterial.
@@ -54,7 +54,7 @@ public class BioMaterialValueObject extends IdentifiableValueObject<BioMaterial>
      * Map of ids (factor232) to a representation of the factor (e.g., the name).
      */
     private Map<String, String> factors;
-    private Collection<FactorValueValueObject> factorValueObjects = new HashSet<>();
+    private Set<FactorValueValueObject> factorValueObjects = new HashSet<>();
     /**
      * Map of ids (fv133) to a representation of the value (for this biomaterial.)
      */
@@ -195,11 +195,11 @@ public class BioMaterialValueObject extends IdentifiableValueObject<BioMaterial>
         this.assayName = assayName;
     }
 
-    public Collection<Long> getBioAssays() {
+    public Set<Long> getBioAssays() {
         return bioAssays;
     }
 
-    public void setBioAssays( Collection<Long> bioAssays ) {
+    public void setBioAssays( Set<Long> bioAssays ) {
         this.bioAssays = bioAssays;
     }
 
@@ -227,7 +227,7 @@ public class BioMaterialValueObject extends IdentifiableValueObject<BioMaterial>
         this.factors = factors;
     }
 
-    public Collection<? extends IdentifiableValueObject> getFactorValueObjects() {
+    public Set<? extends IdentifiableValueObject> getFactorValueObjects() {
         return basicFVs ? fVBasicVOs : factorValueObjects;
     }
 
@@ -240,7 +240,7 @@ public class BioMaterialValueObject extends IdentifiableValueObject<BioMaterial>
         this.characteristicValues = characteristicValues;
     }
 
-    public void setFactorValueObjects( Collection<FactorValueValueObject> factorValueObjects ) {
+    public void setFactorValueObjects( Set<FactorValueValueObject> factorValueObjects ) {
         this.factorValueObjects = factorValueObjects;
     }
 
@@ -260,11 +260,11 @@ public class BioMaterialValueObject extends IdentifiableValueObject<BioMaterial>
         this.name = name;
     }
 
-    public Collection<CharacteristicValueObject> getCharacteristics() {
+    public Set<CharacteristicValueObject> getCharacteristics() {
         return characteristics;
     }
 
-    public void setCharacteristics( Collection<CharacteristicValueObject> characteristicsDetails ) {
+    public void setCharacteristics( Set<CharacteristicValueObject> characteristicsDetails ) {
         this.characteristics = characteristicsDetails;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/BioAssaySet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/BioAssaySet.java
@@ -25,6 +25,7 @@ import ubic.gemma.model.expression.bioAssay.BioAssay;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents a set of BioAssays. This is not associated with any actual data, and soley represents a logical grouping
@@ -35,7 +36,7 @@ public abstract class BioAssaySet extends Investigation {
 
     private static final long serialVersionUID = 2368063046639481521L;
     private DatabaseEntry accession;
-    protected Collection<BioAssay> bioAssays = new HashSet<>();
+    protected Set<BioAssay> bioAssays = new HashSet<>();
 
     public DatabaseEntry getAccession() {
         return this.accession;
@@ -48,7 +49,7 @@ public abstract class BioAssaySet extends Investigation {
     @SuppressWarnings("JpaAttributeTypeInspection") // Inspector is not handling this correctly
     public abstract Collection<BioAssay> getBioAssays();
 
-    public abstract void setBioAssays( Collection<BioAssay> bioAssays );
+    public abstract void setBioAssays( Set<BioAssay> bioAssays );
 
     /**
      * Special use case. Use a constructor of the desired VO instead, or the loadValueObject() in all VO-Enabled services.

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExperimentalDesign.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExperimentalDesign.java
@@ -24,6 +24,8 @@ import ubic.gemma.model.common.description.Characteristic;
 
 import javax.persistence.Transient;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ExperimentalDesign extends Describable implements gemma.gsec.model.SecuredChild {
 
@@ -31,17 +33,17 @@ public class ExperimentalDesign extends Describable implements gemma.gsec.model.
     private String replicateDescription;
     private String qualityControlDescription;
     private String normalizationDescription;
-    private Collection<ExperimentalFactor> experimentalFactors = new java.util.HashSet<>();
-    private Collection<Characteristic> types = new java.util.HashSet<>();
+    private Set<ExperimentalFactor> experimentalFactors = new HashSet<>();
+    private Set<Characteristic> types = new HashSet<>();
 
     /**
      * @return The description of the factors (TimeCourse, Dosage, etc.) that group the BioAssays.
      */
-    public Collection<ExperimentalFactor> getExperimentalFactors() {
+    public Set<ExperimentalFactor> getExperimentalFactors() {
         return this.experimentalFactors;
     }
 
-    public void setExperimentalFactors( Collection<ExperimentalFactor> experimentalFactors ) {
+    public void setExperimentalFactors( Set<ExperimentalFactor> experimentalFactors ) {
         this.experimentalFactors = experimentalFactors;
     }
 
@@ -75,11 +77,11 @@ public class ExperimentalDesign extends Describable implements gemma.gsec.model.
         return null;
     }
 
-    public Collection<Characteristic> getTypes() {
+    public Set<Characteristic> getTypes() {
         return this.types;
     }
 
-    public void setTypes( Collection<Characteristic> types ) {
+    public void setTypes( Set<Characteristic> types ) {
         this.types = types;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExperimentalFactor.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExperimentalFactor.java
@@ -27,6 +27,7 @@ import ubic.gemma.model.common.description.Characteristic;
 import javax.persistence.Transient;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * ExperimentFactors are the dependent variables of an experiment (e.g., genotype, time, glucose concentration).
@@ -39,10 +40,10 @@ public class ExperimentalFactor extends Describable implements SecuredChild {
      * The serial version UID of this class. Needed for serialization.
      */
     private static final long serialVersionUID = 4615731059510436891L;
-    private Collection<Characteristic> annotations = new HashSet<>();
+    private Set<Characteristic> annotations = new HashSet<>();
     private Characteristic category;
     private ExperimentalDesign experimentalDesign;
-    private Collection<FactorValue> factorValues = new HashSet<>();
+    private Set<FactorValue> factorValues = new HashSet<>();
     private ExpressionExperiment securityOwner;
     private FactorType type;
 
@@ -115,11 +116,11 @@ public class ExperimentalFactor extends Describable implements SecuredChild {
         this.securityOwner = securityOwner;
     }
 
-    public Collection<ubic.gemma.model.common.description.Characteristic> getAnnotations() {
+    public Set<ubic.gemma.model.common.description.Characteristic> getAnnotations() {
         return this.annotations;
     }
 
-    public void setAnnotations( Collection<Characteristic> annotations ) {
+    public void setAnnotations( Set<Characteristic> annotations ) {
         this.annotations = annotations;
     }
 
@@ -142,11 +143,11 @@ public class ExperimentalFactor extends Describable implements SecuredChild {
     /**
      * @return The pairing of BioAssay FactorValues with the ExperimentDesign ExperimentFactor.
      */
-    public Collection<ubic.gemma.model.expression.experiment.FactorValue> getFactorValues() {
+    public Set<ubic.gemma.model.expression.experiment.FactorValue> getFactorValues() {
         return this.factorValues;
     }
 
-    public void setFactorValues( Collection<FactorValue> factorValues ) {
+    public void setFactorValues( Set<FactorValue> factorValues ) {
         this.factorValues = factorValues;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperiment.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperiment.java
@@ -16,6 +16,7 @@ package ubic.gemma.model.expression.experiment;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.hibernate.Hibernate;
 import org.hibernate.proxy.HibernateProxyHelper;
@@ -69,10 +70,10 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
     /**
      * If this experiment was split off of a larger experiment, link to its relatives.
      */
-    private Collection<ExpressionExperiment> otherParts = new HashSet<>();
-    private Collection<ProcessedExpressionDataVector> processedExpressionDataVectors = new HashSet<>();
-    private Collection<QuantitationType> quantitationTypes = new HashSet<>();
-    private Collection<RawExpressionDataVector> rawExpressionDataVectors = new HashSet<>();
+    private Set<ExpressionExperiment> otherParts = new HashSet<>();
+    private Set<ProcessedExpressionDataVector> processedExpressionDataVectors = new HashSet<>();
+    private Set<QuantitationType> quantitationTypes = new HashSet<>();
+    private Set<RawExpressionDataVector> rawExpressionDataVectors = new HashSet<>();
     private String shortName;
 
     private String source;
@@ -110,7 +111,7 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
     }
 
     @Override
-    public Collection<BioAssay> getBioAssays() {
+    public Set<BioAssay> getBioAssays() {
         return this.bioAssays;
     }
 
@@ -143,19 +144,19 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
         return this.numberOfDataVectors;
     }
 
-    public Collection<ExpressionExperiment> getOtherParts() {
+    public Set<ExpressionExperiment> getOtherParts() {
         return otherParts;
     }
 
-    public Collection<ProcessedExpressionDataVector> getProcessedExpressionDataVectors() {
+    public Set<ProcessedExpressionDataVector> getProcessedExpressionDataVectors() {
         return this.processedExpressionDataVectors;
     }
 
-    public Collection<QuantitationType> getQuantitationTypes() {
+    public Set<QuantitationType> getQuantitationTypes() {
         return this.quantitationTypes;
     }
 
-    public Collection<RawExpressionDataVector> getRawExpressionDataVectors() {
+    public Set<RawExpressionDataVector> getRawExpressionDataVectors() {
         return this.rawExpressionDataVectors;
     }
 
@@ -196,7 +197,7 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
     }
 
     @Override
-    public void setBioAssays( Collection<BioAssay> bioAssays ) {
+    public void setBioAssays( Set<BioAssay> bioAssays ) {
         this.bioAssays = bioAssays;
         if ( bioAssays != null && Hibernate.isInitialized( bioAssays ) )
             this.numberOfSamples = bioAssays.size();
@@ -228,20 +229,20 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
         this.numberOfDataVectors = numberOfDataVectors;
     }
 
-    public void setOtherParts( Collection<ExpressionExperiment> otherParts ) {
+    public void setOtherParts( Set<ExpressionExperiment> otherParts ) {
         this.otherParts = otherParts;
     }
 
     public void setProcessedExpressionDataVectors(
-            Collection<ProcessedExpressionDataVector> processedExpressionDataVectors ) {
+            Set<ProcessedExpressionDataVector> processedExpressionDataVectors ) {
         this.processedExpressionDataVectors = processedExpressionDataVectors;
     }
 
-    public void setQuantitationTypes( Collection<QuantitationType> quantitationTypes ) {
+    public void setQuantitationTypes( Set<QuantitationType> quantitationTypes ) {
         this.quantitationTypes = quantitationTypes;
     }
 
-    public void setRawExpressionDataVectors( Collection<RawExpressionDataVector> rawExpressionDataVectors ) {
+    public void setRawExpressionDataVectors( Set<RawExpressionDataVector> rawExpressionDataVectors ) {
         this.rawExpressionDataVectors = rawExpressionDataVectors;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperimentDetailsValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperimentDetailsValueObject.java
@@ -30,6 +30,7 @@ import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author paul
@@ -52,7 +53,7 @@ public class ExpressionExperimentDetailsValueObject extends ExpressionExperiment
     private Date dateMissingValueAnalysis;
     private Date datePcaAnalysis;
     private Date dateProcessedDataVectorComputation;
-    private Collection<DifferentialExpressionAnalysisValueObject> differentialExpressionAnalyses = new HashSet<>();
+    private Set<DifferentialExpressionAnalysisValueObject> differentialExpressionAnalyses = new HashSet<>();
     private Collection<ExpressionExperimentSetValueObject> expressionExperimentSets;
     private boolean hasBatchInformation;
     private Boolean hasBothIntensities = false;
@@ -75,7 +76,7 @@ public class ExpressionExperimentDetailsValueObject extends ExpressionExperiment
     private Collection<ArrayDesignValueObject> originalPlatforms;
 
     // if it was split.
-    private Collection<ExpressionExperimentValueObject> otherParts = new HashSet<>();
+    private Set<ExpressionExperimentValueObject> otherParts = new HashSet<>();
 
     private String pcaAnalysisEventType;
 
@@ -192,7 +193,7 @@ public class ExpressionExperimentDetailsValueObject extends ExpressionExperiment
         return this.description;
     }
 
-    public Collection<DifferentialExpressionAnalysisValueObject> getDifferentialExpressionAnalyses() {
+    public Set<DifferentialExpressionAnalysisValueObject> getDifferentialExpressionAnalyses() {
         return differentialExpressionAnalyses;
     }
 
@@ -465,7 +466,7 @@ public class ExpressionExperimentDetailsValueObject extends ExpressionExperiment
     }
 
     public void setDifferentialExpressionAnalyses(
-            Collection<DifferentialExpressionAnalysisValueObject> differentialExpressionAnalyses ) {
+            Set<DifferentialExpressionAnalysisValueObject> differentialExpressionAnalyses ) {
         this.differentialExpressionAnalyses = differentialExpressionAnalyses;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperimentSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperimentSetValueObject.java
@@ -25,6 +25,7 @@ import ubic.gemma.model.analysis.expression.ExpressionExperimentSet;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author tvrossum
@@ -36,7 +37,7 @@ public class ExpressionExperimentSetValueObject extends IdentifiableValueObject<
     private static final long serialVersionUID = -6852364688337216390L;
 
     private String description = "";
-    private Collection<Long> expressionExperimentIds = new HashSet<>();
+    private Set<Long> expressionExperimentIds = new HashSet<>();
     private boolean isPublic = false;
     /**
      * If modifying the set is constrained by existing analyses.
@@ -93,11 +94,11 @@ public class ExpressionExperimentSetValueObject extends IdentifiableValueObject<
         this.description = description;
     }
 
-    public Collection<Long> getExpressionExperimentIds() {
+    public Set<Long> getExpressionExperimentIds() {
         return expressionExperimentIds;
     }
 
-    public void setExpressionExperimentIds( Collection<Long> expressionExperimentIds ) {
+    public void setExpressionExperimentIds( Set<Long> expressionExperimentIds ) {
         this.expressionExperimentIds = expressionExperimentIds;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperimentSubSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperimentSubSet.java
@@ -24,6 +24,7 @@ import ubic.gemma.model.expression.bioAssay.BioAssay;
 
 import javax.persistence.Transient;
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * A subset of samples from an ExpressionExperiment
@@ -50,7 +51,7 @@ public class ExpressionExperimentSubSet extends BioAssaySet implements SecuredCh
     }
 
     @Override
-    public void setBioAssays( Collection<BioAssay> bioAssays ) {
+    public void setBioAssays( Set<BioAssay> bioAssays ) {
         this.bioAssays = bioAssays;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/FreeTextExpressionExperimentResultsValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/FreeTextExpressionExperimentResultsValueObject.java
@@ -37,7 +37,7 @@
 
 package ubic.gemma.model.expression.experiment;
 
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author tvrossum
@@ -57,8 +57,7 @@ public class FreeTextExpressionExperimentResultsValueObject extends SessionBound
 
     /**
      * Method to create a display object from scratch
-     *
-     * @param name        cannot be null
+     *  @param name        cannot be null
      * @param description should not be null
      * @param taxonId     can be null
      * @param taxonName   can be null
@@ -66,7 +65,7 @@ public class FreeTextExpressionExperimentResultsValueObject extends SessionBound
      * @param queryString query string
      */
     public FreeTextExpressionExperimentResultsValueObject( String name, String description, Long taxonId,
-            String taxonName, Collection<Long> memberIds, String queryString ) {
+            String taxonName, Set<Long> memberIds, String queryString ) {
         super( -1L );
         this.setName( name );
         this.setDescription( description );

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/Gene.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/Gene.java
@@ -26,6 +26,7 @@ import ubic.gemma.model.genome.gene.Multifunctionality;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents a functionally transcribed unit in the genome, recognized by other databases (NCBI, Ensembl).
@@ -40,12 +41,12 @@ public class Gene extends ChromosomeFeature {
     private String officialName;
     private Integer ncbiGeneId;
     private String ensemblId; //Non-unique for roughly 2000 genes as of Aug 11th 2017
-    private Collection<GeneProduct> products = new HashSet<>();
-    private Collection<GeneAlias> aliases = new HashSet<>();
+    private Set<GeneProduct> products = new HashSet<>();
+    private Set<GeneAlias> aliases = new HashSet<>();
     private Taxon taxon;
-    private Collection<DatabaseEntry> accessions = new HashSet<>();
+    private Set<DatabaseEntry> accessions = new HashSet<>();
     private Multifunctionality multifunctionality;
-    private Collection<PhenotypeAssociation> phenotypeAssociations = new HashSet<>();
+    private Set<PhenotypeAssociation> phenotypeAssociations = new HashSet<>();
 
     /**
      * No-arg constructor added to satisfy javabean contract
@@ -125,19 +126,19 @@ public class Gene extends ChromosomeFeature {
                 " (NCBI " + this.getNcbiGeneId() + ")" );
     }
 
-    public Collection<DatabaseEntry> getAccessions() {
+    public Set<DatabaseEntry> getAccessions() {
         return this.accessions;
     }
 
-    public void setAccessions( Collection<DatabaseEntry> accessions ) {
+    public void setAccessions( Set<DatabaseEntry> accessions ) {
         this.accessions = accessions;
     }
 
-    public Collection<GeneAlias> getAliases() {
+    public Set<GeneAlias> getAliases() {
         return this.aliases;
     }
 
-    public void setAliases( Collection<GeneAlias> aliases ) {
+    public void setAliases( Set<GeneAlias> aliases ) {
         this.aliases = aliases;
     }
 
@@ -184,19 +185,19 @@ public class Gene extends ChromosomeFeature {
         this.officialSymbol = officialSymbol;
     }
 
-    public Collection<PhenotypeAssociation> getPhenotypeAssociations() {
+    public Set<PhenotypeAssociation> getPhenotypeAssociations() {
         return this.phenotypeAssociations;
     }
 
-    public void setPhenotypeAssociations( Collection<PhenotypeAssociation> phenotypeAssociations ) {
+    public void setPhenotypeAssociations( Set<PhenotypeAssociation> phenotypeAssociations ) {
         this.phenotypeAssociations = phenotypeAssociations;
     }
 
-    public Collection<GeneProduct> getProducts() {
+    public Set<GeneProduct> getProducts() {
         return this.products;
     }
 
-    public void setProducts( Collection<GeneProduct> products ) {
+    public void setProducts( Set<GeneProduct> products ) {
         this.products = products;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/TaxonValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/TaxonValueObject.java
@@ -14,6 +14,7 @@
  */
 package ubic.gemma.model.genome;
 
+import org.hibernate.Hibernate;
 import ubic.gemma.model.IdentifiableValueObject;
 import ubic.gemma.model.common.description.ExternalDatabaseValueObject;
 
@@ -38,6 +39,7 @@ public class TaxonValueObject extends IdentifiableValueObject<Taxon> {
         this.setNcbiId( taxon.getNcbiId() );
         this.setIsGenesUsable( taxon.getIsGenesUsable() );
 
+        // this is set to lazy="false" in Taxon.hbm.xml, so we don't need to test with Hibernate.isInitialized
         if ( taxon.getExternalDatabase() != null ) {
             this.setExternalDatabase( new ExternalDatabaseValueObject( taxon.getExternalDatabase() ) );
         }

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/gene/GeneSet.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/gene/GeneSet.java
@@ -28,6 +28,7 @@ import ubic.gemma.model.genome.Gene;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A grouping of genes that share a common relationship
@@ -35,10 +36,10 @@ import java.util.HashSet;
 public class GeneSet extends AbstractAuditable implements SecuredNotChild {
 
     private static final long serialVersionUID = 4357218100681569138L;
-    private Collection<Characteristic> characteristics = new HashSet<>();
+    private Set<Characteristic> characteristics = new HashSet<>();
     private DatabaseEntry sourceAccession;
-    private Collection<BibliographicReference> literatureSources = new HashSet<>();
-    private Collection<GeneSetMember> members = new HashSet<>();
+    private Set<BibliographicReference> literatureSources = new HashSet<>();
+    private Set<GeneSetMember> members = new HashSet<>();
 
     static public GeneSetMember containsGene( Gene g, GeneSet gs ) {
         for ( GeneSetMember gm : gs.getMembers() ) {
@@ -48,27 +49,27 @@ public class GeneSet extends AbstractAuditable implements SecuredNotChild {
         return null;
     }
 
-    public Collection<Characteristic> getCharacteristics() {
+    public Set<Characteristic> getCharacteristics() {
         return this.characteristics;
     }
 
-    public void setCharacteristics( Collection<Characteristic> characteristics ) {
+    public void setCharacteristics( Set<Characteristic> characteristics ) {
         this.characteristics = characteristics;
     }
 
-    public Collection<BibliographicReference> getLiteratureSources() {
+    public Set<BibliographicReference> getLiteratureSources() {
         return this.literatureSources;
     }
 
-    public void setLiteratureSources( Collection<BibliographicReference> literatureSources ) {
+    public void setLiteratureSources( Set<BibliographicReference> literatureSources ) {
         this.literatureSources = literatureSources;
     }
 
-    public Collection<GeneSetMember> getMembers() {
+    public Set<GeneSetMember> getMembers() {
         return this.members;
     }
 
-    public void setMembers( Collection<GeneSetMember> members ) {
+    public void setMembers( Set<GeneSetMember> members ) {
         this.members = members;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/gene/GeneSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/gene/GeneSetValueObject.java
@@ -26,6 +26,7 @@ import ubic.gemma.model.IdentifiableValueObject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents a Gene group gene set
@@ -53,7 +54,7 @@ public class GeneSetValueObject extends IdentifiableValueObject<GeneSet> impleme
 
     private boolean currentUserIsOwner = false;
     private String description;
-    private Collection<Long> geneIds = new HashSet<>();
+    private Set<Long> geneIds = new HashSet<>();
 
     private boolean isPublic;
     private boolean isShared;
@@ -102,7 +103,7 @@ public class GeneSetValueObject extends IdentifiableValueObject<GeneSet> impleme
         return this.description;
     }
 
-    public Collection<Long> getGeneIds() {
+    public Set<Long> getGeneIds() {
         return this.geneIds;
     }
 
@@ -166,7 +167,7 @@ public class GeneSetValueObject extends IdentifiableValueObject<GeneSet> impleme
         this.description = description;
     }
 
-    public void setGeneIds( Collection<Long> geneMembers ) {
+    public void setGeneIds( Set<Long> geneMembers ) {
         this.geneIds = geneMembers;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/gene/TransientGeneSetValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/gene/TransientGeneSetValueObject.java
@@ -1,0 +1,15 @@
+package ubic.gemma.model.genome.gene;
+
+/**
+ * @author poirigui
+ */
+public class TransientGeneSetValueObject extends GeneSetValueObject {
+
+    public TransientGeneSetValueObject() {
+        super( null );
+    }
+
+    public TransientGeneSetValueObject( Long id ) {
+        super( id );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/gene/phenotype/valueObject/BibliographicPhenotypesValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/gene/phenotype/valueObject/BibliographicPhenotypesValueObject.java
@@ -55,10 +55,10 @@ public class BibliographicPhenotypesValueObject implements Comparable<Bibliograp
         this.phenotypesValues = phenotypesValues;
     }
 
-    public static Collection<BibliographicPhenotypesValueObject> phenotypeAssociations2BibliographicPhenotypesValueObjects(
+    public static Set<BibliographicPhenotypesValueObject> phenotypeAssociations2BibliographicPhenotypesValueObjects(
             Collection<PhenotypeAssociation> phenotypeAssociations ) {
 
-        Collection<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = new TreeSet<>();
+        Set<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = new TreeSet<>();
 
         for ( PhenotypeAssociation phenotypeAssociation : phenotypeAssociations ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/gene/phenotype/valueObject/GeneEvidenceValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/gene/phenotype/valueObject/GeneEvidenceValueObject.java
@@ -38,7 +38,7 @@ public class GeneEvidenceValueObject extends GeneValueObject {
     /**
      * Added field for the Candidate Gene Management System
      */
-    private Collection<EvidenceValueObject<? extends PhenotypeAssociation>> evidence = new HashSet<>();
+    private Set<EvidenceValueObject<? extends PhenotypeAssociation>> evidence = new HashSet<>();
     private Set<String> phenotypesValueUri = new HashSet<>();
 
     /**
@@ -52,7 +52,7 @@ public class GeneEvidenceValueObject extends GeneValueObject {
     }
 
     public GeneEvidenceValueObject( Gene gene,
-            Collection<EvidenceValueObject<? extends PhenotypeAssociation>> evidence ) {
+            Set<EvidenceValueObject<? extends PhenotypeAssociation>> evidence ) {
         super( gene );
         this.evidence = evidence;
     }
@@ -60,7 +60,7 @@ public class GeneEvidenceValueObject extends GeneValueObject {
     public GeneEvidenceValueObject( Long id, String name, Collection<String> aliases, Integer ncbiId,
             String officialSymbol, String officialName, String description, Double score, Long taxonId,
             String taxonScientificName, String taxonCommonName,
-            Collection<EvidenceValueObject<? extends PhenotypeAssociation>> evidence ) {
+            Set<EvidenceValueObject<? extends PhenotypeAssociation>> evidence ) {
         super( id, name, aliases, ncbiId, officialSymbol, officialName, description, score, taxonId,
                 taxonScientificName, taxonCommonName );
         this.evidence = evidence;
@@ -82,11 +82,11 @@ public class GeneEvidenceValueObject extends GeneValueObject {
         return allPhenotypesOnGene;
     }
 
-    public Collection<EvidenceValueObject<? extends PhenotypeAssociation>> getEvidence() {
+    public Set<EvidenceValueObject<? extends PhenotypeAssociation>> getEvidence() {
         return this.evidence;
     }
 
-    public void setEvidence( Collection<EvidenceValueObject<? extends PhenotypeAssociation>> evidence ) {
+    public void setEvidence( Set<EvidenceValueObject<? extends PhenotypeAssociation>> evidence ) {
         this.evidence = evidence;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/gene/phenotype/valueObject/TreeCharacteristicValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/gene/phenotype/valueObject/TreeCharacteristicValueObject.java
@@ -36,7 +36,7 @@ public class TreeCharacteristicValueObject extends CharacteristicValueObject {
      */
     private boolean dbPhenotype = false;
     // all geneNBCI associated with the node or children from publicEvidence, used to write dump file ermineJ way
-    private HashSet<Integer> publicGenesNBCI = new HashSet<>();
+    private Set<Integer> publicGenesNBCI = new HashSet<>();
     // if we need to reconstruct part of the tree in the cache we need to know highest root parent
     private String rootOfTree = "";
 

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/sequenceAnalysis/BlatResultValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/sequenceAnalysis/BlatResultValueObject.java
@@ -19,6 +19,7 @@
 
 package ubic.gemma.model.genome.sequenceAnalysis;
 
+import org.hibernate.Hibernate;
 import ubic.gemma.model.IdentifiableValueObject;
 import ubic.gemma.model.genome.TaxonValueObject;
 
@@ -63,45 +64,33 @@ public class BlatResultValueObject extends IdentifiableValueObject<BlatResult> {
     }
 
     public BlatResultValueObject( BlatResult br ) {
-        this( br.getId(), TaxonValueObject.fromEntity( br.getTargetChromosome().getTaxon() ), br.getBlockCount(),
-                br.getBlockSizes(), br.getMatches(), br.getMismatches(), br.getNs(), br.getQueryEnd(),
-                br.getQueryGapBases(), br.getQueryGapCount(),
-                BioSequenceValueObject.fromEntity( br.getQuerySequence() ), br.getQueryStart(), br.getQueryStarts(),
-                br.getRepMatches(), br.score(), br.identity(), br.getStrand(), br.getTargetChromosome().getName(),
-                br.getSearchedDatabase().getName(), br.getTargetEnd(), br.getTargetGapBases(), br.getTargetGapCount(),
-                br.getTargetStart(), br.getTargetStarts() );
-    }
-
-    public BlatResultValueObject( Long id, TaxonValueObject taxon, Integer blockCount, String blockSizes,
-            Integer matches, Integer mismatches, Integer ns, Integer queryEnd, Integer queryGapBases,
-            Integer queryGapCount, BioSequenceValueObject querySequence, Integer queryStart, String queryStarts,
-            Integer repMatches, Double score, Double identity, String strand, String targetChromosomeName,
-            String targetDatabase, Long targetEnd, Integer targetGapBases, Integer targetGapCount, Long targetStart,
-            String targetStarts ) {
-        super( id );
-        this.setTaxon( taxon );
-        this.blockCount = blockCount;
-        this.blockSizes = blockSizes;
-        this.matches = matches;
-        this.mismatches = mismatches;
-        this.ns = ns;
-        this.queryEnd = queryEnd;
-        this.queryGapBases = queryGapBases;
-        this.queryGapCount = queryGapCount;
-        this.querySequence = querySequence;
-        this.queryStart = queryStart;
-        this.queryStarts = queryStarts;
-        this.repMatches = repMatches;
-        this.score = score;
-        this.identity = identity;
-        this.strand = strand;
-        this.targetChromosomeName = targetChromosomeName;
-        this.targetDatabase = targetDatabase;
-        this.targetEnd = targetEnd;
-        this.targetGapBases = targetGapBases;
-        this.targetGapCount = targetGapCount;
-        this.targetStart = targetStart;
-        this.targetStarts = targetStarts;
+        super( br.getId() );
+        this.setTaxon( TaxonValueObject.fromEntity( br.getTargetChromosome().getTaxon() ) );
+        this.blockCount = br.getBlockCount();
+        this.blockSizes = br.getBlockSizes();
+        this.matches = br.getMatches();
+        this.mismatches = br.getMismatches();
+        this.ns = br.getNs();
+        this.queryEnd = br.getQueryEnd();
+        this.queryGapBases = br.getQueryGapBases();
+        this.queryGapCount = br.getQueryGapCount();
+        this.querySequence = BioSequenceValueObject.fromEntity( br.getQuerySequence() );
+        this.queryStart = br.getQueryStart();
+        this.queryStarts = br.getQueryStarts();
+        this.repMatches = br.getRepMatches();
+        this.score = br.score();
+        this.identity = br.identity();
+        this.strand = br.getStrand();
+        this.targetChromosomeName = br.getTargetChromosome().getName();
+        // FIXME: this is supposed to be initialized in BlatResultDaoImpl#thaw(Collection), but it's not always the case
+        if ( Hibernate.isInitialized( br.getSearchedDatabase() ) ) {
+            this.targetDatabase = br.getSearchedDatabase().getName();
+        }
+        this.targetEnd = br.getTargetEnd();
+        this.targetGapBases = br.getTargetGapBases();
+        this.targetGapCount = br.getTargetGapCount();
+        this.targetStart = br.getTargetStart();
+        this.targetStarts = br.getTargetStarts();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/persister/ExpressionPersister.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/persister/ExpressionPersister.java
@@ -330,11 +330,11 @@ abstract public class ExpressionPersister extends ArrayDesignPersister {
         this.persistCollectionElements( annotations );
     }
 
-    private Collection<BioAssay> fillInExpressionExperimentDataVectorAssociations( ExpressionExperiment ee,
+    private Set<BioAssay> fillInExpressionExperimentDataVectorAssociations( ExpressionExperiment ee,
             ArrayDesignsForExperimentCache c ) {
         AbstractPersister.log.debug( "Filling in DesignElementDataVectors..." );
 
-        Collection<BioAssay> bioAssays = new HashSet<>();
+        Set<BioAssay> bioAssays = new HashSet<>();
         StopWatch timer = new StopWatch();
         timer.start();
         int count = 0;
@@ -533,7 +533,7 @@ abstract public class ExpressionPersister extends ArrayDesignPersister {
      */
     private void processBioAssays( ExpressionExperiment expressionExperiment, ArrayDesignsForExperimentCache c ) {
 
-        Collection<BioAssay> alreadyFilled = new HashSet<>();
+        Set<BioAssay> alreadyFilled = new HashSet<>();
 
         if ( expressionExperiment.getRawExpressionDataVectors().isEmpty() ) {
             AbstractPersister.log.debug( "Filling in bioassays" );
@@ -553,7 +553,7 @@ abstract public class ExpressionPersister extends ArrayDesignPersister {
         this.persistCollectionElements( experimentalDesign.getTypes() );
 
         // Withhold to avoid premature cascade.
-        Collection<ExperimentalFactor> factors = experimentalDesign.getExperimentalFactors();
+        Set<ExperimentalFactor> factors = experimentalDesign.getExperimentalFactors();
         if ( factors == null ) {
             factors = new HashSet<>();
         }
@@ -574,7 +574,7 @@ abstract public class ExpressionPersister extends ArrayDesignPersister {
             experimentalFactor.setExperimentalDesign( experimentalDesign );
 
             // Override cascade like above.
-            Collection<FactorValue> factorValues = experimentalFactor.getFactorValues();
+            Set<FactorValue> factorValues = experimentalFactor.getFactorValues();
             experimentalFactor.setFactorValues( null );
             experimentalFactor = this.persistExperimentalFactor( experimentalFactor );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/persister/GenomePersister.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/persister/GenomePersister.java
@@ -42,10 +42,7 @@ import ubic.gemma.persistence.service.genome.sequenceAnalysis.BlatResultDao;
 import ubic.gemma.persistence.service.genome.taxon.TaxonDao;
 import ubic.gemma.persistence.util.SequenceBinUtils;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author pavlidis
@@ -233,7 +230,7 @@ abstract public class GenomePersister extends CommonPersister {
                      * genes; or 3) an error in the data source. The problem for us is at this point in processing, we
                      * don't know if the gene is going to get 'reattached' to its original gene.
                      */
-                    existingGeneProduct = geneProductDao.thaw( existingGeneProduct );
+                    geneProductDao.thaw( existingGeneProduct );
                     Gene oldGeneForExistingGeneProduct = existingGeneProduct.getGene();
                     if ( oldGeneForExistingGeneProduct != null ) {
                         Gene geneInfo = newGeneProductInfo.getGene(); // transient.
@@ -245,7 +242,7 @@ abstract public class GenomePersister extends CommonPersister {
                                             + " (this can also happen if an mRNA is associated with two genes, which we don't allow, so we switch it arbitrarily)" );
 
                             // Here we just remove its old association.
-                            oldGeneForExistingGeneProduct = geneDao.thaw( oldGeneForExistingGeneProduct );
+                            geneDao.thaw( oldGeneForExistingGeneProduct );
                             oldGeneForExistingGeneProduct.getProducts().remove( existingGeneProduct );
                             log.debug( "Switch: Removing " + existingGeneProduct + " from " + oldGeneForExistingGeneProduct + " GI="
                                     + existingGeneProduct.getNcbiGi() );
@@ -467,7 +464,7 @@ abstract public class GenomePersister extends CommonPersister {
             AbstractPersister.log.debug( "New gene: " + gene );
         gene = geneDao.create( gene );
 
-        Collection<GeneProduct> geneProductsForNewGene = new HashSet<>();
+        Set<GeneProduct> geneProductsForNewGene = new HashSet<>();
         for ( GeneProduct product : tempGeneProduct ) {
             GeneProduct existingProduct = geneProductDao.find( product );
             if ( existingProduct != null ) {
@@ -500,7 +497,7 @@ abstract public class GenomePersister extends CommonPersister {
             // products are not persistent until the session is flushed, later. There might be a better way around this,
             // but so far as I know this is the only place this happens.
             //noinspection unchecked
-            gene.setProducts( geneProductDao.create( gene.getProducts() ) );
+            gene.setProducts( new HashSet<>( geneProductDao.create( gene.getProducts() ) ) );
             geneDao.update( gene );
             return gene;
         } catch ( Exception e ) {
@@ -675,7 +672,7 @@ abstract public class GenomePersister extends CommonPersister {
 
     private void addAnyNewAccessions( GeneProduct existing, GeneProduct geneProduct ) {
         Map<String, DatabaseEntry> updatedGpMap = new HashMap<>();
-        existing = geneProductDao.thaw( existing );
+        geneProductDao.thaw( existing );
         for ( DatabaseEntry de : existing.getAccessions() ) {
             updatedGpMap.put( de.getAccession(), de );
         }
@@ -783,7 +780,7 @@ abstract public class GenomePersister extends CommonPersister {
                 }
 
                 // handle less common cases, largely due to database cruft.
-                otherGpUsingThisGi = geneProductDao.thaw( otherGpUsingThisGi );
+                geneProductDao.thaw( otherGpUsingThisGi );
 
                 Gene oldGeneForExistingGeneProduct = otherGpUsingThisGi.getGene();
                 if ( oldGeneForExistingGeneProduct == null ) {
@@ -810,7 +807,7 @@ abstract public class GenomePersister extends CommonPersister {
                                     + existingGene + " -- detected during GI update checks " );
 
                     // Here we just remove its old association.
-                    oldGeneForExistingGeneProduct = geneDao.thaw( oldGeneForExistingGeneProduct );
+                    geneDao.thaw( oldGeneForExistingGeneProduct );
                     oldGeneForExistingGeneProduct.getProducts().remove( otherGpUsingThisGi );
                     geneDao.update( oldGeneForExistingGeneProduct );
 
@@ -954,7 +951,7 @@ abstract public class GenomePersister extends CommonPersister {
         Gene geneForExistingGeneProduct = existingGeneProduct.getGene();
         assert !this.isTransient( geneForExistingGeneProduct );
 
-        existingGeneProduct = geneProductDao.thaw( existingGeneProduct );
+        geneProductDao.thaw( existingGeneProduct );
 
         // Update all the fields. Note that usually, some of these can't have changed or we wouldn't have even
         // found the 'existing' one (name GI in particular); however, sometimes we are updating this information

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
@@ -18,7 +18,6 @@
  */
 package ubic.gemma.persistence.service;
 
-import com.google.common.collect.Iterables;
 import lombok.NonNull;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,10 +30,8 @@ import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import ubic.gemma.model.common.Identifiable;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * AbstractDao can find the generic type at runtime and simplify the code implementation of the BaseDao interface

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
@@ -88,12 +88,15 @@ public abstract class AbstractDao<T extends Identifiable> extends HibernateDaoSu
 
     @Override
     public List<T> load( @NonNull Collection<Long> ids ) {
-        // ensure that IDs are unique so that elements cannot be repeated in different partitions
-        ids = new HashSet<>( ids );
+        if ( ids.isEmpty() ) {
+            return Collections.emptyList();
+        }
+        // ensure that IDs are unique to avoid creating needlessly long expressions
+        List<Long> distinctIds = ids.stream().distinct().collect( Collectors.toList() );
         //noinspection unchecked
         return ( List<T> ) this.getSessionFactory().getCurrentSession()
                 .createCriteria( elementClass )
-                .add( Restrictions.in( "id", ids ) )
+                .add( Restrictions.in( "id", distinctIds ) )
                 .list();
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractService.java
@@ -139,7 +139,6 @@ public abstract class AbstractService<O extends Identifiable> implements BaseSer
     }
 
     @Override
-    @Deprecated
     @Transactional(readOnly = true)
     public List<O> thaw( final Collection<O> identifiables ) {
         List<O> result = this.load( EntityUtils.getIds( identifiables ) );
@@ -148,7 +147,6 @@ public abstract class AbstractService<O extends Identifiable> implements BaseSer
     }
 
     @Override
-    @Deprecated
     @Transactional(readOnly = true)
     public O thaw( O identifiable ) {
         O result = this.load( identifiable.getId() );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractService.java
@@ -2,17 +2,12 @@ package ubic.gemma.persistence.service;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.aspectj.bridge.MessageUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.Identifiable;
-import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.persistence.util.EntityUtils;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Base for all services handling DAO access.

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseDao.java
@@ -19,6 +19,7 @@
 package ubic.gemma.persistence.service;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Interface that supports basic CRUD operations.
@@ -29,12 +30,12 @@ import java.util.Collection;
 public interface BaseDao<T> {
 
     /**
-     * Crates all the given entities in the persistent storage.
+     * Create all the given entities in the persistent storage.
      *
      * @param entities the entities to be crated.
      * @return collection of entities representing the instances in the persistent storage that were created.
      */
-    Collection<T> create( Collection<T> entities );
+    List<T> create( Collection<T> entities );
 
     /**
      * Create an object. If the entity type is immutable, this may also remove any existing entities identified by an
@@ -51,13 +52,14 @@ public interface BaseDao<T> {
      * @param ids the ids of entities to be loaded. If some id's are not found, they are skipped.
      * @return collection of entities with given ids.
      */
-    Collection<T> load( Collection<Long> ids );
+    List<T> load( Collection<Long> ids );
 
     /**
      * Loads the entity with given id from the persistent storage.
      *
      * @param id the id of entity to load.
-     * @return the entity with given id, or null if such entity does not exist.
+     * @return the entity with given id, or null if such entity does not exist. Note that passing a null identifier will
+     * return null.
      */
     T load( Long id );
 
@@ -66,15 +68,19 @@ public interface BaseDao<T> {
      *
      * @return a collection containing all instances that are currently accessible.
      */
-    Collection<T> loadAll();
+    List<T> loadAll();
 
     /**
      * Counts all instances of specific class in the persitent storage.
      *
      * @return number that is the amount of instances currently accessible.
      */
-    Integer countAll();
+    long countAll();
 
+    /**
+     * Remove all entities in the collection.
+     * @param entities
+     */
     void remove( Collection<T> entities );
 
     /**
@@ -124,4 +130,20 @@ public interface BaseDao<T> {
      * @return the given entity, guaranteed to be representing an entity present in the persistent storage.
      */
     T findOrCreate( T entity );
+
+    /**
+     * Thaw a list of entities.
+     *
+     * The implementation can mutate the collection in-place if desirable. If so, we suggest using {@link java.util.Collections#copy(List, List)}
+     * to perform this operation efficiently.
+     *
+     * @param entities
+     */
+    void thaw( List<T> entities );
+
+    /**
+     * Thaw a single entity.
+     * @param entity
+     */
+    void thaw( T entity );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
@@ -3,6 +3,7 @@ package ubic.gemma.persistence.service;
 import ubic.gemma.model.common.Identifiable;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Interface that supports basic CRUD operations.
@@ -34,8 +35,9 @@ public interface BaseService<O extends Identifiable> {
      * @param entities the entities to be created.
      * @return collection of objects referencing the persistent instances of given entities.
      */
-    @SuppressWarnings("unused") // Consistency
-    Collection<O> create( Collection<O> entities );
+    @SuppressWarnings("unused")
+    // Consistency
+    List<O> create( Collection<O> entities );
 
     /**
      * Creates the given entity in the persistent storage.
@@ -51,7 +53,7 @@ public interface BaseService<O extends Identifiable> {
      * @param ids the ids of objects to be loaded.
      * @return collection containing object with given ids.
      */
-    Collection<O> load( Collection<Long> ids );
+    List<O> load( Collection<Long> ids );
 
     /**
      * Loads object with given id.
@@ -62,13 +64,27 @@ public interface BaseService<O extends Identifiable> {
     O load( Long id );
 
     /**
+     * Load and thaw using {@link BaseDao#thaw(List)} in a single transaction.
+     * @param ids
+     * @return
+     */
+    List<O> loadAndThaw( Collection<Long> ids );
+
+    /**
+     * Load and thaw using {@link BaseDao#thaw(Object)} in a single transaction.
+     * @param id
+     * @return
+     */
+    O loadAndThaw( Long id );
+
+    /**
      * Loads all the entities of specific type.
      *
      * @return collection of all entities currently available in the persistent storage.
      */
-    Collection<O> loadAll();
+    List<O> loadAll();
 
-    int countAll();
+    long countAll();
 
     /**
      * Removes all the given entities from persistent storage.
@@ -110,4 +126,21 @@ public interface BaseService<O extends Identifiable> {
      */
     void update( O entity );
 
+    /**
+     * Reload and thaw a collection of entities.
+     * @deprecated use {@link #loadAndThaw(Collection)} instead, this is inefficient as it will reload the entities from
+     *             the database to ensure that the loading and thawing operations are performed in the same Hibernate
+     *             session.
+     */
+    @Deprecated
+    List<O> thaw( Collection<O> entities );
+
+    /**
+     * Reload and thaw an entity.
+     * @deprecated use {@link #loadAndThaw(Long)} instead, this is inefficient as it will reload the entity from the
+     *             database to ensure that the loading and thawing operations are performed in the same Hibernate
+     *             session.
+     */
+    @Deprecated
+    O thaw( O entity );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
@@ -2,6 +2,7 @@ package ubic.gemma.persistence.service;
 
 import ubic.gemma.model.common.Identifiable;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 
@@ -133,6 +134,7 @@ public interface BaseService<O extends Identifiable> {
      *             session.
      */
     @Deprecated
+    @CheckReturnValue
     List<O> thaw( Collection<O> entities );
 
     /**
@@ -142,5 +144,6 @@ public interface BaseService<O extends Identifiable> {
      *             session.
      */
     @Deprecated
+    @CheckReturnValue
     O thaw( O entity );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisService.java
@@ -23,8 +23,10 @@ import ubic.gemma.model.analysis.Analysis;
 import ubic.gemma.model.analysis.Investigation;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.genome.Taxon;
+import ubic.gemma.persistence.service.BaseService;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,7 +35,7 @@ import java.util.Map;
  * @author Gemma
  */
 @SuppressWarnings("unused") // Possible external use
-public interface AnalysisService<T extends Analysis> {
+public interface AnalysisService<T extends Analysis> extends BaseService<T> {
 
     /**
      * @param toDelete deletes the given analysis from the system
@@ -105,6 +107,6 @@ public interface AnalysisService<T extends Analysis> {
      * @return all of the analysis objects
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<T> loadAll();
+    List<T> loadAll();
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/ExpressionExperimentSetDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/ExpressionExperimentSetDaoImpl.java
@@ -249,7 +249,7 @@ public class ExpressionExperimentSetDaoImpl
 
             // Add experiment ids
             if ( loadEEIds ) {
-                v.setExpressionExperimentIds( this.getExperimentIdsInSet( eeId ) );
+                v.setExpressionExperimentIds( new HashSet<>( this.getExperimentIdsInSet( eeId ) ) );
             }
 
             vo.put( eeId, v );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/coexpression/CoexpressionAnalysisServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/coexpression/CoexpressionAnalysisServiceImpl.java
@@ -26,23 +26,30 @@ import ubic.gemma.model.analysis.expression.coexpression.CoexpCorrelationDistrib
 import ubic.gemma.model.analysis.expression.coexpression.CoexpressionAnalysis;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.genome.Taxon;
+import ubic.gemma.persistence.service.AbstractService;
 import ubic.gemma.persistence.service.association.coexpression.CoexpressionService;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 /**
  * @author paul
  */
 @Service
-public class CoexpressionAnalysisServiceImpl implements CoexpressionAnalysisService {
+public class CoexpressionAnalysisServiceImpl extends AbstractService<CoexpressionAnalysis> implements CoexpressionAnalysisService {
 
     @Autowired
     private CoexpressionAnalysisDao coexpressionAnalysisDao;
 
     @Autowired
     private CoexpressionService geneCoexpressionService;
+
+    @Autowired
+    public CoexpressionAnalysisServiceImpl( CoexpressionAnalysisDao mainDao ) {
+        super( mainDao );
+    }
 
     @Override
     @Transactional
@@ -154,14 +161,14 @@ public class CoexpressionAnalysisServiceImpl implements CoexpressionAnalysisServ
     @SuppressWarnings("unchecked")
     @Override
     @Transactional(readOnly = true)
-    public Collection<CoexpressionAnalysis> loadAll() {
+    public List<CoexpressionAnalysis> loadAll() {
         return this.coexpressionAnalysisDao.loadAll();
     }
 
     @Override
     @Transactional
-    public void removeForExperiment( ExpressionExperiment ee ){
-        this.coexpressionAnalysisDao.removeForExperiment(ee);
+    public void removeForExperiment( ExpressionExperiment ee ) {
+        this.coexpressionAnalysisDao.removeForExperiment( ee );
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDao.java
@@ -29,8 +29,8 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.analysis.AnalysisDao;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @see DifferentialExpressionAnalysis
@@ -77,6 +77,6 @@ public interface DifferentialExpressionAnalysisDao extends AnalysisDao<Different
 
     void thawResultSets(DifferentialExpressionAnalysis dea);
 
-    Map<Long, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperimentIds(
+    Map<Long, Set<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperimentIds(
             Collection<Long> expressionExperimentIds, int offset, int limit );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisService.java
@@ -29,6 +29,7 @@ import ubic.gemma.model.expression.experiment.ExpressionExperimentDetailsValueOb
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.analysis.AnalysisService;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -96,15 +97,18 @@ public interface DifferentialExpressionAnalysisService extends AnalysisService<D
 
     @Override
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_COLLECTION_READ" })
     List<DifferentialExpressionAnalysis> thaw( Collection<DifferentialExpressionAnalysis> expressionAnalyses );
 
     @Override
     @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    @CheckReturnValue
     DifferentialExpressionAnalysis thaw( DifferentialExpressionAnalysis differentialExpressionAnalysis );
 
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     DifferentialExpressionAnalysis thawFully( DifferentialExpressionAnalysis differentialExpressionAnalysis );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisService.java
@@ -32,6 +32,7 @@ import ubic.gemma.persistence.service.analysis.AnalysisService;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author kelsey
@@ -93,12 +94,17 @@ public interface DifferentialExpressionAnalysisService extends AnalysisService<D
     Map<ExpressionExperiment, Collection<DifferentialExpressionAnalysis>> getAnalyses(
             Collection<? extends BioAssaySet> expressionExperiments );
 
+    @Override
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_COLLECTION_READ" })
-    void thaw( Collection<DifferentialExpressionAnalysis> expressionAnalyses );
+    List<DifferentialExpressionAnalysis> thaw( Collection<DifferentialExpressionAnalysis> expressionAnalyses );
 
+    @Override
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
-    void thaw( DifferentialExpressionAnalysis differentialExpressionAnalysis );
+    DifferentialExpressionAnalysis thaw( DifferentialExpressionAnalysis differentialExpressionAnalysis );
 
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     DifferentialExpressionAnalysis thawFully( DifferentialExpressionAnalysis differentialExpressionAnalysis );
 
@@ -124,11 +130,11 @@ public interface DifferentialExpressionAnalysisService extends AnalysisService<D
      * @return map of bioassayset (valueobjects) to analyses (valueobjects) for each.
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
-    Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
+    Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
             Collection<Long> ids );
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
-    Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
+    Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
             Collection<Long> ids, int offset, int limit );
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
@@ -454,7 +454,7 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
                     .info( "Fetching DiffEx from DB took total of " + timer.getTime() + " ms : geneIds=" + StringUtils
                             .abbreviate( StringUtils.join( geneIds, "," ), 50 ) + " result set="
                             + StringUtils
-                                    .abbreviate( StringUtils.join( resultSetsNeeded, "," ), 50 ) );
+                            .abbreviate( StringUtils.join( resultSetsNeeded, "," ), 50 ) );
             if ( timeForFillingNonSig > 100 ) {
                 AbstractDao.log.info( "Filling in non-significant values: " + timeForFillingNonSig + "ms in total" );
             }
@@ -512,7 +512,7 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
     public List<DifferentialExpressionValueObject> findInResultSet( ExpressionAnalysisResultSet resultSet,
             Double threshold, Integer limit, Integer minNumberOfResults ) {
 
-        if ( minNumberOfResults == null || minNumberOfResults < 1) {
+        if ( minNumberOfResults == null || minNumberOfResults < 1 ) {
             throw new IllegalArgumentException( "Minimum number of results must be positive" );
         }
 
@@ -648,7 +648,7 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
 
         //noinspection unchecked
         return this.getSessionFactory().getCurrentSession().createQuery( "select ef from ExpressionAnalysisResultSet rs"
-                + " inner join rs.results r inner join rs.experimentalFactors ef where r=:differentialExpressionAnalysisResult" )
+                        + " inner join rs.results r inner join rs.experimentalFactors ef where r=:differentialExpressionAnalysisResult" )
                 .setParameter( "differentialExpressionAnalysisResult", differentialExpressionAnalysisResult ).list();
 
     }
@@ -877,8 +877,8 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
 
         //noinspection unchecked
         List<Object[]> ees = session.createQuery(
-                "select ee, rs from  ExpressionAnalysisResultSet rs join fetch rs.experimentalFactors join rs.analysis a join a.experimentAnalyzed ee"
-                        + " where rs.id in (:rsids)" )
+                        "select ee, rs from  ExpressionAnalysisResultSet rs join fetch rs.experimentalFactors join rs.analysis a join a.experimentAnalyzed ee"
+                                + " where rs.id in (:rsids)" )
                 .setParameterList( "rsids", resultSets ).list();
 
         /*
@@ -953,36 +953,7 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
     }
 
     @Override
-    public Collection<DifferentialExpressionAnalysisResult> load( Collection<Long> ids ) {
-        //language=HQL
-        final String queryString = "from DifferentialExpressionAnalysisResult dea where dea.id in (:ids)";
-
-        Collection<DifferentialExpressionAnalysisResult> probeResults = new HashSet<>();
-
-        if ( ids.isEmpty() ) {
-            return probeResults;
-        }
-
-        int BATCH_SIZE = 1000; // previously: 500.
-
-        for ( Collection<Long> batch : new BatchIterator<>( ids, BATCH_SIZE ) ) {
-            StopWatch timer = new StopWatch();
-            timer.start();
-            //noinspection unchecked
-            probeResults.addAll( this.getSessionFactory().getCurrentSession().createQuery( queryString )
-                    .setParameterList( "ids", batch ).list() );
-
-            if ( timer.getTime() > 1000 ) {
-                AbstractDao.log.info( "Fetch " + batch.size() + "/" + ids.size() + " results with contrasts: " + timer
-                        .getTime() + "ms; query was\n " + queryString );
-            }
-        }
-
-        return probeResults;
-    }
-
-    @Override
-    public Collection<DifferentialExpressionAnalysisResult> loadAll() {
+    public List<DifferentialExpressionAnalysisResult> loadAll() {
         throw new UnsupportedOperationException( "Sorry, that would be nuts" );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultService.java
@@ -151,8 +151,4 @@ public interface DifferentialExpressionResultService extends BaseService<Differe
     Map<Long, ContrastsValueObject> loadContrastDetailsForResults( Collection<Long> ids );
 
     Histogram loadPvalueDistribution( Long analysisResultSetId );
-
-    void thaw( Collection<DifferentialExpressionAnalysisResult> results );
-
-    void thaw( DifferentialExpressionAnalysisResult result );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultServiceImpl.java
@@ -143,22 +143,10 @@ public class DifferentialExpressionResultServiceImpl extends AbstractService<Dif
         return this.DERDao.loadPvalueDistribution( resultSetId );
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public void thaw( Collection<DifferentialExpressionAnalysisResult> results ) {
-        this.DERDao.thaw( results );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public void thaw( DifferentialExpressionAnalysisResult result ) {
-        this.DERDao.thaw( result );
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     @Transactional(readOnly = true)
-    public Collection<DifferentialExpressionAnalysisResult> load( Collection<Long> ids ) {
+    public List<DifferentialExpressionAnalysisResult> load( Collection<Long> ids ) {
         return this.DERDao.load( ids );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDao.java
@@ -54,8 +54,6 @@ public interface ExpressionAnalysisResultSetDao extends AnalysisResultSetDao<Dif
      */
     void thaw( ExpressionAnalysisResultSet resultSet );
 
-    DifferentialExpressionAnalysis thawFully( DifferentialExpressionAnalysis differentialExpressionAnalysis );
-
     boolean canDelete( DifferentialExpressionAnalysis differentialExpressionAnalysis );
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDaoImpl.java
@@ -96,27 +96,6 @@ public class ExpressionAnalysisResultSetDaoImpl extends AbstractCriteriaFilterin
     }
 
     @Override
-    public DifferentialExpressionAnalysis thawFully( DifferentialExpressionAnalysis differentialExpressionAnalysis ) {
-        StopWatch timer = new StopWatch();
-        timer.start();
-
-        differentialExpressionAnalysis = ( DifferentialExpressionAnalysis ) this.getSessionFactory().getCurrentSession()
-                .load( DifferentialExpressionAnalysis.class, differentialExpressionAnalysis.getId() );
-        Collection<ExpressionAnalysisResultSet> thawed = new HashSet<>();
-        Collection<ExpressionAnalysisResultSet> rss = differentialExpressionAnalysis.getResultSets();
-        int size = rss.size();
-        int cnt = 0;
-        for ( ExpressionAnalysisResultSet rs : rss ) {
-            thawed.add( loadWithResultsAndContrasts( rs.getId() ) );
-            cnt++;
-            log.info( "Thawed " + cnt + "/" + size + " resultSets" );
-        }
-        boolean changed = differentialExpressionAnalysis.getResultSets().addAll( thawed );
-        assert !changed; // they are the same objects, just updated.
-        return differentialExpressionAnalysis;
-    }
-
-    @Override
     public boolean canDelete( DifferentialExpressionAnalysis differentialExpressionAnalysis ) {
         return this.getSessionFactory().getCurrentSession().createQuery(
                         "select a from GeneDifferentialExpressionMetaAnalysis a"
@@ -233,15 +212,15 @@ public class ExpressionAnalysisResultSetDaoImpl extends AbstractCriteriaFilterin
 
     @Override
     public Map<DifferentialExpressionAnalysisResult, List<Gene>> loadResultToGenesMap( ExpressionAnalysisResultSet resultSet ) {
-        Query query = getSessionFactory().getCurrentSession()
-                .createSQLQuery( "select {result.*}, {gene.*} from DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT {result} "
-                        + "join GENE2CS on GENE2CS.CS = {result}.PROBE_FK "
-                        + "join CHROMOSOME_FEATURE as {gene} on {gene}.ID = GENE2CS.GENE "
-                        + "where {result}.RESULT_SET_FK = :rsid" )
-                .addEntity( "result", DifferentialExpressionAnalysisResult.class )
-                .addEntity( "gene", Gene.class )
-                .setParameter( "rsid", resultSet.getId() )
-                .setCacheable( true );
+Query query = getSessionFactory().getCurrentSession()
+        .createSQLQuery( "select {result.*}, {gene.*} from DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT {result} "
+                + "join GENE2CS on GENE2CS.CS = {result}.PROBE_FK "
+                + "join CHROMOSOME_FEATURE as {gene} on {gene}.ID = GENE2CS.GENE "
+                + "where {result}.RESULT_SET_FK = :rsid" )
+        .addEntity( "result", DifferentialExpressionAnalysisResult.class )
+        .addEntity( "gene", Gene.class )
+        .setParameter( "rsid", resultSet.getId() )
+        .setCacheable( true );
 
         //noinspection unchecked
         List<Object[]> list = query.list();

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetService.java
@@ -22,8 +22,6 @@ public interface ExpressionAnalysisResultSetService extends AnalysisResultSetSer
 
     ExpressionAnalysisResultSet loadWithResultsAndContrasts( Long value );
 
-    void thaw( ExpressionAnalysisResultSet e );
-
     ExpressionAnalysisResultSet loadWithExperimentAnalyzed( Long id );
 
     ExpressionAnalysisResultSetValueObject loadValueObjectWithResults( ExpressionAnalysisResultSet ears );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetServiceImpl.java
@@ -37,12 +37,6 @@ public class ExpressionAnalysisResultSetServiceImpl extends AbstractFilteringVoE
 
     @Override
     @Transactional(readOnly = true)
-    public void thaw( ExpressionAnalysisResultSet e ) {
-        voDao.thaw( e );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
     public ExpressionAnalysisResultSet loadWithExperimentAnalyzed( Long id ) {
         ExpressionAnalysisResultSet ears = voDao.load( id );
         if ( ears != null ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/GeneDiffExMetaAnalysisServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/GeneDiffExMetaAnalysisServiceImpl.java
@@ -28,19 +28,26 @@ import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.genome.Taxon;
+import ubic.gemma.persistence.service.AbstractService;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 /**
  * @author Paul
  */
 @Service
-public class GeneDiffExMetaAnalysisServiceImpl implements GeneDiffExMetaAnalysisService {
+public class GeneDiffExMetaAnalysisServiceImpl extends AbstractService<GeneDifferentialExpressionMetaAnalysis> implements GeneDiffExMetaAnalysisService {
 
     @Autowired
     private GeneDiffExMetaAnalysisDao geneDiffExMetaAnalysisDao;
+
+    @Autowired
+    public GeneDiffExMetaAnalysisServiceImpl( GeneDiffExMetaAnalysisDao mainDao ) {
+        super( mainDao );
+    }
 
     @Override
     @Transactional
@@ -116,8 +123,8 @@ public class GeneDiffExMetaAnalysisServiceImpl implements GeneDiffExMetaAnalysis
 
     @Override
     @Transactional
-    public void removeForExperiment( ExpressionExperiment ee ){
-        this.geneDiffExMetaAnalysisDao.removeForExperiment(ee);
+    public void removeForExperiment( ExpressionExperiment ee ) {
+        this.geneDiffExMetaAnalysisDao.removeForExperiment( ee );
     }
 
     @Override
@@ -180,7 +187,7 @@ public class GeneDiffExMetaAnalysisServiceImpl implements GeneDiffExMetaAnalysis
 
     @Override
     @Transactional(readOnly = true)
-    public Collection<GeneDifferentialExpressionMetaAnalysis> loadAll() {
+    public List<GeneDifferentialExpressionMetaAnalysis> loadAll() {
         return geneDiffExMetaAnalysisDao.loadAll();
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/Gene2GOAssociationServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/Gene2GOAssociationServiceImpl.java
@@ -67,11 +67,13 @@ public class Gene2GOAssociationServiceImpl extends AbstractService<Gene2GOAssoci
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene2GOAssociation> findAssociationByGene( Gene gene ) {
         return this.gene2GOAssociationDao.findAssociationByGene( gene );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Characteristic> findByGene( Gene gene ) {
 
         Element element = this.gene2goCache.get( gene );
@@ -110,11 +112,13 @@ public class Gene2GOAssociationServiceImpl extends AbstractService<Gene2GOAssoci
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene> findByGOTerm( String goID, Taxon taxon ) {
         return this.gene2GOAssociationDao.findByGoTerm( goID, taxon );
     }
 
     @Override
+    @Transactional
     public void removeAll() {
         this.gene2GOAssociationDao.removeAll();
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/CurationDetailsService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/CurationDetailsService.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.auditAndSecurity.AuditEvent;
 import ubic.gemma.model.common.auditAndSecurity.curation.Curatable;
 import ubic.gemma.model.common.auditAndSecurity.curation.CurationDetails;
@@ -63,6 +64,7 @@ public class CurationDetailsService {
      * @param curatable  curatable
      */
     @Secured({ "GROUP_AGENT", "ACL_SECURABLE_EDIT" })
+    @Transactional
     public void update( Curatable curatable, AuditEvent auditEvent ) {
         this.curationDetailsDao.update( curatable, auditEvent );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/UserGroupDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/UserGroupDaoImpl.java
@@ -96,11 +96,6 @@ public class UserGroupDaoImpl extends AbstractDao<UserGroup> implements UserGrou
     }
 
     @Override
-    public Integer countAll() {
-        return this.loadAll().size();
-    }
-
-    @Override
     public void remove( Long id ) {
         UserGroup userGroup = this.load( id );
         // this check is done higher up as well...

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/curation/AbstractCuratableDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/curation/AbstractCuratableDao.java
@@ -13,6 +13,7 @@ import ubic.gemma.persistence.util.ObjectFilter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,16 +27,6 @@ public abstract class AbstractCuratableDao<C extends Curatable, VO extends Abstr
 
     protected AbstractCuratableDao( String objectAlias, Class<C> elementClass, SessionFactory sessionFactory ) {
         super( objectAlias, elementClass, sessionFactory );
-    }
-
-    @Override
-    public Collection<C> create( final Collection<C> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( connection -> {
-            for ( C entity : entities ) {
-                AbstractCuratableDao.this.create( entity );
-            }
-        } );
-        return entities;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/BibliographicReferenceDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/BibliographicReferenceDao.java
@@ -46,10 +46,6 @@ public interface BibliographicReferenceDao extends BrowsingDao<BibliographicRefe
 
     Map<ExpressionExperiment, BibliographicReference> getAllExperimentLinkedReferences();
 
-    BibliographicReference thaw( BibliographicReference bibliographicReference );
-
-    Collection<BibliographicReference> thaw( Collection<BibliographicReference> bibliographicReferences );
-
     Map<BibliographicReference, Collection<ExpressionExperiment>> getRelatedExperiments(
             Collection<BibliographicReference> records );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/CharacteristicServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/CharacteristicServiceImpl.java
@@ -72,26 +72,31 @@ public class CharacteristicServiceImpl extends AbstractVoEnabledService<Characte
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Class<?>, Map<String, Collection<Long>>> findExperimentsByUris( Collection<String> uriStrings, Taxon t, int limit ) {
         return this.characteristicDao.findExperimentsByUris( uriStrings, t, limit );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Characteristic> findByUri( Collection<String> uris ) {
         return this.characteristicDao.findByUri( uris );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Characteristic> findByUri( String searchString ) {
         return this.characteristicDao.findByUri( searchString );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Characteristic> findByValue( java.lang.String search ) {
         return this.characteristicDao.findByValue( search + '%' );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Characteristic, Object> getParents( Collection<Characteristic> characteristics ) {
         Map<Characteristic, Object> charToParent = new HashMap<>();
         Collection<Characteristic> needToSearch = new HashSet<>();
@@ -105,6 +110,7 @@ public class CharacteristicServiceImpl extends AbstractVoEnabledService<Characte
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Characteristic, Long> getParentIds( Class<?> parentClass, Collection<Characteristic> characteristics ) {
         return this.characteristicDao.getParentIds( parentClass, characteristics );
     }
@@ -121,6 +127,7 @@ public class CharacteristicServiceImpl extends AbstractVoEnabledService<Characte
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<? extends Characteristic> findByCategory( String query ) {
         return this.characteristicDao.findByCategory( query );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/DatabaseEntryServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/DatabaseEntryServiceImpl.java
@@ -45,7 +45,7 @@ public class DatabaseEntryServiceImpl extends AbstractFilteringVoEnabledService<
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public DatabaseEntry load( String accession ) {
         return this.databaseEntryDao.findByAccession( accession );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/ExternalDatabaseServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/ExternalDatabaseServiceImpl.java
@@ -20,6 +20,7 @@ package ubic.gemma.persistence.service.common.description;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.description.ExternalDatabase;
 import ubic.gemma.persistence.service.AbstractService;
 
@@ -39,6 +40,7 @@ public class ExternalDatabaseServiceImpl extends AbstractService<ExternalDatabas
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ExternalDatabase findByName( String name ) {
         return this.externalDatabaseDao.findByName( name );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/protocol/ProtocolService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/protocol/ProtocolService.java
@@ -23,6 +23,7 @@ import ubic.gemma.model.common.protocol.Protocol;
 import ubic.gemma.persistence.service.BaseService;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author kelsey
@@ -39,7 +40,7 @@ public interface ProtocolService extends BaseService<Protocol> {
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<Protocol> loadAll();
+    List<Protocol> loadAll();
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
     void remove( Long id );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignDao.java
@@ -122,11 +122,11 @@ public interface ArrayDesignDao extends InitializingBean, CuratableDao<ArrayDesi
 
     void removeBiologicalCharacteristics( ArrayDesign arrayDesign );
 
-    ArrayDesign thaw( ArrayDesign arrayDesign );
+    void thaw( ArrayDesign arrayDesign );
 
-    ArrayDesign thawLite( ArrayDesign arrayDesign );
+    void thawLite( ArrayDesign arrayDesign );
 
-    Collection<ArrayDesign> thawLite( Collection<ArrayDesign> arrayDesigns );
+    void thawLite( Collection<ArrayDesign> arrayDesigns );
 
     Boolean updateSubsumingStatus( ArrayDesign candidateSubsumer, ArrayDesign candidateSubsumee );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignService.java
@@ -99,15 +99,24 @@ public interface ArrayDesignService extends FilteringVoEnabledService<ArrayDesig
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     @Override
-    Collection<ArrayDesign> load( Collection<Long> ids );
+    List<ArrayDesign> load( Collection<Long> ids );
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ_QUIET" })
     @Override
     ArrayDesign load( Long id );
 
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    ArrayDesign loadAndThaw( Long id );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    ArrayDesign loadAndThawLite( Long id );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
+    Collection<ArrayDesign> loadAndThawLite( Collection<Long> id );
+
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     @Override
-    Collection<ArrayDesign> loadAll();
+    List<ArrayDesign> loadAll();
 
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
     @Override
@@ -360,18 +369,29 @@ public interface ArrayDesignService extends FilteringVoEnabledService<ArrayDesig
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
     void removeBiologicalCharacteristics( ArrayDesign arrayDesign );
 
+    /**
+     * @deprecated use {@link #loadAndThaw} instead
+     */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ArrayDesign thaw( ArrayDesign arrayDesign );
 
     /**
      * Perform a less intensive thaw of an array design: not the composite sequences.
      *
+     * @deprecated use {@link #loadAndThawLite(Long)} instead
+     *
      * @param arrayDesign AD
      * @return AD
      */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ArrayDesign thawLite( ArrayDesign arrayDesign );
 
+    /**
+     * @deprecated use {@link #loadAndThawLite(Long)} instead
+     */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     Collection<ArrayDesign> thawLite( Collection<ArrayDesign> arrayDesigns );
 
@@ -391,5 +411,4 @@ public interface ArrayDesignService extends FilteringVoEnabledService<ArrayDesig
      * @return
      */
     boolean isBlackListed( String geoAccession );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignService.java
@@ -30,6 +30,7 @@ import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.sequenceAnalysis.BlatResult;
 import ubic.gemma.persistence.service.FilteringVoEnabledService;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -372,7 +373,9 @@ public interface ArrayDesignService extends FilteringVoEnabledService<ArrayDesig
     /**
      * @deprecated use {@link #loadAndThaw} instead
      */
+    @Override
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ArrayDesign thaw( ArrayDesign arrayDesign );
 
@@ -385,6 +388,7 @@ public interface ArrayDesignService extends FilteringVoEnabledService<ArrayDesig
      * @return AD
      */
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ArrayDesign thawLite( ArrayDesign arrayDesign );
 
@@ -392,6 +396,7 @@ public interface ArrayDesignService extends FilteringVoEnabledService<ArrayDesig
      * @deprecated use {@link #loadAndThawLite(Long)} instead
      */
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     Collection<ArrayDesign> thawLite( Collection<ArrayDesign> arrayDesigns );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignServiceImpl.java
@@ -14,6 +14,7 @@
  */
 package ubic.gemma.persistence.service.expression.arrayDesign;
 
+import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +30,8 @@ import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.sequenceAnalysis.BlatResult;
 import ubic.gemma.persistence.service.AbstractFilteringVoEnabledService;
 import ubic.gemma.persistence.service.common.auditAndSecurity.AuditEventDao;
-import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityDao;
+import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityService;
+import ubic.gemma.persistence.util.EntityUtils;
 
 import java.util.*;
 
@@ -43,8 +45,9 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
 
     private final ArrayDesignDao arrayDesignDao;
     private final AuditEventDao auditEventDao;
+
     @Autowired
-    private BlacklistedEntityDao blacklistedEntityDao;
+    private BlacklistedEntityService blacklistedEntityService;
 
     @Autowired
     public ArrayDesignServiceImpl( ArrayDesignDao arrayDesignDao, AuditEventDao auditEventDao ) {
@@ -60,31 +63,55 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> compositeSequenceWithoutBioSequences( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.compositeSequenceWithoutBioSequences( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> compositeSequenceWithoutBlatResults( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.compositeSequenceWithoutBlatResults( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> compositeSequenceWithoutGenes( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.compositeSequenceWithoutGenes( arrayDesign );
     }
 
     @Override
+    @Transactional
     public void deleteAlignmentData( ArrayDesign arrayDesign ) {
         this.arrayDesignDao.deleteAlignmentData( arrayDesign );
     }
 
     @Override
+    @Transactional
     public void deleteGeneProductAssociations( ArrayDesign arrayDesign ) {
         this.arrayDesignDao.deleteGeneProductAssociations( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public ArrayDesign loadAndThawLite( Long id ) {
+        ArrayDesign arrayDesign = this.load( id );
+        if ( arrayDesign != null ) {
+            this.arrayDesignDao.thawLite( arrayDesign );
+        }
+        return arrayDesign;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<ArrayDesign> loadAndThawLite( Collection<Long> id ) {
+        Collection<ArrayDesign> results = this.load( id );
+        this.arrayDesignDao.thawLite( results );
+        return results;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Collection<ArrayDesign> findByAlternateName( String queryString ) {
         return this.arrayDesignDao.findByAlternateName( queryString );
     }
@@ -99,11 +126,13 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
      * @see ArrayDesignService#findByName(java.lang.String)
      */
     @Override
+    @Transactional(readOnly = true)
     public Collection<ArrayDesign> findByName( String name ) {
         return this.arrayDesignDao.findByName( name );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ArrayDesign findByShortName( String shortName ) {
         return this.arrayDesignDao.findByShortName( shortName );
     }
@@ -121,6 +150,7 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public java.util.Collection<BioAssay> getAllAssociatedBioAssays( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.getAllAssociatedBioAssays( arrayDesign );
 
@@ -133,6 +163,7 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Long getCompositeSequenceCount( ArrayDesign arrayDesign ) {
         if ( arrayDesign == null )
             throw new IllegalArgumentException( "Array design cannot be null" );
@@ -140,21 +171,25 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> getCompositeSequences( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.loadCompositeSequences( arrayDesign, -1, 0 );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> getCompositeSequences( ArrayDesign arrayDesign, int limit, int offset ) {
         return this.arrayDesignDao.loadCompositeSequences( arrayDesign, limit, offset );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<ExpressionExperiment> getExpressionExperiments( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.getExpressionExperiments( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, AuditEvent> getLastGeneMapping( Collection<Long> ids ) {
         Map<Long, Collection<AuditEvent>> eventMap = this.arrayDesignDao.getAuditEvents( ids );
         Map<Long, AuditEvent> lastEventMap = new HashMap<>();
@@ -165,6 +200,7 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, AuditEvent> getLastRepeatAnalysis( Collection<Long> ids ) {
         Map<Long, Collection<AuditEvent>> eventMap = this.arrayDesignDao.getAuditEvents( ids );
         Map<Long, AuditEvent> lastEventMap = new HashMap<>();
@@ -176,6 +212,7 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, AuditEvent> getLastSequenceAnalysis( Collection<Long> ids ) {
         Map<Long, Collection<AuditEvent>> eventMap = this.arrayDesignDao.getAuditEvents( ids );
         Map<Long, AuditEvent> lastEventMap = new HashMap<>();
@@ -187,6 +224,7 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, AuditEvent> getLastSequenceUpdate( Collection<Long> ids ) {
         Map<Long, Collection<AuditEvent>> eventMap = this.arrayDesignDao.getAuditEvents( ids );
         Map<Long, AuditEvent> lastEventMap = new HashMap<>();
@@ -204,16 +242,19 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Long> getSwitchedExperimentIds( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.getSwitchedExpressionExperimentIds( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Taxon> getTaxa( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.getTaxa( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Taxon getTaxon( java.lang.Long id ) {
         return this.arrayDesignDao.load( id ).getPrimaryTaxon();
     }
@@ -224,27 +265,32 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
      * @see ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService#isBlackListed(java.lang.String)
      */
     @Override
+    @Transactional(readOnly = true)
     public boolean isBlackListed( String geoAccession ) {
-        return this.blacklistedEntityDao.isBlacklisted( geoAccession );
+        return this.blacklistedEntityService.isBlacklisted( geoAccession );
 
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, Boolean> isMerged( Collection<Long> ids ) {
         return this.arrayDesignDao.isMerged( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, Boolean> isMergee( Collection<Long> ids ) {
         return this.arrayDesignDao.isMergee( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, Boolean> isSubsumed( Collection<Long> ids ) {
         return this.arrayDesignDao.isSubsumed( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, Boolean> isSubsumer( Collection<Long> ids ) {
         return this.arrayDesignDao.isSubsumer( ids );
     }
@@ -256,71 +302,85 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ArrayDesignValueObject> loadValueObjectsForEE( Long eeId ) {
         return this.arrayDesignDao.loadValueObjectsForEE( eeId );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllCompositeSequenceWithBioSequences() {
         return this.arrayDesignDao.numAllCompositeSequenceWithBioSequences();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllCompositeSequenceWithBioSequences( Collection<Long> ids ) {
         return this.arrayDesignDao.numAllCompositeSequenceWithBioSequences( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllCompositeSequenceWithBlatResults() {
         return this.arrayDesignDao.numAllCompositeSequenceWithBlatResults();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllCompositeSequenceWithBlatResults( Collection<Long> ids ) {
         return this.arrayDesignDao.numAllCompositeSequenceWithBlatResults( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllCompositeSequenceWithGenes() {
         return this.arrayDesignDao.numAllCompositeSequenceWithGenes();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllCompositeSequenceWithGenes( Collection<Long> ids ) {
         return this.arrayDesignDao.numAllCompositeSequenceWithGenes( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllGenes() {
         return this.arrayDesignDao.numAllGenes();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numAllGenes( Collection<Long> ids ) {
         return this.arrayDesignDao.numAllGenes( ids );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numBioSequences( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.numBioSequences( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numBlatResults( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.numBlatResults( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numCompositeSequenceWithBioSequences( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.numCompositeSequenceWithBioSequences( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numCompositeSequenceWithBlatResults( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.numCompositeSequenceWithBlatResults( arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numCompositeSequenceWithGenes( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.numCompositeSequenceWithGenes( arrayDesign );
     }
@@ -332,35 +392,38 @@ public class ArrayDesignServiceImpl extends AbstractFilteringVoEnabledService<Ar
     }
 
     @Override
+    @Transactional(readOnly = true)
     public long numGenes( ArrayDesign arrayDesign ) {
         return this.arrayDesignDao.numGenes( arrayDesign );
     }
 
     @Override
+    @Transactional
     public void removeBiologicalCharacteristics( ArrayDesign arrayDesign ) {
         this.arrayDesignDao.removeBiologicalCharacteristics( arrayDesign );
-
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public ArrayDesign thaw( ArrayDesign arrayDesign ) {
-        return this.arrayDesignDao.thaw( arrayDesign );
     }
 
     @Override
     @Transactional(readOnly = true)
     public ArrayDesign thawLite( ArrayDesign arrayDesign ) {
-        return this.arrayDesignDao.thawLite( arrayDesign );
+        ArrayDesign result = load( arrayDesign.getId() );
+        this.arrayDesignDao.thawLite( result );
+        return result;
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Collection<ArrayDesign> thawLite( Collection<ArrayDesign> arrayDesigns ) {
-        return this.arrayDesignDao.thawLite( arrayDesigns );
+    public Collection<ArrayDesign> thawLite( @NonNull Collection<ArrayDesign> arrayDesigns ) {
+        if ( arrayDesigns.isEmpty() ) {
+            return Collections.emptyList();
+        }
+        Collection<ArrayDesign> results = this.load( EntityUtils.getIds( arrayDesigns ) );
+        this.arrayDesignDao.thawLite( results );
+        return results;
     }
 
     @Override
+    @Transactional
     public Boolean updateSubsumingStatus( ArrayDesign candidateSubsumer, ArrayDesign candidateSubsumee ) {
         return this.arrayDesignDao.updateSubsumingStatus( candidateSubsumer, candidateSubsumee );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayDao.java
@@ -38,9 +38,5 @@ public interface BioAssayDao extends BaseVoEnabledDao<BioAssay, BioAssayValueObj
 
     Collection<BioAssay> findByAccession( String accession );
 
-    void thaw( BioAssay bioAssay );
-
-    Collection<BioAssay> thaw( Collection<BioAssay> bioAssays );
-
     List<BioAssayValueObject> loadValueObjects( Collection<BioAssay> entities, boolean basic );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayService.java
@@ -28,6 +28,7 @@ import ubic.gemma.model.expression.biomaterial.BioMaterial;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 import ubic.gemma.persistence.service.FilteringService;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -102,11 +103,13 @@ public interface BioAssayService extends BaseVoEnabledService<BioAssay, BioAssay
 
     @Override
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     BioAssay thaw( BioAssay bioAssay );
 
     @Override
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     List<BioAssay> thaw( Collection<BioAssay> bioAssays );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayService.java
@@ -30,6 +30,7 @@ import ubic.gemma.persistence.service.FilteringService;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author kelsey
@@ -72,7 +73,7 @@ public interface BioAssayService extends BaseVoEnabledService<BioAssay, BioAssay
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<BioAssay> load( Collection<Long> ids );
+    List<BioAssay> load( Collection<Long> ids );
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
@@ -80,7 +81,7 @@ public interface BioAssayService extends BaseVoEnabledService<BioAssay, BioAssay
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<BioAssay> loadAll();
+    List<BioAssay> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
@@ -99,11 +100,15 @@ public interface BioAssayService extends BaseVoEnabledService<BioAssay, BioAssay
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
     void removeBioMaterialAssociation( BioAssay bioAssay, BioMaterial bioMaterial );
 
+    @Override
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
-    void thaw( BioAssay bioAssay );
+    BioAssay thaw( BioAssay bioAssay );
 
+    @Override
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<BioAssay> thaw( Collection<BioAssay> bioAssays );
+    List<BioAssay> thaw( Collection<BioAssay> bioAssays );
 
     List<BioAssayValueObject> loadValueObjects( Collection<BioAssay> entities, boolean basic );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayServiceImpl.java
@@ -30,6 +30,7 @@ import ubic.gemma.persistence.util.Sort;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -87,22 +88,8 @@ public class BioAssayServiceImpl extends AbstractVoEnabledService<BioAssay, BioA
         this.handleRemoveBioMaterialAssociation( bioAssay, bioMaterial );
     }
 
-    /**
-     * @see BioAssayService#thaw(BioAssay)
-     */
     @Override
     @Transactional(readOnly = true)
-    public void thaw( final BioAssay bioAssay ) {
-        this.bioAssayDao.thaw( bioAssay );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Collection<BioAssay> thaw( Collection<BioAssay> bioAssays ) {
-        return this.bioAssayDao.thaw( bioAssays );
-    }
-
-    @Override
     public List<BioAssayValueObject> loadValueObjects( Collection<BioAssay> entities, boolean basic ) {
         return entities == null ? null : bioAssayDao.loadValueObjects( entities, basic );
     }
@@ -112,7 +99,7 @@ public class BioAssayServiceImpl extends AbstractVoEnabledService<BioAssay, BioA
         bioAssay.setSampleUsed( bioMaterial );
 
         // add bioAssay to bioMaterial
-        Collection<BioAssay> currentBioAssays = bioMaterial.getBioAssaysUsedIn();
+        Set<BioAssay> currentBioAssays = bioMaterial.getBioAssaysUsedIn();
         currentBioAssays.add( bioAssay );
         bioMaterial.setBioAssaysUsedIn( currentBioAssays );
 
@@ -147,7 +134,7 @@ public class BioAssayServiceImpl extends AbstractVoEnabledService<BioAssay, BioA
         bioAssayTemp.setSampleUsed( currentBioMaterials );
 
         // Remove bioAssay from bioMaterial
-        Collection<BioAssay> currentBioAssays = biomaterialToBeRemoved.getBioAssaysUsedIn();
+        Set<BioAssay> currentBioAssays = biomaterialToBeRemoved.getBioAssaysUsedIn();
         currentBioAssays.remove( bioAssayTemp );
         biomaterialToBeRemoved.setBioAssaysUsedIn( currentBioAssays );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionDao.java
@@ -29,8 +29,5 @@ public interface BioAssayDimensionDao extends BaseVoEnabledDao<BioAssayDimension
 
     @SuppressWarnings("UnusedReturnValue")
         // Possible external use
-    BioAssayDimension thawLite( BioAssayDimension bioAssayDimension );
-
-    BioAssayDimension thaw( BioAssayDimension bioAssayDimension );
-
+    void thawLite( BioAssayDimension bioAssayDimension );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionDaoImpl.java
@@ -119,11 +119,9 @@ public class BioAssayDimensionDaoImpl extends AbstractVoEnabledDao<BioAssayDimen
     }
 
     @Override
-    public BioAssayDimension thawLite( final BioAssayDimension bioAssayDimension ) {
-        if ( bioAssayDimension == null )
-            return null;
-        if ( bioAssayDimension.getId() == null )
-            return bioAssayDimension;
+    public void thawLite( final BioAssayDimension bioAssayDimension ) {
+        if ( bioAssayDimension == null || bioAssayDimension.getId() == null )
+            return;
 
         this.getHibernateTemplate().execute( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
             @Override
@@ -134,15 +132,12 @@ public class BioAssayDimensionDaoImpl extends AbstractVoEnabledDao<BioAssayDimen
                 return null;
             }
         } );
-        return bioAssayDimension;
     }
 
     @Override
-    public BioAssayDimension thaw( final BioAssayDimension bioAssayDimension ) {
-        if ( bioAssayDimension == null )
-            return null;
-        if ( bioAssayDimension.getId() == null )
-            return bioAssayDimension;
+    public void thaw( final BioAssayDimension bioAssayDimension ) {
+        if ( bioAssayDimension == null || bioAssayDimension.getId() == null )
+            return;
 
         this.getHibernateTemplate().execute( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
             @Override
@@ -168,7 +163,6 @@ public class BioAssayDimensionDaoImpl extends AbstractVoEnabledDao<BioAssayDimen
                 return null;
             }
         } );
-        return bioAssayDimension;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionService.java
@@ -23,6 +23,8 @@ import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimensionValueObject;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * @author Paul
  */
@@ -42,9 +44,11 @@ public interface BioAssayDimensionService
     void remove( BioAssayDimension bioAssayDimension );
 
     @Deprecated
+    @CheckReturnValue
     BioAssayDimension thawLite( BioAssayDimension bioAssayDimension );
 
     @Override
     @Deprecated
+    @CheckReturnValue
     BioAssayDimension thaw( BioAssayDimension bioAssayDimension );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionService.java
@@ -41,7 +41,10 @@ public interface BioAssayDimensionService
     @Secured({ "GROUP_USER" })
     void remove( BioAssayDimension bioAssayDimension );
 
-    void thawLite( BioAssayDimension bioAssayDimension );
+    @Deprecated
+    BioAssayDimension thawLite( BioAssayDimension bioAssayDimension );
 
+    @Override
+    @Deprecated
     BioAssayDimension thaw( BioAssayDimension bioAssayDimension );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionServiceImpl.java
@@ -48,13 +48,9 @@ public class BioAssayDimensionServiceImpl
 
     @Override
     @Transactional(readOnly = true)
-    public void thawLite( BioAssayDimension bioAssayDimension ) {
-        this.bioAssayDimensionDao.thawLite( bioAssayDimension );
+    public BioAssayDimension thawLite( BioAssayDimension bioAssayDimension ) {
+        BioAssayDimension result = this.load( bioAssayDimension.getId() );
+        this.bioAssayDimensionDao.thawLite( result );
+        return result;
     }
-
-    @Override
-    public BioAssayDimension thaw( BioAssayDimension bioAssayDimension ) {
-        return this.bioAssayDimensionDao.thaw( bioAssayDimension );
-    }
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDao.java
@@ -27,6 +27,7 @@ import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.persistence.service.BaseDao;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @see ubic.gemma.model.expression.bioAssayData.DesignElementDataVector
@@ -52,7 +53,7 @@ public interface DesignElementDataVectorDao<T extends DesignElementDataVector> e
      * @return the created instances.
      */
     @Override
-    Collection<T> create( Collection<T> entities );
+    List<T> create( Collection<T> entities );
 
     /**
      * @param designElementDataVector DE data vector
@@ -75,7 +76,7 @@ public interface DesignElementDataVectorDao<T extends DesignElementDataVector> e
      * @return the loaded entities.
      */
     @Override
-    Collection<T> loadAll();
+    List<T> loadAll();
 
     void thaw( Collection<T> designElementDataVectors );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDao.java
@@ -36,56 +36,13 @@ import java.util.List;
 @Repository
 public interface DesignElementDataVectorDao<T extends DesignElementDataVector> extends BaseDao<T> {
 
-    void removeRawAndProcessed( Collection<DesignElementDataVector> vectors );
+    void removeRawAndProcessed( Collection<? extends DesignElementDataVector> vectors );
 
-    Collection<DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim );
+    Collection<? extends DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim );
 
-    Collection<DesignElementDataVector> findRawAndProcessed( QuantitationType qt );
+    Collection<? extends DesignElementDataVector> findRawAndProcessed( QuantitationType qt );
 
-    void thawRawAndProcessed( Collection<DesignElementDataVector> designElementDataVectors );
-
-    /**
-     * Creates a new instance of ubic.gemma.model.expression.bioAssayData.DesignElementDataVector and adds from the
-     * passed in <code>entities</code> collection
-     *
-     * @param entities the collection of ubic.gemma.model.expression.bioAssayData.DesignElementDataVector instances to
-     *                 create.
-     * @return the created instances.
-     */
-    @Override
-    List<T> create( Collection<T> entities );
-
-    /**
-     * @param designElementDataVector DE data vector
-     * @return Creates an instance of ubic.gemma.model.expression.bioAssayData.DesignElementDataVector and adds it to the
-     * persistent store.
-     */
-    @Override
-    T create( T designElementDataVector );
-
-    /**
-     * @param id id
-     * @return Loads an instance of ubic.gemma.model.expression.bioAssayData.DesignElementDataVector from the persistent store.
-     */
-    @Override
-    T load( Long id );
-
-    /**
-     * Loads all entities of type {@link DesignElementDataVector}.
-     *
-     * @return the loaded entities.
-     */
-    @Override
-    List<T> loadAll();
-
-    void thaw( Collection<T> designElementDataVectors );
-
-    /**
-     * @param designElementDataVector Thaws associations of the given DesignElementDataVector
-     */
-    @SuppressWarnings("unused")
-    // Possible external use
-    void thaw( T designElementDataVector );
+    void thawRawAndProcessed( Collection<? extends DesignElementDataVector> designElementDataVectors );
 
     Collection<T> find( BioAssayDimension bioAssayDimension );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDaoImpl.java
@@ -34,10 +34,7 @@ import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.persistence.service.AbstractDao;
 
 import java.sql.Connection;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author pavlidis
@@ -125,8 +122,8 @@ public abstract class DesignElementDataVectorDaoImpl<T extends DesignElementData
         for ( BioAssayDimension bad : dims.keySet() ) {
 
             BioAssayDimension tbad = ( BioAssayDimension ) this.getSessionFactory().getCurrentSession().createQuery(
-                    "select distinct bad from BioAssayDimension bad join fetch bad.bioAssays ba join fetch ba.sampleUsed "
-                            + "bm join fetch ba.arrayDesignUsed left join fetch bm.factorValues fetch all properties where bad.id= :bad " )
+                            "select distinct bad from BioAssayDimension bad join fetch bad.bioAssays ba join fetch ba.sampleUsed "
+                                    + "bm join fetch ba.arrayDesignUsed left join fetch bm.factorValues fetch all properties where bad.id= :bad " )
                     .setParameter( "bad", bad.getId() ).uniqueResult();
 
             assert tbad != null;
@@ -207,35 +204,10 @@ public abstract class DesignElementDataVectorDaoImpl<T extends DesignElementData
         return new HashSet<>( this.findByProperty( "quantitationType", quantitationType ) );
     }
 
-    @Override
-    public Collection<T> create( final Collection<T> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( new Work() {
-            @Override
-            public void execute( Connection connection ) {
-                for ( T entity : entities ) {
-                    DesignElementDataVectorDaoImpl.this.create( entity );
-                }
-            }
-        } );
-        return entities;
-    }
-
-    @Override
-    public void update( final Collection<T> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( new Work() {
-            @Override
-            public void execute( Connection connection ) {
-                for ( T entity : entities ) {
-                    DesignElementDataVectorDaoImpl.this.update( entity );
-                }
-            }
-        } );
-    }
-
     /**
      * @param  ee      ee
      * @param  cs2gene Map of probes to genes.
-     * @return         map of vectors to gene ids.
+     * @return map of vectors to gene ids.
      */
     Map<T, Collection<Long>> getVectorsForProbesInExperiments( Long ee, Map<Long, Collection<Long>> cs2gene ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDaoImpl.java
@@ -48,24 +48,24 @@ public abstract class DesignElementDataVectorDaoImpl<T extends DesignElementData
     }
 
     @Override
-    public final void removeRawAndProcessed( Collection<DesignElementDataVector> vectors ) {
+    public final void removeRawAndProcessed( Collection<? extends DesignElementDataVector> vectors ) {
         for ( DesignElementDataVector v : vectors ) {
             this.getSessionFactory().getCurrentSession().delete( v );
         }
     }
 
     @Override
-    public final Collection<DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim ) {
+    public final Collection<? extends DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim ) {
         return this.findRawAndProcessed( "bioAssayDimension", dim );
     }
 
     @Override
-    public final Collection<DesignElementDataVector> findRawAndProcessed( QuantitationType qt ) {
+    public final Collection<? extends DesignElementDataVector> findRawAndProcessed( QuantitationType qt ) {
         return this.findRawAndProcessed( "quantitationType", qt );
     }
 
     @Override
-    public void thawRawAndProcessed( Collection<DesignElementDataVector> designElementDataVectors ) {
+    public void thawRawAndProcessed( Collection<? extends DesignElementDataVector> designElementDataVectors ) {
         if ( designElementDataVectors == null )
             return;
 
@@ -173,9 +173,9 @@ public abstract class DesignElementDataVectorDaoImpl<T extends DesignElementData
     }
 
     @Override
-    public void thaw( Collection<T> designElementDataVectors ) {
+    public void thaw( List<T> designElementDataVectors ) {
         //noinspection unchecked // Doesnt matter which implementation it is
-        this.thawRawAndProcessed( ( Collection<DesignElementDataVector> ) designElementDataVectors );
+        this.thawRawAndProcessed( designElementDataVectors );
     }
 
     @Override
@@ -270,7 +270,7 @@ public abstract class DesignElementDataVectorDaoImpl<T extends DesignElementData
         return dedv2genes;
     }
 
-    private Collection<DesignElementDataVector> findRawAndProcessed( String propName, Object value ) {
+    private Collection<? extends DesignElementDataVector> findRawAndProcessed( String propName, Object value ) {
         Criteria criteria = this.getSessionFactory().getCurrentSession()
                 .createCriteria( DesignElementDataVector.class );
         criteria.add( Restrictions.eq( propName, value ) );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorService.java
@@ -57,13 +57,6 @@ interface DesignElementDataVectorService<T extends DesignElementDataVector> exte
     void removeDataForQuantitationType( QuantitationType quantitationType );
 
     /**
-     * Thaws the given vectors.
-     *
-     * @param designElementDataVectors the vectors to thaw.
-     */
-    void thaw( Collection<T> designElementDataVectors );
-
-    /**
      * Find specific type ({@link T}) of vectors that meet the given criteria.
      *
      * @param arrayDesign      the AD

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorService.java
@@ -20,7 +20,7 @@ interface DesignElementDataVectorService<T extends DesignElementDataVector> exte
      * @param vectors the vectors to be thawed
      */
     @Secured({ "GROUP_ADMIN" })
-    void thawRawAndProcessed( Collection<DesignElementDataVector> vectors );
+    void thawRawAndProcessed( Collection<? extends DesignElementDataVector> vectors );
 
     /**
      * Finds all vectors for the given BA Dimension
@@ -29,7 +29,7 @@ interface DesignElementDataVectorService<T extends DesignElementDataVector> exte
      * @return the found data vectors
      */
     @Secured({ "GROUP_ADMIN" })
-    Collection<DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim );
+    Collection<? extends DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim );
 
     /**
      * Finds all vectors for the given quantitation type
@@ -38,7 +38,7 @@ interface DesignElementDataVectorService<T extends DesignElementDataVector> exte
      * @return the found data vectors
      */
     @Secured({ "GROUP_ADMIN" })
-    Collection<DesignElementDataVector> findRawAndProcessed( QuantitationType qt );
+    Collection<? extends DesignElementDataVector> findRawAndProcessed( QuantitationType qt );
 
     /**
      * Removes specific type ({@link T}) of vectors for the given CS.

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorServiceImpl.java
@@ -22,19 +22,19 @@ public abstract class DesignElementDataVectorServiceImpl<T extends DesignElement
 
     @Override
     @Transactional(readOnly = true)
-    public void thawRawAndProcessed( Collection<DesignElementDataVector> vectors ) {
+    public void thawRawAndProcessed( Collection<? extends DesignElementDataVector> vectors ) {
         this.designElementDataVectorDao.thawRawAndProcessed( vectors );
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Collection<DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim ) {
+    public Collection<? extends DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim ) {
         return this.designElementDataVectorDao.findRawAndProcessed( dim );
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Collection<DesignElementDataVector> findRawAndProcessed( QuantitationType qt ) {
+    public Collection<? extends DesignElementDataVector> findRawAndProcessed( QuantitationType qt ) {
         return this.designElementDataVectorDao.findRawAndProcessed( qt );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorServiceImpl.java
@@ -1,5 +1,6 @@
 package ubic.gemma.persistence.service.expression.bioAssayData;
 
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
@@ -14,62 +15,67 @@ public abstract class DesignElementDataVectorServiceImpl<T extends DesignElement
 
     private final DesignElementDataVectorDao<T> designElementDataVectorDao;
 
-    DesignElementDataVectorServiceImpl( DesignElementDataVectorDao<T> mainDao ) {
+    protected DesignElementDataVectorServiceImpl( DesignElementDataVectorDao<T> mainDao ) {
         super( mainDao );
         this.designElementDataVectorDao = mainDao;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void thawRawAndProcessed( Collection<DesignElementDataVector> vectors ) {
         this.designElementDataVectorDao.thawRawAndProcessed( vectors );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<DesignElementDataVector> findRawAndProcessed( BioAssayDimension dim ) {
         return this.designElementDataVectorDao.findRawAndProcessed( dim );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<DesignElementDataVector> findRawAndProcessed( QuantitationType qt ) {
         return this.designElementDataVectorDao.findRawAndProcessed( qt );
     }
 
     @Override
+    @Transactional
     public void removeDataForCompositeSequence( CompositeSequence compositeSequence ) {
         this.designElementDataVectorDao.removeDataForCompositeSequence( compositeSequence );
     }
 
     @Override
+    @Transactional
     public void removeDataForQuantitationType( QuantitationType quantitationType ) {
         this.designElementDataVectorDao.removeDataForQuantitationType( quantitationType );
     }
 
     @Override
-    public void thaw( Collection<T> designElementDataVectors ) {
-        this.designElementDataVectorDao.thaw( designElementDataVectors );
-    }
-
-    @Override
+    @Transactional(readOnly = true)
     public Collection<T> find( ArrayDesign arrayDesign, QuantitationType quantitationType ) {
         return this.designElementDataVectorDao.find( arrayDesign, quantitationType );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<T> find( BioAssayDimension bioAssayDimension ) {
         return this.designElementDataVectorDao.find( bioAssayDimension );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<T> find( Collection<QuantitationType> quantitationTypes ) {
         return this.designElementDataVectorDao.find( quantitationTypes );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<T> find( QuantitationType quantitationType ) {
         return this.designElementDataVectorDao.find( quantitationType );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<T> find( Collection<CompositeSequence> designElements, QuantitationType quantitationType ) {
         return this.designElementDataVectorDao.find( designElements, quantitationType );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorServiceImpl.java
@@ -59,6 +59,7 @@ public class ProcessedExpressionDataVectorServiceImpl
     }
 
     @Override
+    @Transactional
     public ExpressionExperiment createProcessedDataVectors( ExpressionExperiment ee,
             Collection<ProcessedExpressionDataVector> vectors ) {
         try {
@@ -249,7 +250,7 @@ public class ProcessedExpressionDataVectorServiceImpl
             return null;
         }
 
-        expressionAnalysisResultSetService.thaw( ar );
+        ar = expressionAnalysisResultSetService.thaw( ar );
 
         BioAssaySet analyzedSet = ar.getAnalysis().getExperimentAnalyzed();
 
@@ -292,6 +293,7 @@ public class ProcessedExpressionDataVectorServiceImpl
     }
 
     @Override
+    @Transactional
     public Collection<ProcessedExpressionDataVector> computeProcessedExpressionData( ExpressionExperiment ee ) {
         try {
 
@@ -306,12 +308,13 @@ public class ProcessedExpressionDataVectorServiceImpl
         } catch ( Exception e ) {
             auditTrailService.addUpdateEvent( ee, FailedProcessedVectorComputationEvent.Factory.newInstance(),
                     ExceptionUtils.getStackTrace( e ) );
-            throw new RuntimeException( e );
+            throw e;
         }
 
     }
 
     @Override
+    @Transactional
     public void reorderByDesign( Long eeId ) {
         this.helperService.reorderByDesign( eeId );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialDao.java
@@ -42,9 +42,4 @@ public interface BioMaterialDao extends BaseVoEnabledDao<BioMaterial, BioMateria
      * @return the experiment the biomaterial appears in
      */
     ExpressionExperiment getExpressionExperiment( Long bioMaterialId );
-
-    void thaw( BioMaterial bioMaterial );
-
-    Collection<BioMaterial> thaw( Collection<BioMaterial> bioMaterials );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialDaoImpl.java
@@ -31,6 +31,7 @@ import ubic.gemma.persistence.util.BusinessKey;
 import ubic.gemma.persistence.util.EntityUtils;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -104,7 +105,7 @@ public class BioMaterialDaoImpl extends AbstractVoEnabledDao<BioMaterial, BioMat
     public Collection<BioMaterial> findByExperiment( ExpressionExperiment experiment ) {
         //noinspection unchecked
         return this.getSessionFactory().getCurrentSession().createQuery(
-                "select distinct bm from ExpressionExperiment e join e.bioAssays b join b.sampleUsed bm where e = :ee" )
+                        "select distinct bm from ExpressionExperiment e join e.bioAssays b join b.sampleUsed bm where e = :ee" )
                 .setParameter( "ee", experiment ).list();
     }
 
@@ -119,7 +120,7 @@ public class BioMaterialDaoImpl extends AbstractVoEnabledDao<BioMaterial, BioMat
     @Override
     public ExpressionExperiment getExpressionExperiment( Long bioMaterialId ) {
         return ( ExpressionExperiment ) this.getSessionFactory().getCurrentSession().createQuery(
-                "select distinct e from ExpressionExperiment e inner join e.bioAssays ba inner join ba.sampleUsed bm where bm.id =:bmid " )
+                        "select distinct e from ExpressionExperiment e inner join e.bioAssays ba inner join ba.sampleUsed bm where bm.id =:bmid " )
                 .setParameter( "bmid", bioMaterialId ).uniqueResult();
     }
 
@@ -135,14 +136,15 @@ public class BioMaterialDaoImpl extends AbstractVoEnabledDao<BioMaterial, BioMat
     }
 
     @Override
-    public Collection<BioMaterial> thaw( Collection<BioMaterial> bioMaterials ) {
+    public void thaw( List<BioMaterial> bioMaterials ) {
         if ( bioMaterials.isEmpty() )
-            return bioMaterials;
+            return;
         //noinspection unchecked
-        return this.getSessionFactory().getCurrentSession().createQuery(
-                "select distinct b from BioMaterial b left join fetch b.sourceTaxon left join fetch b.bioAssaysUsedIn"
-                        + " left join fetch b.treatments left join fetch b.factorValues where b.id in (:ids)" )
+        List<BioMaterial> results = this.getSessionFactory().getCurrentSession().createQuery(
+                        "select distinct b from BioMaterial b left join fetch b.sourceTaxon left join fetch b.bioAssaysUsedIn"
+                                + " left join fetch b.treatments left join fetch b.factorValues where b.id in (:ids)" )
                 .setParameterList( "ids", EntityUtils.getIds( bioMaterials ) ).list();
+        Collections.copy( bioMaterials, results );
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialService.java
@@ -25,6 +25,7 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.expression.experiment.FactorValue;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -83,11 +84,13 @@ public interface BioMaterialService extends BaseVoEnabledService<BioMaterial, Bi
 
     @Override
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
     BioMaterial thaw( BioMaterial bioMaterial );
 
     @Override
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     List<BioMaterial> thaw( Collection<BioMaterial> bioMaterials );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialService.java
@@ -26,7 +26,7 @@ import ubic.gemma.model.expression.experiment.FactorValue;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 
 import java.util.Collection;
-import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -60,7 +60,7 @@ public interface BioMaterialService extends BaseVoEnabledService<BioMaterial, Bi
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<BioMaterial> load( Collection<Long> ids );
+    List<BioMaterial> load( Collection<Long> ids );
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
@@ -68,7 +68,7 @@ public interface BioMaterialService extends BaseVoEnabledService<BioMaterial, Bi
 
     @Override
     @Secured({ "GROUP_USER", "AFTER_ACL_COLLECTION_READ" })
-    Collection<BioMaterial> loadAll();
+    List<BioMaterial> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
@@ -81,11 +81,15 @@ public interface BioMaterialService extends BaseVoEnabledService<BioMaterial, Bi
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
     ExpressionExperiment getExpressionExperiment( Long id );
 
-    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE__READ" })
-    void thaw( BioMaterial bioMaterial );
+    @Override
+    @Deprecated
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
+    BioMaterial thaw( BioMaterial bioMaterial );
 
+    @Override
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<BioMaterial> thaw( Collection<BioMaterial> bioMaterials );
+    List<BioMaterial> thaw( Collection<BioMaterial> bioMaterials );
 
     /**
      * Update the biomaterials that are described by the given valueObjects. This is used to update experimental designs

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/biomaterial/BioMaterialServiceImpl.java
@@ -86,18 +86,6 @@ public class BioMaterialServiceImpl extends AbstractVoEnabledService<BioMaterial
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public void thaw( BioMaterial bioMaterial ) {
-        this.bioMaterialDao.thaw( bioMaterial );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Collection<BioMaterial> thaw( Collection<BioMaterial> bioMaterials ) {
-        return this.bioMaterialDao.thaw( bioMaterials );
-    }
-
-    @Override
     @Transactional
     public Collection<BioMaterial> updateBioMaterials( Collection<BioMaterialValueObject> valueObjects ) {
 
@@ -112,6 +100,7 @@ public class BioMaterialServiceImpl extends AbstractVoEnabledService<BioMaterial
     }
 
     @Override
+    @Transactional
     public <T> void associateBatchFactor( final Map<BioMaterial, T> descriptors, final Map<T, FactorValue> d2fv ) {
 
         for ( final BioMaterial bm : descriptors.keySet() ) {
@@ -172,6 +161,7 @@ public class BioMaterialServiceImpl extends AbstractVoEnabledService<BioMaterial
      * @see BioMaterialService#findOrCreate(ubic.gemma.model.expression.biomaterial.BioMaterial)
      */
     @Override
+    @Transactional
     public BioMaterial findOrCreate( BioMaterial bioMaterial ) {
         return this.bioMaterialDao.findOrCreate( bioMaterial );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDao.java
@@ -80,9 +80,4 @@ public interface CompositeSequenceDao extends FilteringVoEnabledDao<CompositeSeq
     Collection<Object[]> getRawSummary( Collection<CompositeSequence> compositeSequences );
 
     Collection<Object[]> getRawSummary( ArrayDesign arrayDesign, Integer numResults );
-
-    void thaw( Collection<CompositeSequence> compositeSequences );
-
-    CompositeSequence thaw( CompositeSequence compositeSequence );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDaoImpl.java
@@ -518,7 +518,7 @@ public class CompositeSequenceDaoImpl extends AbstractQueryFilteringVoEnabledDao
                         GeneProduct geneProduct = bs2gp.getGeneProduct();
                         if ( geneProduct != null && geneProduct.getGene() != null ) {
                             Gene g = geneProduct.getGene();
-                            g.getAliases().size();
+                            Hibernate.initialize( g.getAliases() );
                             session.evict( g );
                             session.evict( geneProduct );
                         }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDaoImpl.java
@@ -476,7 +476,7 @@ public class CompositeSequenceDaoImpl extends AbstractQueryFilteringVoEnabledDao
     }
 
     @Override
-    public void thaw( final Collection<CompositeSequence> compositeSequences ) {
+    public void thaw( final List<CompositeSequence> compositeSequences ) {
         HibernateTemplate templ = this.getHibernateTemplate();
         templ.executeWithNativeSession( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
             @Override
@@ -544,9 +544,8 @@ public class CompositeSequenceDaoImpl extends AbstractQueryFilteringVoEnabledDao
     }
 
     @Override
-    public CompositeSequence thaw( final CompositeSequence compositeSequence ) {
-        this.thaw( Collections.singleton( compositeSequence ) );
-        return compositeSequence;
+    public void thaw( final CompositeSequence compositeSequence ) {
+        this.thaw( Collections.singletonList( compositeSequence ) );
     }
 
     //    @Override
@@ -593,39 +592,6 @@ public class CompositeSequenceDaoImpl extends AbstractQueryFilteringVoEnabledDao
     //        } );
     //
     //    }
-
-    @Override
-    public Collection<CompositeSequence> load( Collection<Long> ids ) {
-
-        if ( ids == null || ids.size() == 0 ) {
-            return new HashSet<>();
-        }
-
-        //language=HQL
-        final String queryString = "select cs from CompositeSequence cs where cs.id in (:ids)";
-        org.hibernate.Query queryObject = this.getSessionFactory().getCurrentSession().createQuery( queryString );
-        int batchSize = 2000;
-        Collection<Long> batch = new HashSet<>();
-        Collection<CompositeSequence> results = new HashSet<>();
-        for ( Long id : ids ) {
-            batch.add( id );
-
-            if ( batch.size() == batchSize ) {
-                queryObject.setParameterList( "ids", batch );
-                //noinspection unchecked
-                results.addAll( queryObject.list() );
-                batch.clear();
-            }
-        }
-
-        // tail end.
-        if ( batch.size() > 0 ) {
-            queryObject.setParameterList( "ids", batch );
-            //noinspection unchecked
-            results.addAll( queryObject.list() );
-        }
-        return results;
-    }
 
     @Override
     public CompositeSequence find( CompositeSequence compositeSequence ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceService.java
@@ -55,7 +55,7 @@ public interface CompositeSequenceService
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_ARRAYDESIGN_COLLECTION_READ" })
-    Collection<CompositeSequence> load( Collection<Long> ids );
+    List<CompositeSequence> load( Collection<Long> ids );
 
     @Override
     @Secured({ "GROUP_USER" })
@@ -124,9 +124,4 @@ public interface CompositeSequenceService
 
     Collection<GeneMappingSummary> getGeneMappingSummary( BioSequence biologicalCharacteristic,
             CompositeSequenceValueObject cs );
-
-    void thaw( Collection<CompositeSequence> compositeSequences );
-
-    CompositeSequence thaw( CompositeSequence compositeSequence );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceServiceImpl.java
@@ -28,10 +28,7 @@ import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.gene.GeneProductValueObject;
 import ubic.gemma.model.genome.gene.GeneValueObject;
-import ubic.gemma.model.genome.sequenceAnalysis.AnnotationAssociation;
-import ubic.gemma.model.genome.sequenceAnalysis.BioSequenceValueObject;
-import ubic.gemma.model.genome.sequenceAnalysis.BlatAssociation;
-import ubic.gemma.model.genome.sequenceAnalysis.BlatResultValueObject;
+import ubic.gemma.model.genome.sequenceAnalysis.*;
 import ubic.gemma.persistence.service.AbstractFilteringVoEnabledService;
 import ubic.gemma.persistence.service.AbstractService;
 import ubic.gemma.persistence.service.genome.biosequence.BioSequenceService;
@@ -71,16 +68,19 @@ public class CompositeSequenceServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> findByBioSequence( BioSequence bioSequence ) {
         return this.compositeSequenceDao.findByBioSequence( bioSequence );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> findByBioSequenceName( String name ) {
         return this.compositeSequenceDao.findByBioSequenceName( name );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> findByGene( Gene gene ) {
         return this.compositeSequenceDao.findByGene( gene );
     }
@@ -113,21 +113,25 @@ public class CompositeSequenceServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Slice<CompositeSequenceValueObject> loadValueObjectsForGene( Gene gene, int start, int limit ) {
         return this.compositeSequenceDao.findByGene( gene, start, limit ).map( this::loadValueObject );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> findByGene( Gene gene, ArrayDesign arrayDesign ) {
         return this.compositeSequenceDao.findByGene( gene, arrayDesign );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> findByName( String name ) {
         return this.compositeSequenceDao.findByName( name );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CompositeSequence findByName( ArrayDesign arrayDesign, String name ) {
         return this.compositeSequenceDao.findByName( arrayDesign, name );
     }
@@ -137,6 +141,7 @@ public class CompositeSequenceServiceImpl
      * collection of composite sequences as a HashSet, preserving order based on insertion.
      */
     @Override
+    @Transactional(readOnly = true)
     public Collection<CompositeSequence> findByNamesInArrayDesigns( Collection<String> compositeSequenceNames,
             Collection<ArrayDesign> arrayDesigns ) {
         LinkedHashMap<String, CompositeSequence> compositeSequencesMap = new LinkedHashMap<>();
@@ -162,37 +167,44 @@ public class CompositeSequenceServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<CompositeSequence, Collection<Gene>> getGenes( Collection<CompositeSequence> sequences ) {
         return this.compositeSequenceDao.getGenes( sequences );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene> getGenes( CompositeSequence compositeSequence ) {
         return this.getGenes( compositeSequence, 0, -1 );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Slice<Gene> getGenes( CompositeSequence compositeSequence, int offset, int limit ) {
         return this.compositeSequenceDao.getGenes( compositeSequence, offset, limit );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<CompositeSequence, Collection<BioSequence2GeneProduct>> getGenesWithSpecificity(
             Collection<CompositeSequence> compositeSequences ) {
         return this.compositeSequenceDao.getGenesWithSpecificity( compositeSequences );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Object[]> getRawSummary( Collection<CompositeSequence> compositeSequences, Integer numResults ) {
         return this.compositeSequenceDao.getRawSummary( compositeSequences );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Object[]> getRawSummary( ArrayDesign arrayDesign, Integer numResults ) {
         return this.compositeSequenceDao.getRawSummary( arrayDesign, numResults );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<GeneMappingSummary> getGeneMappingSummary( BioSequence biologicalCharacteristic,
             CompositeSequenceValueObject cs ) {
 
@@ -257,17 +269,7 @@ public class CompositeSequenceServiceImpl
     }
 
     @Override
-    public void thaw( Collection<CompositeSequence> compositeSequences ) {
-        this.compositeSequenceDao.thaw( compositeSequences );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public CompositeSequence thaw( CompositeSequence compositeSequence ) {
-        return this.compositeSequenceDao.thaw( compositeSequence );
-    }
-
-    @Override
+    @Transactional
     public void remove( Collection<CompositeSequence> sequencesToDelete ) {
         // check the collection to make sure it contains no transitive entities (just check the id and make sure its
         // non-null
@@ -285,8 +287,9 @@ public class CompositeSequenceServiceImpl
      */
     private void addBlatResultsLackingGenes( BioSequence biologicalCharacteristic,
             Map<Integer, GeneMappingSummary> blatResults, CompositeSequenceValueObject cs ) {
-        Collection<BlatResultValueObject> allBlatResultsForCs = blatResultService.loadValueObjects(
-                blatResultService.thaw( blatResultService.findByBioSequence( biologicalCharacteristic ) ) );
+        Collection<BlatResult> results = blatResultService.findByBioSequence( biologicalCharacteristic );
+        results = blatResultService.thaw( results );
+        Collection<BlatResultValueObject> allBlatResultsForCs = blatResultService.loadValueObjects( results );
         for ( BlatResultValueObject blatResult : allBlatResultsForCs ) {
             if ( !blatResults.containsKey( ProbeMapUtils.hashBlatResult( blatResult ) ) ) {
                 GeneMappingSummary summary = new GeneMappingSummary();

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/BlacklistedEntityService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/BlacklistedEntityService.java
@@ -1,0 +1,12 @@
+package ubic.gemma.persistence.service.expression.experiment;
+
+import ubic.gemma.model.expression.BlacklistedEntity;
+import ubic.gemma.model.expression.BlacklistedValueObject;
+import ubic.gemma.persistence.service.BaseVoEnabledService;
+
+public interface BlacklistedEntityService extends BaseVoEnabledService<BlacklistedEntity, BlacklistedValueObject> {
+
+    boolean isBlacklisted( String accession );
+
+    BlacklistedEntity findByAccession( String accession );
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/BlacklistedEntityServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/BlacklistedEntityServiceImpl.java
@@ -1,0 +1,32 @@
+package ubic.gemma.persistence.service.expression.experiment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ubic.gemma.model.expression.BlacklistedEntity;
+import ubic.gemma.model.expression.BlacklistedValueObject;
+import ubic.gemma.persistence.service.AbstractVoEnabledService;
+
+@Service
+public class BlacklistedEntityServiceImpl extends AbstractVoEnabledService<BlacklistedEntity, BlacklistedValueObject> implements BlacklistedEntityService {
+
+    private final BlacklistedEntityDao blacklistedEntityDao;
+
+    @Autowired
+    public BlacklistedEntityServiceImpl( BlacklistedEntityDao voDao ) {
+        super( voDao );
+        this.blacklistedEntityDao = voDao;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isBlacklisted( String accession ) {
+        return blacklistedEntityDao.isBlacklisted( accession );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BlacklistedEntity findByAccession( String accession ) {
+        return blacklistedEntityDao.findByAccession( accession );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalDesignService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalDesignService.java
@@ -24,6 +24,7 @@ import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.BaseService;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author kelsey
@@ -43,7 +44,7 @@ public interface ExperimentalDesignService extends BaseService<ExperimentalDesig
 
     @Override
     @Secured({ "GROUP_ADMIN" })
-    Collection<ExperimentalDesign> loadAll();
+    List<ExperimentalDesign> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorDao.java
@@ -33,5 +33,5 @@ public interface ExperimentalFactorDao extends BaseVoEnabledDao<ExperimentalFact
     @Override
     ExperimentalFactor findOrCreate( ExperimentalFactor experimentalFactor );
 
-    ExperimentalFactor thaw( ExperimentalFactor ef );
+    void thaw( ExperimentalFactor ef );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorDaoImpl.java
@@ -52,7 +52,7 @@ public class ExperimentalFactorDaoImpl extends AbstractVoEnabledDao<Experimental
     @Override
     public ExperimentalFactor load( Long id ) {
         return ( ExperimentalFactor ) this.getSessionFactory().getCurrentSession().createQuery(
-                "select ef from ExperimentalFactor ef left join fetch ef.factorValues fv left join fetch fv.characteristics c where ef.id=:id" )
+                        "select ef from ExperimentalFactor ef left join fetch ef.factorValues fv left join fetch fv.characteristics c where ef.id=:id" )
                 .setParameter( "id", id ).uniqueResult();
     }
 
@@ -137,10 +137,8 @@ public class ExperimentalFactorDaoImpl extends AbstractVoEnabledDao<Experimental
     }
 
     @Override
-    public ExperimentalFactor thaw( ExperimentalFactor ef ) {
-        ef = this.load( ef.getId() );
+    public void thaw( ExperimentalFactor ef ) {
         Hibernate.initialize( ef );
         Hibernate.initialize( ef.getExperimentalDesign() );
-        return ef;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorService.java
@@ -24,6 +24,7 @@ import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author paul
@@ -39,6 +40,8 @@ public interface ExperimentalFactorService
 
     String BATCH_FACTOR_NAME = "batch";
     String FACTOR_VALUE_RNAME_PREFIX = "fv_";
+
+    ExperimentalFactor loadAndThaw( Long id );
 
     /**
      * Delete the factor, its associated factor values and all differential expression analyses in which it is used.
@@ -58,7 +61,7 @@ public interface ExperimentalFactorService
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExperimentalFactor> load( Collection<Long> ids );
+    List<ExperimentalFactor> load( Collection<Long> ids );
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
@@ -66,11 +69,17 @@ public interface ExperimentalFactorService
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExperimentalFactor> loadAll();
+    List<ExperimentalFactor> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
     void update( ExperimentalFactor experimentalFactor );
 
+    /**
+     * @deprecated use {@link #loadAndThaw(Long)} instead
+     * @param ef
+     * @return
+     */
+    @Deprecated
     ExperimentalFactor thaw( ExperimentalFactor ef );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorService.java
@@ -23,6 +23,7 @@ import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 
@@ -80,6 +81,8 @@ public interface ExperimentalFactorService
      * @param ef
      * @return
      */
+    @Override
     @Deprecated
+    @CheckReturnValue
     ExperimentalFactor thaw( ExperimentalFactor ef );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorServiceImpl.java
@@ -16,6 +16,7 @@ package ubic.gemma.persistence.service.expression.experiment;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
@@ -46,6 +47,7 @@ public class ExperimentalFactorServiceImpl
     }
 
     @Override
+    @Transactional
     public void delete( ExperimentalFactor experimentalFactor ) {
         /*
          * First, check to see if there are any diff results that use this factor.
@@ -57,10 +59,4 @@ public class ExperimentalFactorServiceImpl
         }
         this.experimentalFactorDao.remove( experimentalFactor );
     }
-
-    @Override
-    public ExperimentalFactor thaw(ExperimentalFactor ef){
-        return this.experimentalFactorDao.thaw(ef);
-    }
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDao.java
@@ -15,7 +15,6 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.FilteringVoEnabledDao;
 import ubic.gemma.persistence.service.common.auditAndSecurity.curation.CuratableDao;
 import ubic.gemma.persistence.util.Filters;
-import ubic.gemma.persistence.util.ObjectFilter;
 import ubic.gemma.persistence.util.Slice;
 import ubic.gemma.persistence.util.Sort;
 
@@ -38,7 +37,7 @@ public interface ExpressionExperimentDao
 
     List<ExpressionExperiment> browse( Integer start, Integer limit );
 
-    Integer countNotTroubled();
+    Long countNotTroubled();
 
     Collection<Long> filterByTaxon( Collection<Long> ids, Taxon taxon );
 
@@ -155,13 +154,11 @@ public interface ExpressionExperimentDao
 
     List<ExpressionExperimentValueObject> loadValueObjectsByIds( Collection<Long> ids );
 
-    ExpressionExperiment thaw( ExpressionExperiment expressionExperiment );
+    void thawBioAssays( ExpressionExperiment expressionExperiment );
 
-    ExpressionExperiment thawBioAssays( ExpressionExperiment expressionExperiment );
+    void thawForFrontEnd( ExpressionExperiment expressionExperiment );
 
-    ExpressionExperiment thawForFrontEnd( ExpressionExperiment expressionExperiment );
-
-    ExpressionExperiment thawWithoutVectors( ExpressionExperiment expressionExperiment );
+    void thawWithoutVectors( ExpressionExperiment expressionExperiment );
 
     Collection<? extends AnnotationValueObject> getAnnotationsByBioMaterials( Long eeId );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentService.java
@@ -80,7 +80,7 @@ public interface ExpressionExperimentService
     boolean checkHasBatchInfo( ExpressionExperiment ee );
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
-    Integer countNotTroubled();
+    Long countNotTroubled();
 
     /**
      * returns ids of search results.
@@ -113,16 +113,31 @@ public interface ExpressionExperimentService
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExpressionExperiment> load( Collection<Long> ids );
+    List<ExpressionExperiment> load( Collection<Long> ids );
 
     @Override
     @Monitored
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ_QUIET" })
     ExpressionExperiment load( Long id );
 
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    ExpressionExperiment loadAndThaw( Long eeid );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    ExpressionExperiment loadAndThawLiter( Long id );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    ExpressionExperiment loadAndThawLite( Long id );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
+    Collection<ExpressionExperiment> loadAndThawLite( Collection<Long> ids );
+
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    ExpressionExperiment loadAndThawBioAssays( Long id );
+
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExpressionExperiment> loadAll();
+    List<ExpressionExperiment> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
@@ -498,21 +513,36 @@ public interface ExpressionExperimentService
      */
     void saveExpressionExperimentStatements( Collection<Characteristic> vc, ExpressionExperiment ee );
 
+    /**
+     * @deprecated use {@link #loadAndThaw(Long)} instead
+     */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thaw( ExpressionExperiment expressionExperiment );
 
+    /**
+     * @deprecated use {@link #loadAndThawBioAssays(Long)} instead
+     */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thawBioAssays( ExpressionExperiment expressionExperiment );
 
     /**
      * Partially thaw the expression experiment given - do not thaw the raw data.
      *
+     * @deprecated use {@link #loadAndThawLite(Long)} instead
+     *
      * @param expressionExperiment experiment
      * @return thawed experiment
      */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thawLite( ExpressionExperiment expressionExperiment );
 
+    /**
+     * @deprecated use {@link #loadAndThawLiter(Long)} instead
+     */
+    @Deprecated
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thawLiter( ExpressionExperiment expressionExperiment );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentService.java
@@ -42,6 +42,7 @@ import ubic.gemma.persistence.util.Slice;
 import ubic.gemma.persistence.util.Sort;
 import ubic.gemma.persistence.util.monitor.Monitored;
 
+import javax.annotation.CheckReturnValue;
 import java.util.*;
 
 /**
@@ -517,6 +518,7 @@ public interface ExpressionExperimentService
      * @deprecated use {@link #loadAndThaw(Long)} instead
      */
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thaw( ExpressionExperiment expressionExperiment );
 
@@ -524,6 +526,7 @@ public interface ExpressionExperimentService
      * @deprecated use {@link #loadAndThawBioAssays(Long)} instead
      */
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thawBioAssays( ExpressionExperiment expressionExperiment );
 
@@ -536,6 +539,7 @@ public interface ExpressionExperimentService
      * @return thawed experiment
      */
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thawLite( ExpressionExperiment expressionExperiment );
 
@@ -543,6 +547,7 @@ public interface ExpressionExperimentService
      * @deprecated use {@link #loadAndThawLiter(Long)} instead
      */
     @Deprecated
+    @CheckReturnValue
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     ExpressionExperiment thawLiter( ExpressionExperiment expressionExperiment );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
@@ -618,7 +618,7 @@ public class ExpressionExperimentServiceImpl
     @Override
     @Transactional(readOnly = true)
     public BatchEffectDetails getBatchEffect( ExpressionExperiment ee ) {
-        this.thawLiter( ee );
+        ee = this.thawLiter( ee );
 
         BatchEffectDetails details = new BatchEffectDetails( this.checkBatchFetchStatus( ee ),
                 this.getHasBeenBatchCorrected( ee ), this.checkIfSingleBatch( ee ) );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.Data;
 import org.apache.commons.math3.exception.NotStrictlyPositiveException;
@@ -149,7 +150,7 @@ public class ExpressionExperimentServiceImpl
     @Autowired
     private SampleCoexpressionAnalysisService sampleCoexpressionAnalysisService;
     @Autowired
-    private BlacklistedEntityDao blacklistedEntityDao;
+    private BlacklistedEntityService blacklistedEntityService;
 
     @Autowired
     public ExpressionExperimentServiceImpl( ExpressionExperimentDao expressionExperimentDao ) {
@@ -253,6 +254,7 @@ public class ExpressionExperimentServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean checkHasBatchInfo( ExpressionExperiment ee ) {
 
         for ( ExperimentalFactor ef : ee.getExperimentalDesign().getExperimentalFactors() ) {
@@ -268,6 +270,7 @@ public class ExpressionExperimentServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public BatchInformationFetchingEvent checkBatchFetchStatus( ExpressionExperiment ee ) {
 
         for ( ExperimentalFactor ef : ee.getExperimentalDesign().getExperimentalFactors() ) {
@@ -283,7 +286,8 @@ public class ExpressionExperimentServiceImpl
     }
 
     @Override
-    public Integer countNotTroubled() {
+    @Transactional(readOnly = true)
+    public Long countNotTroubled() {
         return this.expressionExperimentDao.countNotTroubled();
     }
 
@@ -313,6 +317,7 @@ public class ExpressionExperimentServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Long> filterByTaxon( Collection<Long> ids, Taxon taxon ) {
         return this.expressionExperimentDao.filterByTaxon( ids, taxon );
     }
@@ -613,7 +618,7 @@ public class ExpressionExperimentServiceImpl
     @Override
     @Transactional(readOnly = true)
     public BatchEffectDetails getBatchEffect( ExpressionExperiment ee ) {
-        ee = this.thawLiter( ee );
+        this.thawLiter( ee );
 
         BatchEffectDetails details = new BatchEffectDetails( this.checkBatchFetchStatus( ee ),
                 this.getHasBeenBatchCorrected( ee ), this.checkIfSingleBatch( ee ) );
@@ -819,6 +824,7 @@ public class ExpressionExperimentServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean isRNASeq( ExpressionExperiment expressionExperiment ) {
         Collection<ArrayDesign> ads = this.expressionExperimentDao.getArrayDesignsUsed( expressionExperiment );
         /*
@@ -846,6 +852,7 @@ public class ExpressionExperimentServiceImpl
      * @return true, if the given experiment, or any of its parenting array designs is troubled. False otherwise
      */
     @Override
+    @Transactional(readOnly = true)
     public boolean isTroubled( ExpressionExperiment ee ) {
         if ( ee.getCurationDetails().getTroubled() )
             return true;
@@ -967,9 +974,10 @@ public class ExpressionExperimentServiceImpl
      * @param ee the experiment to add the characteristics to.
      */
     @Override
+    @Transactional
     public void saveExpressionExperimentStatement( Characteristic vc, ExpressionExperiment ee ) {
-        ee = this.thawLite(
-                this.load( ee.getId() ) ); // Necessary to make sure we have the persistent version of the given ee.
+        // Necessary to make sure we have the persistent version of the given ee.
+        ee = this.loadAndThawLite( ee.getId() );
         ontologyService.addExpressionExperimentStatement( vc, ee );
         this.update( ee );
     }
@@ -982,6 +990,7 @@ public class ExpressionExperimentServiceImpl
      * @param ee the experiment to add the characteristics to.
      */
     @Override
+    @Transactional
     public void saveExpressionExperimentStatements( Collection<Characteristic> vc, ExpressionExperiment ee ) {
         for ( Characteristic characteristic : vc ) {
             this.saveExpressionExperimentStatement( characteristic, ee );
@@ -990,31 +999,55 @@ public class ExpressionExperimentServiceImpl
 
     @Override
     @Transactional(readOnly = true)
-    public ExpressionExperiment thaw( final ExpressionExperiment expressionExperiment ) {
-        return this.expressionExperimentDao.thaw( expressionExperiment );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
     public ExpressionExperiment thawBioAssays( final ExpressionExperiment expressionExperiment ) {
-        return this.expressionExperimentDao.thawBioAssays( expressionExperiment );
+        ExpressionExperiment result = this.load( expressionExperiment.getId() );
+        this.expressionExperimentDao.thawBioAssays( result );
+        return result;
     }
 
     @Override
     @Transactional(readOnly = true)
     public ExpressionExperiment thawLite( final ExpressionExperiment expressionExperiment ) {
-        return this.expressionExperimentDao.thawWithoutVectors( expressionExperiment );
+        ExpressionExperiment result = this.load( expressionExperiment.getId() );
+        this.expressionExperimentDao.thawWithoutVectors( result );
+        return result;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ExpressionExperiment thawLiter( final ExpressionExperiment expressionExperiment ) {
-        return this.expressionExperimentDao.thawForFrontEnd( expressionExperiment );
+        ExpressionExperiment result = this.load( expressionExperiment.getId() );
+        this.expressionExperimentDao.thawForFrontEnd( result );
+        return result;
     }
 
     @Override
     @Transactional
     public ExpressionExperiment findOrCreate( final ExpressionExperiment expressionExperiment ) {
         return this.expressionExperimentDao.findOrCreate( expressionExperiment );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ExpressionExperiment loadAndThawLiter( Long id ) {
+        return this.thawLiter( this.load( id ) );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ExpressionExperiment loadAndThawLite( Long id ) {
+        return this.thawLite( this.load( id ) );
+    }
+
+    @Override
+    public Collection<ExpressionExperiment> loadAndThawLite( Collection<Long> ids ) {
+        return null;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ExpressionExperiment loadAndThawBioAssays( Long id ) {
+        return this.thawBioAssays( this.load( id ) );
     }
 
     @Override
@@ -1126,11 +1159,13 @@ public class ExpressionExperimentServiceImpl
      * ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService#isBlackListed(java.lang.String)
      */
     @Override
+    @Transactional(readOnly = true)
     public boolean isBlackListed( String geoAccession ) {
-        return this.blacklistedEntityDao.isBlacklisted( geoAccession );
+        return this.blacklistedEntityService.isBlacklisted( geoAccession );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Boolean isSuitableForDEA( ExpressionExperiment ee ) {
         AuditEvent ev = auditEventDao.getLastEvent( ee, DifferentialExpressionSuitabilityEvent.class );
         if ( ev == null ) return true;
@@ -1141,6 +1176,7 @@ public class ExpressionExperimentServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<ExpressionExperiment> getExperimentsLackingPublications() {
         return this.expressionExperimentDao.getExperimentsLackingPublications();
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentSetService.java
@@ -28,6 +28,7 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.BaseVoEnabledService;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author paul
@@ -43,15 +44,18 @@ public interface ExpressionExperimentSetService
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExpressionExperimentSet> load( Collection<Long> ids );
+    List<ExpressionExperimentSet> load( Collection<Long> ids );
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
     ExpressionExperimentSet load( Long id );
 
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
+    ExpressionExperimentSet loadAndThaw( Long id );
+
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExpressionExperimentSet> loadAll();
+    List<ExpressionExperimentSet> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
@@ -189,6 +193,4 @@ public interface ExpressionExperimentSetService
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_COLLECTION_READ" })
     Collection<ExpressionExperimentSetValueObject> loadValueObjectsByIds( Collection<Long> eeSetIds );
-
-    void thaw( ExpressionExperimentSet set );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentSetServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentSetServiceImpl.java
@@ -37,6 +37,7 @@ import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 /**
  * Spring Service base class for <code>ubic.gemma.model.analysis.expression.ExpressionExperimentSetService</code>,
@@ -168,6 +169,7 @@ public class ExpressionExperimentSetServiceImpl
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<ExpressionExperimentSet> findByName( String name ) {
         return this.expressionExperimentSetDao.findByName( name );
     }
@@ -355,16 +357,10 @@ public class ExpressionExperimentSetServiceImpl
         return this.expressionExperimentSetDao.loadValueObjects( eeSetIds, false );
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public void thaw( ExpressionExperimentSet expressionExperimentSet ) {
-        this.expressionExperimentSetDao.thaw( expressionExperimentSet );
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     @Transactional(readOnly = true)
-    public Collection<ExpressionExperimentSet> load( Collection<Long> ids ) {
+    public List<ExpressionExperimentSet> load( Collection<Long> ids ) {
         return this.expressionExperimentSetDao.load( ids );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentSubSetService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentSubSetService.java
@@ -26,6 +26,7 @@ import ubic.gemma.model.expression.experiment.FactorValueValueObject;
 import ubic.gemma.persistence.service.BaseService;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author kelsey
@@ -50,7 +51,7 @@ public interface ExpressionExperimentSubSetService extends BaseService<Expressio
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<ExpressionExperimentSubSet> loadAll();
+    List<ExpressionExperimentSubSet> loadAll();
 
     /**
      * Deletes an experiment subset and all of its associated DifferentialExpressionAnalysis objects. This method is

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/FactorValueService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/FactorValueService.java
@@ -21,10 +21,10 @@ package ubic.gemma.persistence.service.expression.experiment;
 import org.springframework.security.access.annotation.Secured;
 import ubic.gemma.model.expression.experiment.FactorValue;
 import ubic.gemma.model.expression.experiment.FactorValueValueObject;
-import ubic.gemma.persistence.service.BaseVoEnabledService;
 import ubic.gemma.persistence.service.FilteringVoEnabledService;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author kelsey
@@ -44,7 +44,7 @@ public interface FactorValueService extends FilteringVoEnabledService<FactorValu
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<FactorValue> loadAll();
+    List<FactorValue> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/ChromosomeServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/ChromosomeServiceImpl.java
@@ -47,7 +47,7 @@ public class ChromosomeServiceImpl extends AbstractService<Chromosome> implement
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public Collection<Chromosome> find( String name, Taxon taxon ) {
         return this.chromosomeDao.find( name, taxon );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/GeneDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/GeneDao.java
@@ -130,13 +130,11 @@ public interface GeneDao extends FilteringVoEnabledDao<Gene, GeneValueObject> {
 
     Collection<Gene> loadThawedLiter( Collection<Long> ids );
 
-    Gene thaw( Gene gene );
+    void thawAliases( Gene gene );
 
-    Gene thawAliases( Gene gene );
+    void thawLite( Collection<Gene> genes );
 
-    Collection<Gene> thawLite( Collection<Gene> genes );
+    void thawLite( Gene gene );
 
-    Gene thawLite( Gene gene );
-
-    Gene thawLiter( Gene gene );
+    void thawLiter( Gene gene );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceDao.java
@@ -58,9 +58,5 @@ public interface BioSequenceDao extends BaseVoEnabledDao<BioSequence, BioSequenc
      */
     Collection<Gene> getGenesByName( String search );
 
-    Collection<BioSequence> thaw( Collection<BioSequence> bioSequences );
-
-    BioSequence thaw( BioSequence bioSequence );
-
     BioSequence findByCompositeSequence( CompositeSequence compositeSequence );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceService.java
@@ -73,9 +73,5 @@ public interface BioSequenceService extends BaseVoEnabledService<BioSequence, Bi
 
     Collection<Gene> getGenesByName( String search );
 
-    Collection<BioSequence> thaw( Collection<BioSequence> bioSequences );
-
-    BioSequence thaw( BioSequence bs );
-
     BioSequence findByCompositeSequence( CompositeSequence compositeSequence );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceServiceImpl.java
@@ -20,6 +20,7 @@ package ubic.gemma.persistence.service.genome.biosequence;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.genome.Gene;
@@ -52,21 +53,25 @@ public class BioSequenceServiceImpl extends AbstractVoEnabledService<BioSequence
     }
 
     @Override
+    @Transactional(readOnly = true)
     public BioSequence findByAccession( DatabaseEntry accession ) {
         return this.bioSequenceDao.findByAccession( accession );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Gene, Collection<BioSequence>> findByGenes( Collection<Gene> genes ) {
         return this.bioSequenceDao.findByGenes( genes );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<BioSequence> findByName( String name ) {
         return this.bioSequenceDao.findByName( name );
     }
 
     @Override
+    @Transactional
     public Collection<BioSequence> findOrCreate( Collection<BioSequence> bioSequences ) {
         Collection<BioSequence> result = new HashSet<>();
         for ( BioSequence bioSequence : bioSequences ) {
@@ -76,26 +81,19 @@ public class BioSequenceServiceImpl extends AbstractVoEnabledService<BioSequence
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene> getGenesByAccession( String search ) {
         return this.bioSequenceDao.getGenesByAccession( search );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene> getGenesByName( String search ) {
         return this.bioSequenceDao.getGenesByName( search );
     }
 
     @Override
-    public Collection<BioSequence> thaw( Collection<BioSequence> bioSequences ) {
-        return this.bioSequenceDao.thaw( bioSequences );
-    }
-
-    @Override
-    public BioSequence thaw( BioSequence bioSequence ) {
-        return this.bioSequenceDao.thaw( bioSequence );
-    }
-
-    @Override
+    @Transactional(readOnly = true)
     public BioSequence findByCompositeSequence( CompositeSequence compositeSequence ) {
         return this.bioSequenceDao.findByCompositeSequence( compositeSequence );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductDao.java
@@ -38,7 +38,4 @@ public interface GeneProductDao extends BaseVoEnabledDao<GeneProduct, GeneProduc
     Collection<Gene> getGenesByNcbiId( String search );
 
     Collection<GeneProduct> findByName( String name, Taxon taxon );
-
-    GeneProduct thaw( GeneProduct existing );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductDaoImpl.java
@@ -104,13 +104,17 @@ public class GeneProductDaoImpl extends AbstractVoEnabledDao<GeneProduct, GenePr
 
     @Override
     public void thaw( GeneProduct existing ) {
-        Hibernate.initialize( existing.getGene() );
-        Hibernate.initialize( existing.getGene().getTaxon() );
-        Hibernate.initialize( existing.getGene().getAliases() );
-        Hibernate.initialize( existing.getPhysicalLocation() );
-        Hibernate.initialize( existing.getPhysicalLocation().getChromosome() );
-        Hibernate.initialize( existing.getPhysicalLocation().getChromosome().getTaxon() );
         Hibernate.initialize( existing.getAccessions() );
+        if ( existing.getGene() != null ) {
+            Hibernate.initialize( existing.getGene() );
+            Hibernate.initialize( existing.getGene().getTaxon() );
+            Hibernate.initialize( existing.getGene().getAliases() );
+        }
+        if ( existing.getPhysicalLocation() != null ) {
+            Hibernate.initialize( existing.getPhysicalLocation() );
+            Hibernate.initialize( existing.getPhysicalLocation().getChromosome() );
+            Hibernate.initialize( existing.getPhysicalLocation().getChromosome().getTaxon() );
+        }
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductService.java
@@ -73,7 +73,4 @@ public interface GeneProductService extends BaseVoEnabledService<GeneProduct, Ge
     Collection<Gene> getGenesByNcbiId( String search );
 
     Collection<GeneProduct> findByName( String name, Taxon taxon );
-
-    GeneProduct thaw( GeneProduct geneProduct );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductServiceImpl.java
@@ -60,11 +60,13 @@ public class GeneProductServiceImpl extends AbstractVoEnabledService<GeneProduct
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene> getGenesByName( String search ) {
         return this.geneProductDao.getGenesByName( search );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Gene> getGenesByNcbiId( String search ) {
         return this.geneProductDao.getGenesByNcbiId( search );
     }
@@ -73,12 +75,6 @@ public class GeneProductServiceImpl extends AbstractVoEnabledService<GeneProduct
     @Transactional(readOnly = true)
     public Collection<GeneProduct> findByName( String name, Taxon taxon ) {
         return this.geneProductDao.findByName( name, taxon );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public GeneProduct thaw( GeneProduct existing ) {
-        return this.geneProductDao.thaw( existing );
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneSetDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneSetDao.java
@@ -24,9 +24,11 @@ import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.model.genome.gene.DatabaseBackedGeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneSet;
+import ubic.gemma.model.genome.gene.GeneSetValueObject;
 import ubic.gemma.persistence.service.BaseDao;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The interface for managing groupings of genes.
@@ -65,23 +67,23 @@ public interface GeneSetDao extends BaseDao<GeneSet> {
     Collection<GeneSet> loadMyGeneSets();
 
     @Secured({ "GROUP_USER", "AFTER_ACL_FILTER_MY_DATA" })
-    Collection<? extends GeneSet> loadMyGeneSets( Taxon tax );
+    Collection<GeneSet> loadMyGeneSets( Taxon tax );
 
     @Secured({ "GROUP_USER", "AFTER_ACL_FILTER_MY_PRIVATE_DATA" })
-    Collection<? extends GeneSet> loadMySharedGeneSets();
+    Collection<GeneSet> loadMySharedGeneSets();
 
     @Secured({ "GROUP_USER", "AFTER_ACL_FILTER_MY_PRIVATE_DATA" })
-    Collection<? extends GeneSet> loadMySharedGeneSets( Taxon tax );
+    Collection<GeneSet> loadMySharedGeneSets( Taxon tax );
 
-    DatabaseBackedGeneSetValueObject loadValueObject( GeneSet geneSet );
+    DatabaseBackedGeneSetValueObject loadValueObject( GeneSet resultObject );
 
-    Collection<? extends DatabaseBackedGeneSetValueObject> loadValueObjects( Collection<Long> ids );
+    Collection<DatabaseBackedGeneSetValueObject> loadValueObjects( Collection<Long> ids );
 
-    Collection<? extends DatabaseBackedGeneSetValueObject> loadValueObjectsLite( Collection<Long> ids );
+    Collection<DatabaseBackedGeneSetValueObject> loadValueObjectsLite( Collection<Long> ids );
 
     @Override
     @Secured({ "GROUP_USER" })
-    Collection<GeneSet> create( final Collection<GeneSet> entities );
+    List<GeneSet> create( final Collection<GeneSet> entities );
 
     @Secured({ "GROUP_USER" })
     @Override
@@ -89,7 +91,7 @@ public interface GeneSetDao extends BaseDao<GeneSet> {
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<GeneSet> load( Collection<Long> ids );
+    List<GeneSet> load( Collection<Long> ids );
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_READ" })
@@ -97,7 +99,7 @@ public interface GeneSetDao extends BaseDao<GeneSet> {
 
     @Override
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
-    Collection<GeneSet> loadAll();
+    List<GeneSet> loadAll();
 
     @Override
     @Secured({ "GROUP_USER", "ACL_SECURABLE_COLLECTION_EDIT" })
@@ -130,10 +132,4 @@ public interface GeneSetDao extends BaseDao<GeneSet> {
 
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_COLLECTION_READ" })
     Collection<GeneSet> loadAll( Taxon tax );
-
-    /**
-     * @param geneSet gene set
-     */
-    void thaw( GeneSet geneSet );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneSetMemberDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneSetMemberDaoImpl.java
@@ -27,7 +27,9 @@ import ubic.gemma.persistence.service.AbstractDao;
 import ubic.gemma.persistence.service.BaseDao;
 
 import java.sql.Connection;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author kelsey
@@ -39,30 +41,4 @@ public class GeneSetMemberDaoImpl extends AbstractDao<GeneSetMember> implements 
     public GeneSetMemberDaoImpl( SessionFactory sessionFactory ) {
         super( GeneSetMember.class, sessionFactory );
     }
-
-    @Override
-    public Collection<GeneSetMember> create( final Collection<GeneSetMember> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( new Work() {
-            @Override
-            public void execute( Connection connection ) {
-                for ( GeneSetMember entity : entities ) {
-                    GeneSetMemberDaoImpl.this.create( entity );
-                }
-            }
-        } );
-        return entities;
-    }
-
-    @Override
-    public void update( final Collection<GeneSetMember> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( new Work() {
-            @Override
-            public void execute( Connection connection ) {
-                for ( GeneSetMember entity : entities ) {
-                    GeneSetMemberDaoImpl.this.update( entity );
-                }
-            }
-        } );
-    }
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationDaoImpl.java
@@ -30,9 +30,7 @@ import ubic.gemma.persistence.service.AbstractDao;
 import ubic.gemma.persistence.util.BusinessKey;
 
 import java.sql.Connection;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.*;
 
 /**
  * @author paul
@@ -133,61 +131,6 @@ public class AnnotationAssociationDaoImpl extends AbstractDao<AnnotationAssociat
         return this.getSessionFactory().getCurrentSession()
                 .createQuery( "select b from AnnotationAssociation b join b.geneProduct gp where gp in (:gps)" )
                 .setParameterList( "gps", gps ).list();
-    }
-
-    @Override
-    public Collection<AnnotationAssociation> create( final Collection<AnnotationAssociation> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( new Work() {
-            @Override
-            public void execute( Connection connection ) {
-                for ( AnnotationAssociation entity : entities ) {
-                    AnnotationAssociationDaoImpl.this.create( entity );
-                }
-            }
-        } );
-        return entities;
-    }
-
-    @Override
-    public Collection<AnnotationAssociation> load( Collection<Long> ids ) {
-        if ( ids.size() == 0 ) {
-            return new HashSet<>();
-        }
-        int BATCH_SIZE = 2000;
-
-        //language=HQL
-        final String queryString = "select a from AnnotationAssociation a where a.id in (:ids)";
-        Collection<Long> batch = new HashSet<>();
-        Collection<AnnotationAssociation> results = new HashSet<>();
-
-        for ( Long id : ids ) {
-            batch.add( id );
-            if ( batch.size() == BATCH_SIZE ) {
-                //noinspection unchecked
-                results.addAll( this.getSessionFactory().getCurrentSession().createQuery( queryString )
-                        .setParameterList( "ids", batch ).list() );
-                batch.clear();
-            }
-        }
-        if ( batch.size() > 0 ) {
-            //noinspection unchecked
-            results.addAll( this.getSessionFactory().getCurrentSession().createQuery( queryString )
-                    .setParameterList( "ids", batch ).list() );
-        }
-
-        return results;
-    }
-
-    @Override
-    public void update( final Collection<AnnotationAssociation> entities ) {
-        this.getSessionFactory().getCurrentSession().doWork( new Work() {
-            @Override
-            public void execute( Connection connection ) {
-                for ( AnnotationAssociation entity : entities ) {
-                    AnnotationAssociationDaoImpl.this.update( entity );
-                }
-            }
-        } );
     }
 
     private void thawAssociation( org.hibernate.Session session, AnnotationAssociation association ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationDaoImpl.java
@@ -16,6 +16,7 @@ package ubic.gemma.persistence.service.genome.sequenceAnalysis;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
+import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.jdbc.Work;
@@ -139,7 +140,7 @@ public class AnnotationAssociationDaoImpl extends AbstractDao<AnnotationAssociat
         session.update( association.getGeneProduct() );
         session.update( association.getGeneProduct().getGene() );
         session.update( association.getGeneProduct().getGene().getPhysicalLocation() );
-        association.getGeneProduct().getGene().getProducts().size();
+        Hibernate.initialize( association.getGeneProduct().getGene().getProducts() );
         session.update( association.getBioSequence() );
         //noinspection ResultOfMethodCallIgnored called so that the collection is initialised.
         association.getBioSequence().getSequenceDatabaseEntry();

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationService.java
@@ -47,9 +47,5 @@ public interface AnnotationAssociationService extends BaseService<AnnotationAsso
 
     Collection<AnnotationAssociation> find( Gene gene );
 
-    void thaw( AnnotationAssociation annotationAssociation );
-
-    void thaw( Collection<AnnotationAssociation> anCollection );
-
     Collection<AnnotationValueObject> removeRootTerms( Collection<AnnotationValueObject> associations );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/AnnotationAssociationServiceImpl.java
@@ -25,27 +25,15 @@ public class AnnotationAssociationServiceImpl extends AbstractService<Annotation
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<AnnotationAssociation> find( BioSequence bioSequence ) {
         return this.annotationAssociationDao.find( bioSequence );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<AnnotationAssociation> find( Gene gene ) {
         return this.annotationAssociationDao.find( gene );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public void thaw( AnnotationAssociation annotationAssociation ) {
-        this.annotationAssociationDao.thaw( annotationAssociation );
-
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public void thaw( Collection<AnnotationAssociation> anCollection ) {
-        this.annotationAssociationDao.thaw( anCollection );
-
     }
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatAssociationService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatAssociationService.java
@@ -47,9 +47,4 @@ public interface BlatAssociationService extends BaseService<BlatAssociation> {
     Collection<BlatAssociation> find( BioSequence bioSequence );
 
     Collection<BlatAssociation> find( Gene gene );
-
-    void thaw( Collection<BlatAssociation> blatAssociations );
-
-    void thaw( BlatAssociation blatAssociation );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatAssociationServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatAssociationServiceImpl.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2007 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,6 +20,7 @@ package ubic.gemma.persistence.service.genome.sequenceAnalysis;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.sequenceAnalysis.BlatAssociation;
@@ -45,22 +46,14 @@ public class BlatAssociationServiceImpl extends AbstractService<BlatAssociation>
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<BlatAssociation> find( BioSequence bioSequence ) {
         return this.blatAssociationDao.find( bioSequence );
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<BlatAssociation> find( Gene gene ) {
         return this.blatAssociationDao.find( gene );
-    }
-
-    @Override
-    public void thaw( Collection<BlatAssociation> blatAssociations ) {
-        this.blatAssociationDao.thaw( blatAssociations );
-    }
-
-    @Override
-    public void thaw( BlatAssociation blatAssociation ) {
-        this.blatAssociationDao.thaw( blatAssociation );
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultDao.java
@@ -31,10 +31,6 @@ import java.util.Collection;
  */
 public interface BlatResultDao extends BaseVoEnabledDao<BlatResult, BlatResultValueObject> {
 
-    BlatResult thaw( BlatResult blatResult );
-
-    Collection<BlatResult> thaw( Collection<BlatResult> blatResults );
-
     /**
      * Find BLAT results for the given sequence
      *

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultService.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project.
- * 
+ *
  * Copyright (c) 2006-2007 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -40,9 +40,4 @@ public interface BlatResultService extends BaseVoEnabledService<BlatResult, Blat
     @Override
     @Secured({ "GROUP_USER" })
     void update( BlatResult blatResult );
-
-    BlatResult thaw( BlatResult blatResult );
-
-    Collection<BlatResult> thaw( Collection<BlatResult> blatResults );
-
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultServiceImpl.java
@@ -54,16 +54,4 @@ public class BlatResultServiceImpl extends AbstractVoEnabledService<BlatResult, 
             final ubic.gemma.model.genome.biosequence.BioSequence bioSequence ) {
         return this.blatResultDao.findByBioSequence( bioSequence );
     }
-
-    @Override
-    @Transactional(readOnly = true)
-    public BlatResult thaw( BlatResult blatResult ) {
-        return this.blatResultDao.thaw( blatResult );
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Collection<BlatResult> thaw( Collection<BlatResult> blatResults ) {
-        return this.blatResultDao.thaw( blatResults );
-    }
 }

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/BaseAnalyzerConfigurationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/BaseAnalyzerConfigurationTest.java
@@ -48,10 +48,7 @@ import ubic.gemma.model.expression.experiment.*;
 import ubic.gemma.persistence.service.expression.bioAssayData.ProcessedExpressionDataVectorService;
 import ubic.gemma.persistence.util.Settings;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 /**
  * Other tests can extend this class if they want an expression experiment with complete block design and biological
@@ -77,7 +74,7 @@ public abstract class BaseAnalyzerConfigurationTest extends BaseSpringContextTes
 
     ExperimentalFactor experimentalFactorA_Area = null;
     ExperimentalFactor experimentalFactorB = null;
-    List<ExperimentalFactor> experimentalFactors = null;
+    Set<ExperimentalFactor> experimentalFactors = null;
     QuantitationType quantitationType = null;
     FactorValue factorValueA1;
     FactorValue factorValueA2;
@@ -103,7 +100,7 @@ public abstract class BaseAnalyzerConfigurationTest extends BaseSpringContextTes
 
     private RClient rc = null;
 
-    private Collection<ProcessedExpressionDataVector> vectors = null;
+    private Set<ProcessedExpressionDataVector> vectors = null;
 
     @Before
     public void setUp() throws Exception {
@@ -336,9 +333,9 @@ public abstract class BaseAnalyzerConfigurationTest extends BaseSpringContextTes
         biomaterial3a.getBioAssaysUsedIn().add( bioAssay3a );
         biomaterial3b.getBioAssaysUsedIn().add( bioAssay3b );
 
-        expressionExperiment.setBioAssays( bioAssays );
+        expressionExperiment.setBioAssays( new HashSet<>( bioAssays ) );
 
-        experimentalFactors = new ArrayList<>();
+        experimentalFactors = new HashSet<>();
         experimentalFactors.add( experimentalFactorA_Area );
         experimentalFactors.add( experimentalFactorB );
 
@@ -437,7 +434,7 @@ public abstract class BaseAnalyzerConfigurationTest extends BaseSpringContextTes
         bioAssays.remove( bioAssay2b );
         bioAssays.remove( bioAssay3b );
 
-        expressionExperiment.setBioAssays( bioAssays );
+        expressionExperiment.setBioAssays( new HashSet<>( bioAssays ) );
 
         bioAssayDimension.setBioAssays( bioAssays );
 
@@ -466,7 +463,7 @@ public abstract class BaseAnalyzerConfigurationTest extends BaseSpringContextTes
         DoubleMatrix<String, String> dataMatrix = r.read( this.getClass().getResourceAsStream( path ) );
         // RandomData randomData = new RandomDataImpl( new MersenneTwister( 0 ) ); // fixed seed - important!
 
-        Collection<CompositeSequence> compositeSequences = new HashSet<>();
+        Set<CompositeSequence> compositeSequences = new HashSet<>();
         for ( int i = 0; i < BaseAnalyzerConfigurationTest.NUM_DESIGN_ELEMENTS; i++ ) {
             ProcessedExpressionDataVector vector = ProcessedExpressionDataVector.Factory.newInstance();
             vector.setBioAssayDimension( bioAssayDimension );

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/BaselineDetectionTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/BaselineDetectionTest.java
@@ -75,15 +75,13 @@ public class BaselineDetectionTest extends AbstractGeoServiceTest {
         }
         ee = this.eeService.thawLite( ee );
         if ( ee.getExperimentalDesign().getExperimentalFactors().isEmpty() ) {
-            ee = eeService.load( ee.getId() );
-            ee = this.eeService.thawLite( ee );
+            ee = eeService.loadAndThawLite( ee.getId() );
 
             try ( InputStream is = this.getClass()
                     .getResourceAsStream( "/data/loader/expression/geo/gse18162Short/design.txt" ) ) {
                 experimentalDesignImporter.importDesign( ee, is );
             }
-            ee = eeService.load( ee.getId() );
-            ee = this.eeService.thawLite( ee );
+            ee = eeService.loadAndThawLite( ee.getId() );
         }
         // end setup
     }

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
@@ -392,8 +392,9 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
         assertNotNull( mdvo );
 
         for ( IncludedResultSetInfoValueObject gdemairsivo : mdvo.getIncludedResultSetsInfo() ) {
-            this.differentialExpressionAnalysisService
+            DifferentialExpressionAnalysis dea = this.differentialExpressionAnalysisService
                     .thawFully( this.differentialExpressionAnalysisService.load( gdemairsivo.getAnalysisId() ) );
+            assertEquals( gdemairsivo.getAnalysisId(), dea.getId() );
         }
 
         for ( GeneDifferentialExpressionMetaAnalysisResultValueObject vo : mdvo.getResults() ) {

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
@@ -130,8 +130,8 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
          * Add genes.
          */
         if ( !loadedGenes ) {
-            try (InputStream geneFile = this.getClass().getResourceAsStream(
-                    "/data/loader/expression/geo/meta-analysis/human.genes.subset.for.import.txt" )) {
+            try ( InputStream geneFile = this.getClass().getResourceAsStream(
+                    "/data/loader/expression/geo/meta-analysis/human.genes.subset.for.import.txt" ) ) {
                 externalFileGeneLoaderService.load( geneFile, "human" );
                 loadedGenes = true;
             }
@@ -236,9 +236,9 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
         assertTrue( !ds2Analyses.isEmpty() );
         assertTrue( !ds3Analyses.isEmpty() );
 
-        differentialExpressionAnalysisService.thaw( ds1Analyses );
-        differentialExpressionAnalysisService.thaw( ds2Analyses );
-        differentialExpressionAnalysisService.thaw( ds3Analyses );
+        ds1Analyses = differentialExpressionAnalysisService.thaw( ds1Analyses );
+        ds2Analyses = differentialExpressionAnalysisService.thaw( ds2Analyses );
+        ds3Analyses = differentialExpressionAnalysisService.thaw( ds3Analyses );
 
         ExpressionAnalysisResultSet rs1 = ds1Analyses.iterator().next().getResultSets().iterator().next();
         ExpressionAnalysisResultSet rs2 = ds2Analyses.iterator().next().getResultSets().iterator().next();
@@ -301,7 +301,7 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
                     foundTests++;
                     assertTrue( r.getUpperTail() );
                     assertEquals( this.logComponentResults( r, gene ), 0.003375654, r.getMetaPvalue(), 0.00001 );
-                    found[0]= true;
+                    found[0] = true;
                     break;
                 case "ABCF1":
                     fail( "Should have gotten removed due to conflicting results" );
@@ -421,7 +421,7 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
                 .find( EntityUtils.getIds( Arrays.asList( ds1, ds2, ds3 ) ), 0.05, 10 ).isEmpty() );
         assertTrue( !differentialExpressionResultService.find( g, 0.05, 10 ).isEmpty() );
 
-        Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> analysesByExperiment = differentialExpressionAnalysisService
+        Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> analysesByExperiment = differentialExpressionAnalysisService
                 .getAnalysesByExperiment( EntityUtils.getIds( Arrays.asList( ds1, ds2, ds3 ) ) );
 
         Collection<DiffExResultSetSummaryValueObject> resultSets = new HashSet<>();

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceTest.java
@@ -346,7 +346,7 @@ public class DifferentialExpressionAnalyzerServiceTest extends AbstractGeoServic
         Collection<DifferentialExpressionAnalysis> analyses = differentialExpressionAnalyzerService
                 .runDifferentialExpressionAnalyses( ee, config );
         for ( DifferentialExpressionAnalysis analysis : analyses ) {
-            differentialExpressionAnalysisService.thaw( analysis );
+            analysis = differentialExpressionAnalysisService.thaw( analysis );
             for ( ExpressionAnalysisResultSet resultSet : analysis.getResultSets() ) {
                 Histogram hist = resultService.loadPvalueDistribution( resultSet.getId() );
                 assertNotNull( hist );

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceTest.java
@@ -319,7 +319,7 @@ public class DifferentialExpressionAnalyzerServiceTest extends AbstractGeoServic
 
         // check that we read it back correctly.
         {
-            Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> vos = differentialExpressionAnalysisService
+            Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> vos = differentialExpressionAnalysisService
                     .getAnalysesByExperiment( Collections.singleton( ee.getId() ) );
             // it will retrieve the analysis of the subset.
             assertEquals( 1, vos.size() );
@@ -327,7 +327,7 @@ public class DifferentialExpressionAnalyzerServiceTest extends AbstractGeoServic
 
         // retrieve the analysis of the subset directly.
         {
-            Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> vos = differentialExpressionAnalysisService
+            Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> vos = differentialExpressionAnalysisService
                     .getAnalysesByExperiment( Collections.singleton( eeset.getId() ) );
             assertEquals( 1, vos.size() );
             for ( DifferentialExpressionAnalysisValueObject vo : vos.entrySet().iterator().next().getValue() ) {

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/TwoWayAnovaWithInteractionTest2.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/TwoWayAnovaWithInteractionTest2.java
@@ -33,13 +33,12 @@ import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisService;
-import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionResultService;
 import ubic.gemma.persistence.service.analysis.expression.diff.ExpressionAnalysisResultSetService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.HashSet;
 
 import static org.junit.Assert.*;
 
@@ -157,10 +156,8 @@ public class TwoWayAnovaWithInteractionTest2 extends BaseSpringContextTest {
         DifferentialExpressionAnalysis refetched = differentialExpressionAnalysisService
                 .load( persistent.iterator().next().getId() );
 
-        differentialExpressionAnalysisService.thaw( refetched );
-        for ( ExpressionAnalysisResultSet ears : refetched.getResultSets() ) {
-            expressionAnalysisResultSetService.thaw( ears );
-        }
+        refetched = differentialExpressionAnalysisService.thaw( refetched );
+        refetched.setResultSets( new HashSet<>( expressionAnalysisResultSetService.thaw( refetched.getResultSets() ) ) );
 
         this.checkResults( refetched );
 

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataCreateServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/preprocess/ProcessedExpressionDataCreateServiceTest.java
@@ -144,7 +144,7 @@ public class ProcessedExpressionDataCreateServiceTest extends AbstractGeoService
                 .getProcessedDataVectors( ee );
         ee = eeService.load( ee.getId() );
         ee = this.eeService.thawLite( ee );
-        processedExpressionDataVectorService.thaw( preferredVectors );
+        preferredVectors = processedExpressionDataVectorService.thaw( preferredVectors );
 
         ExpressionDataDoubleMatrix mat = new ExpressionDataDoubleMatrix( preferredVectors );
         assertEquals( 10, mat.columns() );
@@ -323,7 +323,7 @@ public class ProcessedExpressionDataCreateServiceTest extends AbstractGeoService
             // thawingto avoid lazy error because we are outside of transaction in this test. All references in code run
             // inside a transaction
             BioAssayDimension bioAssayDimension = vector.getBioAssayDimension();
-            bioAssayDimensionService.thawLite( bioAssayDimension );
+            bioAssayDimension = bioAssayDimensionService.thawLite( bioAssayDimension );
 
             Collection<BioAssay> bioAssays = bioAssayDimension.getBioAssays();
 

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/preprocess/SplitExperimentTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/preprocess/SplitExperimentTest.java
@@ -21,7 +21,9 @@ package ubic.gemma.core.analysis.preprocess;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -82,12 +84,14 @@ public class SplitExperimentTest extends BaseSpringContextTest {
 
     @Test
     @Category(SlowTest.class)
-    public void testSplitGSE17183ByOrganismPart() throws Exception, PreprocessingException {
+    public void testSplitGSE17183ByOrganismPart() throws PreprocessingException, URISyntaxException, IOException {
 
         String geoId = "GSE17183";
 
         geoService.setGeoDomainObjectGenerator(
                 new GeoDomainObjectGeneratorLocal( FileTools.resourceToPath( "/data/analysis/preprocess" ) ) );
+
+        eeService.remove( eeService.findByAccession( geoId ) );
 
         @SuppressWarnings("unchecked")
         Collection<ExpressionExperiment> ees = ( Collection<ExpressionExperiment> ) geoService.fetchAndLoad( geoId, false, false, false );

--- a/gemma-core/src/test/java/ubic/gemma/core/datastructure/matrix/ExpressionDataDoubleMatrixTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/datastructure/matrix/ExpressionDataDoubleMatrixTest.java
@@ -112,8 +112,8 @@ public class ExpressionDataDoubleMatrixTest extends AbstractGeoServiceTest {
         metaData.setType( StandardQuantitationType.AMOUNT );
         metaData.setIsRatio( true );
 
-        try (InputStream data = this.getClass()
-                .getResourceAsStream( "/data/loader/aov.results-2-monocyte-data-bytime.bypat.data.sort" )) {
+        try ( InputStream data = this.getClass()
+                .getResourceAsStream( "/data/loader/aov.results-2-monocyte-data-bytime.bypat.data.sort" ) ) {
             DoubleMatrix<String, String> matrix = simpleExpressionDataLoaderService.parse( data );
             ee = simpleExpressionDataLoaderService.convert( metaData, matrix );
         }
@@ -267,7 +267,7 @@ public class ExpressionDataDoubleMatrixTest extends AbstractGeoServiceTest {
         de2.setArrayDesign( ad );
         vector2.setDesignElement( de2 );
 
-        Collection<RawExpressionDataVector> eeVectors = new LinkedHashSet<>();
+        Set<RawExpressionDataVector> eeVectors = new LinkedHashSet<>();
         eeVectors.add( vector1 );
         eeVectors.add( vector2 );
 
@@ -298,7 +298,7 @@ public class ExpressionDataDoubleMatrixTest extends AbstractGeoServiceTest {
         // make sure we really thaw them, so we can get the design element sequences.
 
         Collection<RawExpressionDataVector> vectors = newee.getRawExpressionDataVectors();
-        rawExpressionDataVectorService.thaw( vectors );
+        vectors = rawExpressionDataVectorService.thaw( vectors );
 
         ExpressionDataMatrixBuilder builder = new ExpressionDataMatrixBuilder( vectors );
         ExpressionDataDoubleMatrix matrix = builder.getPreferredData();
@@ -333,7 +333,7 @@ public class ExpressionDataDoubleMatrixTest extends AbstractGeoServiceTest {
         newee = expressionExperimentService.thaw( newee );
         Collection<ProcessedExpressionDataVector> vecs = newee.getProcessedExpressionDataVectors();
 
-        this.processedDataVectorService.thaw( vecs );
+        vecs = this.processedDataVectorService.thaw( vecs );
 
         assertTrue( !vecs.isEmpty() );
 
@@ -349,7 +349,7 @@ public class ExpressionDataDoubleMatrixTest extends AbstractGeoServiceTest {
         newee = expressionExperimentService.thaw( newee );
         vecs = newee.getProcessedExpressionDataVectors();
 
-        this.processedDataVectorService.thaw( vecs );
+        vecs = this.processedDataVectorService.thaw( vecs );
 
         assertTrue( !vecs.isEmpty() );
 

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearchTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/entrez/pubmed/PubMedSearchTest.java
@@ -28,6 +28,7 @@ import ubic.gemma.model.common.description.BibliographicReference;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -48,7 +49,7 @@ public class PubMedSearchTest {
     public void testSearchAndRetrieveByHTTP() throws Exception {
         try {
             PubMedSearch pms = new PubMedSearch();
-            Collection<String> searchTerms = new HashSet<>();
+            Set<String> searchTerms = new HashSet<>();
             searchTerms.add( "brain" );
             searchTerms.add( "hippocampus" );
             searchTerms.add( "habenula" );
@@ -59,8 +60,8 @@ public class PubMedSearchTest {
              * at least, this was the result on 4/2008.
              */
             BibliographicReference r = actualResult.iterator().next();
-            assertNotNull(r.getAuthorList());
-            assertNotNull(r.getPublicationDate());
+            assertNotNull( r.getAuthorList() );
+            assertNotNull( r.getPublicationDate() );
         } catch ( java.net.UnknownHostException e ) {
             PubMedSearchTest.log.warn( "Test skipped due to unknown host exception" );
         } catch ( java.io.IOException e ) {
@@ -80,7 +81,7 @@ public class PubMedSearchTest {
     public void testSearchAndRetrieveByHTTPInChunks() throws Exception {
         try {
             PubMedSearch pms = new PubMedSearch();
-            Collection<String> searchTerms = new HashSet<>();
+            Set<String> searchTerms = new HashSet<>();
             searchTerms.add( "brain" );
             searchTerms.add( "hippocampus" );
             searchTerms.add( "habenula" );
@@ -102,7 +103,7 @@ public class PubMedSearchTest {
     public void testSearchAndRetrieveIdByHTTPBookshelf() throws Exception {
         try {
             PubMedSearch pms = new PubMedSearch();
-            Collection<String> searchTerms = new HashSet<>();
+            Set<String> searchTerms = new HashSet<>();
             searchTerms.add( "23865096" );
             Collection<BibliographicReference> actualResult = pms.searchAndRetrieveIdByHTTP( searchTerms );
             assertEquals( 1, actualResult.size() );
@@ -117,7 +118,7 @@ public class PubMedSearchTest {
     public void testSearchAndRetrievIdsByHTTP() throws Exception {
         try {
             PubMedSearch pms = new PubMedSearch();
-            Collection<String> searchTerms = new HashSet<>();
+            Set<String> searchTerms = new HashSet<>();
             searchTerms.add( "brain" );
             searchTerms.add( "hippocampus" );
             searchTerms.add( "habenula" );

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/expression/arrayDesign/ArrayDesignMergeServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/expression/arrayDesign/ArrayDesignMergeServiceTest.java
@@ -54,12 +54,9 @@ public class ArrayDesignMergeServiceTest extends BaseSpringContextTest {
                 "ad1ad2ad3_" + RandomStringUtils.randomAlphabetic( 4 ),
                 "ad1ad2ad3_" + RandomStringUtils.randomAlphabetic( 4 ), false );
 
-        ad1 = arrayDesignService.load( ad1.getId() );
-        ad1 = arrayDesignService.thawLite( ad1 );
-        ad2 = arrayDesignService.load( ad2.getId() );
-        ad2 = arrayDesignService.thawLite( ad2 );
-        ad3 = arrayDesignService.load( ad3.getId() );
-        ad3 = arrayDesignService.thawLite( ad3 );
+        ad1 = arrayDesignService.loadAndThawLite( ad1.getId() );
+        ad2 = arrayDesignService.loadAndThawLite( ad2.getId() );
+        ad3 = arrayDesignService.loadAndThawLite( ad3.getId() );
 
         /*
          * merged contains all three.

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/expression/geo/service/GeoDatasetServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/expression/geo/service/GeoDatasetServiceTest.java
@@ -43,7 +43,6 @@ import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
 import ubic.gemma.model.expression.bioAssayData.DesignElementDataVector;
 import ubic.gemma.model.expression.bioAssayData.ProcessedExpressionDataVector;
 import ubic.gemma.model.expression.bioAssayData.RawExpressionDataVector;
-import ubic.gemma.model.expression.biomaterial.BioMaterial;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
@@ -152,7 +151,7 @@ public class GeoDatasetServiceTest extends AbstractGeoServiceTest {
 
             ee = eeService.thaw( ee );
             Collection<ProcessedExpressionDataVector> vecs = ee.getProcessedExpressionDataVectors();
-            dataVectorService.thaw( vecs );
+            vecs = dataVectorService.thaw( vecs );
 
             ExpressionDataMatrixBuilder builder = new ExpressionDataMatrixBuilder( vecs );
 
@@ -240,8 +239,7 @@ public class GeoDatasetServiceTest extends AbstractGeoServiceTest {
             return;
         }
 
-        ee = eeService.load( ee.getId() );
-        ee = this.eeService.thawLite( ee );
+        ee = eeService.thawLite( ee );
 
         // fix for unknown log scale
         for ( QuantitationType qt : ee.getQuantitationTypes() ) {
@@ -257,8 +255,7 @@ public class GeoDatasetServiceTest extends AbstractGeoServiceTest {
 
         twoChannelMissingValues.computeMissingValues( ee );
 
-        ee = eeService.load( ee.getId() );
-        ee = this.eeService.thawLite( ee );
+        ee = eeService.thawLite( ee );
         qts = eeService.getQuantitationTypes( ee );
         assertEquals( 17, qts.size() ); // 16 that were imported plus the detection call we added.
 
@@ -267,14 +264,13 @@ public class GeoDatasetServiceTest extends AbstractGeoServiceTest {
 
         assertEquals( 10, dataVectors.size() );
 
-        processedExpressionDataVectorService.thaw( dataVectors );
+        dataVectors = processedExpressionDataVectorService.thaw( dataVectors );
         for ( ProcessedExpressionDataVector v : dataVectors ) {
             assertTrue( v.getRankByMax() != null );
             assertTrue( v.getRankByMean() != null );
         }
 
-        ee = eeService.load( ee.getId() );
-        ee = this.eeService.thawLite( ee );
+        ee = eeService.thawLite( ee );
         qts = eeService.getQuantitationTypes( ee );
         assertEquals( 18, qts.size() );
         File f = dataFileService.writeOrLocateDataFile( ee, true, true );
@@ -365,7 +361,7 @@ public class GeoDatasetServiceTest extends AbstractGeoServiceTest {
 
         Collection<RawExpressionDataVector> vectors = newee.getRawExpressionDataVectors();
 
-        rawExpressionDataVectorService.thaw( vectors );
+        vectors = rawExpressionDataVectorService.thaw( vectors );
 
         ExpressionDataMatrixBuilder builder = new ExpressionDataMatrixBuilder( vectors );
 
@@ -436,7 +432,7 @@ public class GeoDatasetServiceTest extends AbstractGeoServiceTest {
     }
 
     @SuppressWarnings("unused")
-    // !! Please leave this here, we use it to load data sets for chopping.
+        // !! Please leave this here, we use it to load data sets for chopping.
     ExpressionExperiment fetchASeries( String accession ) {
         geoService.setGeoDomainObjectGenerator( new GeoDomainObjectGenerator() );
         return ( ExpressionExperiment ) geoService.fetchAndLoad( accession, false, false, false ).iterator().next();

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceTest.java
@@ -44,10 +44,7 @@ import ubic.gemma.persistence.service.common.description.CharacteristicService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
@@ -116,7 +113,7 @@ public class SearchServiceTest extends BaseSpringContextTest {
         eeCharCortexURI.setValueUri( SearchServiceTest.BRAIN_CAVITY );
         characteristicService.create( eeCharCortexURI );
 
-        Collection<Characteristic> chars = new HashSet<>();
+        Set<Characteristic> chars = new HashSet<>();
         chars.add( eeCharSpinalCord );
         chars.add( eeCharGeneURI );
         chars.add( eeCharCortexURI );

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceVoConversionTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceVoConversionTest.java
@@ -166,7 +166,7 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
         }
 
         @Bean
-        public BlacklistedEntityDao blackListDao() {
+        public BlacklistedEntityDao blacklistedEntityDao() {
             return mock( BlacklistedEntityDao.class );
         }
 

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceVoConversionTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceVoConversionTest.java
@@ -30,6 +30,7 @@ import ubic.gemma.persistence.service.common.description.CharacteristicService;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 import ubic.gemma.persistence.service.expression.designElement.CompositeSequenceService;
 import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityDao;
+import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentSetService;
 import ubic.gemma.persistence.service.genome.biosequence.BioSequenceService;
@@ -166,8 +167,8 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
         }
 
         @Bean
-        public BlacklistedEntityDao blacklistedEntityDao() {
-            return mock( BlacklistedEntityDao.class );
+        public BlacklistedEntityService blacklistedEntityService() {
+            return mock( BlacklistedEntityService.class );
         }
 
         @Bean

--- a/gemma-core/src/test/java/ubic/gemma/core/security/authorization/SecurityServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/security/authorization/SecurityServiceTest.java
@@ -86,7 +86,7 @@ public class SecurityServiceTest extends BaseSpringContextTest {
         CompositeSequence cs2 = CompositeSequence.Factory.newInstance();
         cs2.setName( SecurityServiceTest.compositeSequenceName2 );
 
-        Collection<CompositeSequence> col = new HashSet<>();
+        Set<CompositeSequence> col = new HashSet<>();
         col.add( cs1 );
         col.add( cs2 );
 

--- a/gemma-core/src/test/java/ubic/gemma/core/security/authorization/acl/AclAuthorizationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/security/authorization/acl/AclAuthorizationTest.java
@@ -41,6 +41,7 @@ import ubic.gemma.persistence.service.expression.designElement.CompositeSequence
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -86,7 +87,7 @@ public class AclAuthorizationTest extends BaseSpringContextTest {
         CompositeSequence cs2 = CompositeSequence.Factory.newInstance();
         cs2.setName( compositeSequenceName2 );
 
-        Collection<CompositeSequence> col = new HashSet<>();
+        Set<CompositeSequence> col = new HashSet<>();
         col.add( cs1 );
         col.add( cs2 );
         cs1.setArrayDesign( arrayDesign );

--- a/gemma-core/src/test/java/ubic/gemma/core/util/test/PersistentDummyObjectHelper.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/util/test/PersistentDummyObjectHelper.java
@@ -275,7 +275,7 @@ public class PersistentDummyObjectHelper {
 
         Set<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<>() );
 
-        eeService.thaw( prototype );
+        prototype = eeService.thaw( prototype );
         Set<RawExpressionDataVector> vectors = new HashSet<>();
         for ( ArrayDesign ad : arrayDesignsUsed ) {
             List<BioAssay> bas = this.getBioAssays( bioMaterials, ad );

--- a/gemma-core/src/test/java/ubic/gemma/core/util/test/PersistentDummyObjectHelper.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/util/test/PersistentDummyObjectHelper.java
@@ -271,12 +271,12 @@ public class PersistentDummyObjectHelper {
         ee.setExperimentalDesign( ed );
         ee.setOwner( this.getTestPersistentContact() );
         List<ArrayDesign> arrayDesignsUsed = new ArrayList<>( eeService.getArrayDesignsUsed( prototype ) );
-        Collection<BioAssay> bioAssays = new HashSet<>();
+        Set<BioAssay> bioAssays = new HashSet<>();
 
-        Collection<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<QuantitationType>() );
+        Set<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<>() );
 
         eeService.thaw( prototype );
-        Collection<RawExpressionDataVector> vectors = new HashSet<>();
+        Set<RawExpressionDataVector> vectors = new HashSet<>();
         for ( ArrayDesign ad : arrayDesignsUsed ) {
             List<BioAssay> bas = this.getBioAssays( bioMaterials, ad );
             bioAssays.addAll( bas );
@@ -324,7 +324,7 @@ public class PersistentDummyObjectHelper {
         ee.setExperimentalDesign( ed );
         ee.setOwner( this.getTestPersistentContact() );
 
-        Collection<BioAssay> bioAssays = new HashSet<>();
+        Set<BioAssay> bioAssays = new HashSet<>();
         Collection<BioMaterial> bioMaterials = this.getBioMaterials( allFactorValues );
         List<BioAssay> bioAssaysA = this.getBioAssays( bioMaterials, adA );
         List<BioAssay> bioAssaysB = this.getBioAssays( bioMaterials, adB );
@@ -334,9 +334,9 @@ public class PersistentDummyObjectHelper {
         ee.setTaxon( bioAssays.iterator().next().getSampleUsed().getSourceTaxon() );
 
         log.debug( "expression experiment => design element data vectors" );
-        Collection<RawExpressionDataVector> vectors = new HashSet<>();
+        Set<RawExpressionDataVector> vectors = new HashSet<>();
 
-        Collection<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<QuantitationType>() );
+        Set<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<>() );
 
         assert quantitationTypes.size() > 0;
 
@@ -558,7 +558,7 @@ public class PersistentDummyObjectHelper {
         ee.getBioAssays().addAll( bioAssays );
         ee.setTaxon( bioAssays.iterator().next().getSampleUsed().getSourceTaxon() );
 
-        Collection<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<QuantitationType>() );
+        Set<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<>() );
 
         assert quantitationTypes.size() > 0;
         ee.setQuantitationTypes( quantitationTypes );
@@ -782,9 +782,9 @@ public class PersistentDummyObjectHelper {
         ee.setOwner( this.getTestPersistentContact() );
 
         log.debug( "expression experiment => design element data vectors" );
-        Collection<RawExpressionDataVector> vectors = new HashSet<>();
+        Set<RawExpressionDataVector> vectors = new HashSet<>();
 
-        Collection<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<QuantitationType>() );
+        Set<QuantitationType> quantitationTypes = this.addQuantitationTypes( new HashSet<QuantitationType>() );
 
         assert quantitationTypes.size() > 0;
 
@@ -831,9 +831,9 @@ public class PersistentDummyObjectHelper {
         this.testElementCollectionSize = PersistentDummyObjectHelper.DEFAULT_TEST_ELEMENT_COLLECTION_SIZE;
     }
 
-    protected Collection<ExperimentalFactor> getExperimentalFactors( ExperimentalDesign ed,
+    protected Set<ExperimentalFactor> getExperimentalFactors( ExperimentalDesign ed,
             Collection<FactorValue> allFactorValues ) {
-        Collection<ExperimentalFactor> efCol = new HashSet<>();
+        Set<ExperimentalFactor> efCol = new HashSet<>();
         for ( int i = 0; i < PersistentDummyObjectHelper.NUM_EXPERIMENTAL_FACTORS; i++ ) {
             ExperimentalFactor ef = ExperimentalFactor.Factory.newInstance();
             ef.setExperimentalDesign( ed );
@@ -852,10 +852,10 @@ public class PersistentDummyObjectHelper {
         return efCol;
     }
 
-    protected Collection<FactorValue> getFactorValues( ExperimentalFactor ef,
+    protected Set<FactorValue> getFactorValues( ExperimentalFactor ef,
             Collection<FactorValue> allFactorValues ) {
 
-        Collection<FactorValue> fvCol = new HashSet<>();
+        Set<FactorValue> fvCol = new HashSet<>();
         for ( int i = 0; i < PersistentDummyObjectHelper.NUM_FACTOR_VALUES; i++ ) {
             FactorValue fv = FactorValue.Factory.newInstance();
             fv.setValue( "Factor value " + RandomStringUtils
@@ -869,7 +869,7 @@ public class PersistentDummyObjectHelper {
         return fvCol;
     }
 
-    private Collection<QuantitationType> addQuantitationTypes( Collection<QuantitationType> quantitationTypes ) {
+    private Set<QuantitationType> addQuantitationTypes( Set<QuantitationType> quantitationTypes ) {
         for ( int quantitationTypeNum = 0; quantitationTypeNum < PersistentDummyObjectHelper.NUM_QUANTITATION_TYPES; quantitationTypeNum++ ) {
             QuantitationType q = PersistentDummyObjectHelper.getTestNonPersistentQuantitationType();
             if ( quantitationTypes.size() == 0 ) {
@@ -902,7 +902,7 @@ public class PersistentDummyObjectHelper {
         // one biomaterial for each set of bioassays
         for ( int j = 0; j < PersistentDummyObjectHelper.NUM_BIOMATERIALS; j++ ) {
             BioMaterial bm = this.getTestNonPersistentBioMaterial();
-            Collection<FactorValue> fvCol = new HashSet<>();
+            Set<FactorValue> fvCol = new HashSet<>();
             if ( iter.hasNext() ) {
                 fvCol.add( iter.next() );
             } else {

--- a/gemma-core/src/test/java/ubic/gemma/model/common/description/CharacteristicServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/common/description/CharacteristicServiceTest.java
@@ -107,8 +107,8 @@ public class CharacteristicServiceTest extends BaseSpringContextTest {
         assertEquals( null, charToParent.get( eeChar2 ) );
     }
 
-    private Collection<Characteristic> getTestPersistentCharacteristics( int n ) {
-        Collection<Characteristic> chars = new HashSet<>();
+    private Set<Characteristic> getTestPersistentCharacteristics( int n ) {
+        Set<Characteristic> chars = new HashSet<>();
         for ( int i = 0; i < n; ++i ) {
             Characteristic c = Characteristic.Factory.newInstance();
             c.setCategory( "test" );

--- a/gemma-core/src/test/java/ubic/gemma/model/common/search/SearchSettingsTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/common/search/SearchSettingsTest.java
@@ -28,7 +28,7 @@ public class SearchSettingsTest {
         searchSettings.setQuery( "http://example.ca/" );
         assertThat( searchSettings.getQuery() ).isEqualTo( "http://example.ca/" );
         assertThat( searchSettings.getRawQuery() ).isEqualTo( "http://example.ca/" );
-        assertThat( searchSettings.isTermQuery() );
+        assertThat( searchSettings.isTermQuery() ).isTrue();
         assertThat( searchSettings.getTermUri() ).isEqualTo( "http://example.ca/" );
     }
 
@@ -38,7 +38,7 @@ public class SearchSettingsTest {
         searchSettings.setQuery( " http://example.ca/ " );
         assertThat( searchSettings.getQuery() ).isEqualTo( "http://example.ca/" );
         assertThat( searchSettings.getRawQuery() ).isEqualTo( " http://example.ca/ " );
-        assertThat( searchSettings.isTermQuery() );
+        assertThat( searchSettings.isTermQuery() ).isTrue();
         assertThat( searchSettings.getTermUri() ).isEqualTo( "http://example.ca/" );
     }
 

--- a/gemma-core/src/test/java/ubic/gemma/model/expression/BlacklistTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/expression/BlacklistTest.java
@@ -1,8 +1,8 @@
 /*
  * The gemma-core project
- * 
+ *
  * Copyright (c) 2018 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,21 +32,18 @@ import ubic.gemma.core.util.test.BaseSpringContextTest;
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.common.description.ExternalDatabase;
 import ubic.gemma.model.expression.experiment.BlacklistedExperiment;
-import ubic.gemma.persistence.service.common.description.ExternalDatabaseDao;
-import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityDao;
+import ubic.gemma.persistence.service.common.description.ExternalDatabaseService;
+import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityService;
 
 /**
- * 
- * 
+ *
+ *
  * @author paul
  */
 public class BlacklistTest extends BaseSpringContextTest {
 
     @Autowired
-    BlacklistedEntityDao blacklistedEntityDao;
-
-    @Autowired
-    ExternalDatabaseDao externalDatabaseDao;
+    BlacklistedEntityService blacklistedEntityService;
 
     @Autowired
     GeoService geoService;
@@ -63,15 +60,15 @@ public class BlacklistTest extends BaseSpringContextTest {
 
         blee.setShortName( acc );
 
-        ExternalDatabase geo = externalDatabaseDao.findByName( "geo" );
+        ExternalDatabase geo = externalDatabaseService.findByName( "geo" );
 
         DatabaseEntry d = DatabaseEntry.Factory.newInstance( acc, null, null, geo );
         blee.setExternalAccession( d );
 
-        blacklistedEntityDao.create( blee );
+        blacklistedEntityService.create( blee );
 
-        assertTrue( blacklistedEntityDao.isBlacklisted( acc ) );
-        assertFalse( blacklistedEntityDao.isBlacklisted( "imok" ) );
+        assertTrue( blacklistedEntityService.isBlacklisted( acc ) );
+        assertFalse( blacklistedEntityService.isBlacklisted( "imok" ) );
         try {
             geoService.fetchAndLoad( acc, false, false, false );
             fail( "Should have gotten an exception when trying to load a blacklisted experiment" );

--- a/gemma-core/src/test/java/ubic/gemma/model/expression/arrayDesign/ArrayDesignServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/expression/arrayDesign/ArrayDesignServiceTest.java
@@ -140,8 +140,7 @@ public class ArrayDesignServiceTest extends BaseSpringContextTest {
     @Test
     public void testCountAll() {
         ad = ( ArrayDesign ) persisterHelper.persist( ad );
-        Integer count = arrayDesignService.countAll();
-        assertNotNull( count );
+        long count = arrayDesignService.countAll();
         assertTrue( count > 0 );
     }
 

--- a/gemma-core/src/test/java/ubic/gemma/model/expression/bioAssay/BioAssayServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/expression/bioAssay/BioAssayServiceTest.java
@@ -68,7 +68,7 @@ public class BioAssayServiceTest extends BaseSpringContextTest {
 
     @Test
     public void testGetCount() {
-        Integer count = bioAssayService.countAll();
+        Long count = bioAssayService.countAll();
         assertNotNull( count );
         assertTrue( count > 0 );
     }

--- a/gemma-core/src/test/java/ubic/gemma/model/expression/experiment/ExpressionExperimentServiceImplTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/expression/experiment/ExpressionExperimentServiceImplTest.java
@@ -30,8 +30,10 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentServiceImpl;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,7 +43,7 @@ import static org.mockito.Mockito.when;
  * @author paul
  */
 public class ExpressionExperimentServiceImplTest extends BaseSpringContextTest {
-    private Collection<ExpressionExperiment> c;
+    private List<ExpressionExperiment> c;
     private Collection<ExpressionExperiment> cJustTwelve;
     private ExpressionExperiment ee = null;
     private User nobody = null;
@@ -80,7 +82,7 @@ public class ExpressionExperimentServiceImplTest extends BaseSpringContextTest {
             ee.getBioAssays().add( ba );
         }
 
-        c = new HashSet<>();
+        c = new ArrayList<>();
         ExpressionExperiment numberTwelve = ExpressionExperiment.Factory.newInstance();
         numberTwelve.setId( 12L );
 

--- a/gemma-core/src/test/java/ubic/gemma/model/expression/experiment/ExpressionExperimentSetServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/expression/experiment/ExpressionExperimentSetServiceTest.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2012 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,6 +33,7 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -70,7 +71,7 @@ public class ExpressionExperimentSetServiceTest extends BaseSpringContextTest {
         eeMouse = this.getTestPersistentExpressionExperiment( taxMouse );
 
         // Make experiment set
-        Collection<ExpressionExperiment> ees = new HashSet<>();
+        Set<ExpressionExperiment> ees = new HashSet<>();
         ees.add( ee1 );
         ees.add( ee2 );
 
@@ -101,7 +102,7 @@ public class ExpressionExperimentSetServiceTest extends BaseSpringContextTest {
 
         String newName = "newName";
         String newDesc = "newDesc";
-        Collection<BioAssaySet> newMembers = new HashSet<>();
+        Set<BioAssaySet> newMembers = new HashSet<>();
         newMembers.add( ee1 );
 
         eeSet.setName( newName );
@@ -126,7 +127,7 @@ public class ExpressionExperimentSetServiceTest extends BaseSpringContextTest {
 
     @Test(expected = Exception.class)
     public void testAddingExperimentOfWrongTaxonUpdate() {
-        Collection<BioAssaySet> newMembers = new LinkedList<>();
+        Set<BioAssaySet> newMembers = new HashSet<>();
         newMembers.add( ee1 );
         newMembers.add( eeMouse );
         eeSet.setExperiments( newMembers );

--- a/gemma-core/src/test/java/ubic/gemma/model/genome/gene/GeneServiceImplTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/genome/gene/GeneServiceImplTest.java
@@ -34,6 +34,7 @@ import ubic.gemma.persistence.service.genome.GeneDaoImpl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.easymock.EasyMock.*;
 
@@ -44,9 +45,9 @@ import static org.easymock.EasyMock.*;
 public class GeneServiceImplTest extends BaseSpringContextTest {
 
     private static final String STRAND = "+";
-    private final Collection<Gene> allThree = new HashSet<>();
-    private final Collection<Gene> justRab = new HashSet<>();
-    private final Collection<Gene> justRabble = new HashSet<>();
+    private final Set<Gene> allThree = new HashSet<>();
+    private final Set<Gene> justRab = new HashSet<>();
+    private final Set<Gene> justRabble = new HashSet<>();
     private GeneServiceImpl svc;
     private Gene g = null;
     private Gene g2 = null;
@@ -153,7 +154,7 @@ public class GeneServiceImplTest extends BaseSpringContextTest {
         gp5.setName( "wrong chromosome gp5" );
         gp5.setId( ( long ) 4567 );
 
-        Collection<GeneProduct> gps = new ArrayList<>();
+        Set<GeneProduct> gps = new HashSet<>();
         gps.add( gp1 );
         gps.add( gp2 );
         gps.add( gp4 );

--- a/gemma-core/src/test/java/ubic/gemma/model/genome/gene/GeneServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/genome/gene/GeneServiceTest.java
@@ -34,6 +34,8 @@ import ubic.gemma.persistence.service.common.description.ExternalDatabaseService
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -207,7 +209,7 @@ public class GeneServiceTest extends BaseSpringContextTest {
         gene.setNcbiGeneId( id );
         gene.setName( GeneServiceTest.TEST_GENE_NAME );
 
-        Collection<GeneAlias> aliases = new ArrayList<>();
+        Set<GeneAlias> aliases = new HashSet<>();
         GeneAlias alias = GeneAlias.Factory.newInstance();
         alias.setId( ( long ) 1 );
         alias.setAlias( "GRIN1" );

--- a/gemma-core/src/test/java/ubic/gemma/model/genome/gene/GeneSetServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/genome/gene/GeneSetServiceTest.java
@@ -18,6 +18,7 @@
  */
 package ubic.gemma.model.genome.gene;
 
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.After;
@@ -211,7 +212,7 @@ public class GeneSetServiceTest extends BaseSpringContextTest {
         // make sure members collection is initialized
         session = sessionFactory.openSession();
         session.update( gset );
-        gset.getMembers().size();
+        Hibernate.initialize( gset.getMembers() );
         session.close();
 
         gmember = GeneSetMember.Factory.newInstance();
@@ -230,7 +231,7 @@ public class GeneSetServiceTest extends BaseSpringContextTest {
         // make sure members collection is initialized
         session = sessionFactory.openSession();
         session.update( gset );
-        gset.getMembers().size();
+        Hibernate.initialize( gset.getMembers() );
         session.close();
 
         assertEquals( 2, gset.getMembers().size() );
@@ -244,7 +245,7 @@ public class GeneSetServiceTest extends BaseSpringContextTest {
         // make sure members collection is initialized
         session = sessionFactory.openSession();
         session.update( gset );
-        gset.getMembers().size();
+        Hibernate.initialize( gset.getMembers() );
         session.close();
 
         assertEquals( 1, gset.getMembers().size() );

--- a/gemma-core/src/test/java/ubic/gemma/persistence/GenomePersisterTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/GenomePersisterTest.java
@@ -31,6 +31,7 @@ import ubic.gemma.persistence.service.genome.biosequence.BioSequenceService;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -50,7 +51,7 @@ public class GenomePersisterTest extends BaseSpringContextTest {
         gene.setName( RandomStringUtils.randomAlphabetic( 10 ) );
         gene.setNcbiGeneId( Integer.parseInt( RandomStringUtils.randomNumeric( 8 ) ) );
 
-        Collection<GeneProduct> gps = new HashSet<>();
+        Set<GeneProduct> gps = new HashSet<>();
         for ( int i = 0; i < 10; i++ ) {
             GeneProduct gp = GeneProduct.Factory.newInstance();
             gp.setName( RandomStringUtils.randomAlphabetic( 10 ) );

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/ObjectFilterTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/ObjectFilterTest.java
@@ -156,6 +156,11 @@ public class ObjectFilterTest {
     }
 
     @Test
+    public void testCollection() {
+        new ObjectFilter( "ee", "id", Integer.class, ObjectFilter.Operator.in, Arrays.asList( 1, 2, 3 ) );
+    }
+
+    @Test
     public void testInvalidCollectionTypeConversion() {
         assertThatThrownBy( () -> new ObjectFilter( "ee", "id", String.class, ObjectFilter.Operator.in, Arrays.asList( 1, 2, 3 ) ) )
                 .isInstanceOf( IllegalArgumentException.class );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/GeneralSearchControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/GeneralSearchControllerImpl.java
@@ -318,9 +318,7 @@ public class GeneralSearchControllerImpl extends BaseFormController implements G
             vos = compositeSequenceService
                     .loadValueObjectsWithoutGeneMappingSummary( compositeSequences );
         } else if ( BibliographicReference.class.isAssignableFrom( entityClass ) ) {
-            Collection<BibliographicReference> bss = bibliographicReferenceService
-                    .load( ids );
-            bss = bibliographicReferenceService.thaw( bss );
+            Collection<BibliographicReference> bss = bibliographicReferenceService.loadAndThaw( ids );
             vos = bibliographicReferenceService.loadValueObjects( bss );
         } else if ( Gene.class.isAssignableFrom( entityClass ) ) {
             Collection<Gene> genes = geneService.load( ids );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/BatchInfoFetchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/BatchInfoFetchController.java
@@ -46,10 +46,9 @@ public class BatchInfoFetchController {
         if ( id == null )
             throw new IllegalArgumentException( "ID cannot be null" );
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
         if ( ee == null )
             throw new IllegalArgumentException( "Could not load experiment with id=" + id );
-        ee = expressionExperimentService.thawLite( ee );
 
         /*
          * Check preconditions.

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/PreprocessController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/PreprocessController.java
@@ -47,17 +47,15 @@ public class PreprocessController {
      * Update the processed data vectors as well as diagnostics
      *
      * @param  id of the experiment
-     * @return    status
+     * @return status
      */
     public String run( Long id ) {
         if ( id == null )
             throw new IllegalArgumentException( "ID cannot be null" );
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThaw( id );
         if ( ee == null )
             throw new IllegalArgumentException( "Could not load experiment with id=" + id );
-
-        ee = expressionExperimentService.thawLite( ee );
 
         PreprocessTaskCommand cmd = new PreprocessTaskCommand( ee );
         experimentReportService.evictFromCache( id );
@@ -68,17 +66,15 @@ public class PreprocessController {
      * Only update the daignostics
      *
      * @param  id of experiment
-     * @return    status
+     * @return status
      */
     public String diagnostics( Long id ) {
         if ( id == null )
             throw new IllegalArgumentException( "ID cannot be null" );
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
         if ( ee == null )
             throw new IllegalArgumentException( "Could not load experiment with id=" + id );
-
-        ee = expressionExperimentService.thawLite( ee );
 
         PreprocessTaskCommand cmd = new PreprocessTaskCommand( ee );
         cmd.setDiagnosticsOnly( true );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/SvdController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/SvdController.java
@@ -48,11 +48,10 @@ public class SvdController {
     public String run( Long id ) {
         if ( id == null )
             throw new IllegalArgumentException( "ID cannot be null" );
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
         if ( ee == null )
             throw new IllegalArgumentException( "Could not load experiment with id=" + id );
 
-        ee = expressionExperimentService.thawLite( ee );
         experimentReportService.evictFromCache( id );
         SvdTaskCommand cmd = new SvdTaskCommand( ee );
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/TwoChannelMissingValueController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/TwoChannelMissingValueController.java
@@ -45,12 +45,11 @@ public class TwoChannelMissingValueController {
      * AJAX entry point. -- uses default settings
      */
     public String run( Long id ) {
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
 
         if ( ee == null ) {
             throw new IllegalArgumentException( "Cannot access experiment with id=" + id );
         }
-        ee = expressionExperimentService.thawLite( ee );
 
         TwoChannelMissingValueTaskCommand cmd = new TwoChannelMissingValueTaskCommand( ee );
         experimentReportService.evictFromCache( id );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/sequence/ArrayDesignRepeatScanController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/sequence/ArrayDesignRepeatScanController.java
@@ -42,9 +42,8 @@ public class ArrayDesignRepeatScanController {
      * AJAX entry point.
      */
     public String run( Long id ) {
-        ArrayDesign ad = arrayDesignService.load( id );
+        ArrayDesign ad = arrayDesignService.loadAndThawLite( id );
 
-        ad = arrayDesignService.thawLite( ad );
         ArrayDesignRepeatScanTaskCommand cmd = new ArrayDesignRepeatScanTaskCommand( ad );
 
         return taskRunningService.submitTaskCommand( cmd );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/coexpressionSearch/CoexpressionSearchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/coexpressionSearch/CoexpressionSearchController.java
@@ -36,6 +36,7 @@ import ubic.gemma.core.tasks.AbstractTask;
 import ubic.gemma.model.analysis.expression.ExpressionExperimentSet;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.genome.gene.GeneSetValueObject;
+import ubic.gemma.model.genome.gene.TransientGeneSetValueObject;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentSetService;
 import ubic.gemma.persistence.util.EntityUtils;
@@ -101,7 +102,7 @@ public class CoexpressionSearchController {
 
             if ( searchOptions.getGeneSetId() != null ) {
                 searchOptions.setGeneIds(
-                        geneSetService.getGeneIdsInGroup( new GeneSetValueObject( searchOptions.getGeneSetId() ) ) );
+                        geneSetService.getGeneIdsInGroup( new TransientGeneSetValueObject( searchOptions.getGeneSetId() ) ) );
             }
 
             if ( searchOptions.getGeneIds().isEmpty() ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/common/CharacteristicBrowserController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/common/CharacteristicBrowserController.java
@@ -74,7 +74,7 @@ public class CharacteristicBrowserController {
     private CharacteristicService characteristicService;
 
     public JsonReaderResponse<AnnotationValueObject> browse( ListBatchCommand batch ) {
-        Integer count = characteristicService.countAll();
+        Long count = characteristicService.countAll();
 
         List<AnnotationValueObject> results = new ArrayList<>();
 
@@ -127,7 +127,7 @@ public class CharacteristicBrowserController {
             results.add( avo );
         }
 
-        return new JsonReaderResponse<>( results, count );
+        return new JsonReaderResponse<>( results, count.intValue() );
     }
 
     private void populateClassValues( Characteristic c, AnnotationValueObject avo ) {
@@ -137,7 +137,7 @@ public class CharacteristicBrowserController {
     }
 
     public Integer count() {
-        return characteristicService.countAll();
+        return (int) characteristicService.countAll();
     }
 
     public Collection<AnnotationValueObject> findCharacteristics( String valuePrefix ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/common/description/bibref/BibliographicReferenceControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/common/description/bibref/BibliographicReferenceControllerImpl.java
@@ -97,7 +97,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
     @Override
     public JsonReaderResponse<BibliographicReferenceValueObject> browse( ListBatchCommand batch ) {
 
-        Integer count = this.bibliographicReferenceService.countAll();
+        Long count = this.bibliographicReferenceService.countAll();
         List<BibliographicReference> records = this.getBatch( batch );
         Map<BibliographicReference, Collection<ExpressionExperiment>> relatedExperiments = this.bibliographicReferenceService
                 .getRelatedExperiments( records );
@@ -110,7 +110,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
             BibliographicReferenceValueObject vo = new BibliographicReferenceValueObject( ref );
 
             if ( relatedExperiments.containsKey( ref ) ) {
-                vo.setExperiments( expressionExperimentService.loadValueObjects( relatedExperiments.get( ref ) ) );
+                vo.setExperiments( new HashSet<>( expressionExperimentService.loadValueObjects( relatedExperiments.get( ref ) ) ) );
             }
             valueObjects.add( vo );
 
@@ -119,13 +119,13 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
             Collection<PhenotypeAssociation> phenotypeAssociations = this.phenotypeAssociationService
                     .findPhenotypesForBibliographicReference( vo.getPubAccession() );
 
-            Collection<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = BibliographicPhenotypesValueObject
+            Set<BibliographicPhenotypesValueObject> bibliographicPhenotypesValueObjects = BibliographicPhenotypesValueObject
                     .phenotypeAssociations2BibliographicPhenotypesValueObjects( phenotypeAssociations );
             vo.setBibliographicPhenotypes( bibliographicPhenotypesValueObjects );
 
         }
 
-        return new JsonReaderResponse<>( valueObjects, count );
+        return new JsonReaderResponse<>( valueObjects, count.intValue() );
     }
 
     @Override
@@ -179,8 +179,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
     @Override
     public JsonReaderResponse<BibliographicReferenceValueObject> loadMultiple( Collection<Long> ids ) {
 
-        Collection<BibliographicReference> bss = bibliographicReferenceService.load( ids );
-        bss = bibliographicReferenceService.thaw( bss );
+        Collection<BibliographicReference> bss = bibliographicReferenceService.loadAndThaw( ids );
         Collection<BibliographicReferenceValueObject> bibRefs = bibliographicReferenceService.loadValueObjects( bss );
 
         return new JsonReaderResponse<>( new ArrayList<>( bibRefs ), bibRefs.size() );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/diff/DifferentialExpressionSearchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/diff/DifferentialExpressionSearchController.java
@@ -163,7 +163,7 @@ public class DifferentialExpressionSearchController {
             Collection<DifferentialExpressionAnalysis> analyses = diffAnalyses.get( id );
 
             for ( DifferentialExpressionAnalysis analysis : analyses ) {
-                differentialExpressionAnalysisService.thaw( analysis );
+                analysis = differentialExpressionAnalysisService.thaw( analysis );
 
                 Collection<ExperimentalFactor> factors = new HashSet<>();
                 for ( FactorAssociatedAnalysisResultSet fars : analysis.getResultSets() ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignControllerImpl.java
@@ -407,13 +407,12 @@ public class ArrayDesignControllerImpl implements ArrayDesignController {
             throw new IllegalArgumentException( "ID cannot be null" );
         }
 
-        ArrayDesign arrayDesign = arrayDesignService.load( id );
+        ArrayDesign arrayDesign = arrayDesignService.loadAndThawLite( id );
 
         if ( arrayDesign == null ) {
             throw new IllegalArgumentException( "No platform with id=" + id + " could be loaded" );
         }
 
-        arrayDesign = arrayDesignService.thawLite( arrayDesign );
         return arrayDesign;
     }
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignProbeMapperController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignProbeMapperController.java
@@ -43,8 +43,7 @@ public class ArrayDesignProbeMapperController {
      */
     public String run( Long id ) {
 
-        ArrayDesign arrayDesign = arrayDesignService.load( id );
-        arrayDesign = arrayDesignService.thaw( arrayDesign );
+        ArrayDesign arrayDesign = arrayDesignService.loadAndThaw( id );
 
         ArrayDesignProbeMapTaskCommand cmd = new ArrayDesignProbeMapTaskCommand();
         cmd.setArrayDesign( arrayDesign );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/bioAssay/BioAssayController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/bioAssay/BioAssayController.java
@@ -67,12 +67,11 @@ public class BioAssayController {
     private OutlierDetectionService outlierDetectionService;
 
     public Collection<BioAssayValueObject> getBioAssays( Long eeId ) {
-        ExpressionExperiment ee = eeService.load( eeId );
+        ExpressionExperiment ee = eeService.loadAndThawLite( eeId );
         if ( ee == null ) {
             throw new IllegalArgumentException( "Could not load experiment with ID=" + eeId );
         }
 
-        ee = this.eeService.thawLite( ee );
         Collection<BioAssayValueObject> result = new HashSet<>();
         Collection<OutlierDetails> outliers = null;
         try {
@@ -117,12 +116,10 @@ public class BioAssayController {
                     .addObject( "message", BioAssayController.identifierNotFound );
         }
 
-        BioAssay bioAssay = bioAssayService.load( id );
+        BioAssay bioAssay = bioAssayService.loadAndThaw( id );
         if ( bioAssay == null ) {
             throw new EntityNotFoundException( id + " not found" );
         }
-
-        bioAssayService.thaw( bioAssay );
 
         request.setAttribute( "id", id );
         return new ModelAndView( "bioAssay.detail" )
@@ -143,11 +140,10 @@ public class BioAssayController {
             String[] idList = StringUtils.split( sId, ',' );
             for ( String anIdList : idList ) {
                 Long id = Long.parseLong( anIdList );
-                BioAssay bioAssay = bioAssayService.load( id );
+                BioAssay bioAssay = bioAssayService.loadAndThaw( id );
                 if ( bioAssay == null ) {
                     throw new EntityNotFoundException( id + " not found" );
                 }
-                bioAssayService.thaw( bioAssay );
                 bioAssays.add( bioAssay );
             }
         }

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/biomaterial/BioMaterialController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/biomaterial/BioMaterialController.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2006 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -47,6 +47,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author keshav
@@ -84,8 +85,8 @@ public class BioMaterialController {
         ExperimentalFactor eFactor = factorVToAdd.getExperimentalFactor();
 
         for ( BioMaterial material : bms ) {
-            Collection<FactorValue> oldValues = material.getFactorValues();
-            Collection<FactorValue> updatedValues = new HashSet<>();
+            Set<FactorValue> oldValues = material.getFactorValues();
+            Set<FactorValue> updatedValues = new HashSet<>();
 
             // Make sure that the BM doesn't have a FactorValue for the Factor
             // we are adding already
@@ -187,7 +188,7 @@ public class BioMaterialController {
             return null;
 
         BioMaterial bioM = bioMaterialService.load( bm.getId() );
-        bioMaterialService.thaw( bioM );
+        bioM = bioMaterialService.thaw( bioM );
         Collection<FactorValueValueObject> results = new HashSet<>();
         Collection<FactorValue> factorValues = bioM.getFactorValues();
 
@@ -233,7 +234,7 @@ public class BioMaterialController {
         if ( bioMaterial == null ) {
             throw new EntityNotFoundException( id + " not found" );
         }
-        bioMaterialService.thaw( bioMaterial );
+        bioMaterial = bioMaterialService.thaw( bioMaterial );
 
         request.setAttribute( "id", id ); // / ??
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/designElement/CompositeSequenceController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/designElement/CompositeSequenceController.java
@@ -139,7 +139,7 @@ public class CompositeSequenceController extends BaseController {
         CompositeSequence cs = compositeSequenceService.load( csd.getId() );
 
         // unnecessary see https://github.com/PavlidisLab/Gemma/issues/176
-   //     compositeSequenceService.thaw( Collections.singletonList( cs ) );
+        //     compositeSequenceService.thaw( Collections.singletonList( cs ) );
 
         log.debug( "Finished processing AJAX call: getGeneMappingSummary" );
         return compositeSequenceService.getGeneMappingSummary( cs.getBiologicalCharacteristic(),
@@ -185,12 +185,10 @@ public class CompositeSequenceController extends BaseController {
     @RequestMapping(value = "/show")
     public ModelAndView show( HttpServletRequest request, HttpServletResponse response ) {
         Long id = Long.parseLong( request.getParameter( "id" ) );
-        CompositeSequence cs = compositeSequenceService.load( id );
+        CompositeSequence cs = compositeSequenceService.loadAndThaw( id );
         if ( cs == null ) {
             addMessage( request, "object.notfound", new Object[] { "composite sequence " + id } );
         }
-
-        compositeSequenceService.thaw( Collections.singletonList( cs ) );
 
         ModelAndView mav = new ModelAndView( "compositeSequence.detail" );
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/AnnotationController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/AnnotationController.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2009 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -39,6 +39,7 @@ import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Controller for methods involving annotation of experiments (and potentially other things); delegates to
@@ -76,11 +77,10 @@ public class AnnotationController {
     }
 
     public void createBiomaterialTag( Characteristic vc, Long id ) {
-        BioMaterial bm = bioMaterialService.load( id );
+        BioMaterial bm = bioMaterialService.loadAndThaw( id );
         if ( bm == null ) {
             throw new IllegalArgumentException( "No such BioMaterial with id=" + id );
         }
-        bioMaterialService.thaw( bm );
         ontologyService.saveBioMaterialStatement( vc, bm );
     }
 
@@ -91,11 +91,10 @@ public class AnnotationController {
      * @param id of the expression experiment
      */
     public void createExperimentTag( Characteristic vc, Long id ) {
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
         if ( ee == null ) {
             throw new IllegalArgumentException( "No such experiment with id=" + id );
         }
-        ee = expressionExperimentService.thawLite( ee );
         ontologyService.addExpressionExperimentStatement( vc, ee );
         expressionExperimentService.update( ee );
     }
@@ -129,25 +128,22 @@ public class AnnotationController {
     }
 
     public void removeBiomaterialTag( Characteristic vc, Long id ) {
-        BioMaterial bm = bioMaterialService.load( id );
+        BioMaterial bm = bioMaterialService.loadAndThaw( id );
         if ( bm == null ) {
             throw new IllegalArgumentException( "No such BioMaterial with id=" + id );
         }
-        bioMaterialService.thaw( bm );
         ontologyService.removeBioMaterialStatement( vc.getId(), bm );
     }
 
     public void removeExperimentTag( Collection<Long> characterIds, Long eeId ) {
 
-        ExpressionExperiment ee = expressionExperimentService.load( eeId );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( eeId );
 
         if ( ee == null ) {
             return;
         }
 
-        ee = expressionExperimentService.thawLite( ee );
-
-        Collection<Characteristic> current = ee.getCharacteristics();
+        Set<Characteristic> current = ee.getCharacteristics();
 
         Collection<Characteristic> found = new HashSet<>();
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExperimentalDesignControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExperimentalDesignControllerImpl.java
@@ -94,8 +94,7 @@ public class ExperimentalDesignControllerImpl extends BaseController implements 
 
     @Override
     public void createDesignFromFile( Long eeid, String filePath ) {
-        ExpressionExperiment ee = expressionExperimentService.load( eeid );
-        ee = expressionExperimentService.thaw( ee );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThaw( eeid );
 
         if ( ee == null ) {
             throw new IllegalArgumentException( "Could not access experiment with id=" + eeid );
@@ -112,7 +111,7 @@ public class ExperimentalDesignControllerImpl extends BaseController implements 
             throw new IllegalArgumentException( "Cannot read from file:" + f );
         }
 
-        try (InputStream is = new FileInputStream( f )) {
+        try ( InputStream is = new FileInputStream( f ) ) {
             // removed dry run code, validation and object creation is done before any commits to DB
             // So if validation fails no rollback needed. However, this call is wrapped in a transaction
             // as a fail safe.
@@ -167,7 +166,7 @@ public class ExperimentalDesignControllerImpl extends BaseController implements 
                     "Experimental factor with ID=" + e.getId() + " could not be accessed for editing" );
         }
 
-        Collection<Characteristic> chars = new HashSet<>();
+        Set<Characteristic> chars = new HashSet<>();
         for ( FactorValue fv : ef.getFactorValues() ) {
             //noinspection LoopStatementThatDoesntLoop // No, but its an effective way of doing this
             for ( Characteristic c : fv.getCharacteristics() ) {
@@ -202,9 +201,9 @@ public class ExperimentalDesignControllerImpl extends BaseController implements 
         if ( fv == null ) {
             throw new EntityNotFoundException( "No such factor value with id=" + e.getId() );
         }
-        
+
         if ( StringUtils.isBlank( c.getCategory() ) ) {
-            throw new IllegalArgumentException("The category cannot be blank for " + c);
+            throw new IllegalArgumentException( "The category cannot be blank for " + c );
         }
 
         if ( fv.getCharacteristics() == null ) {
@@ -280,8 +279,7 @@ public class ExperimentalDesignControllerImpl extends BaseController implements 
     public Collection<BioMaterialValueObject> getBioMaterials( EntityDelegator e ) {
         if ( e == null || e.getId() == null )
             return null;
-        ExpressionExperiment ee = expressionExperimentService.load( e.getId() );
-        ee = expressionExperimentService.thawLite( ee );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( e.getId() );
         Collection<BioMaterialValueObject> result = new HashSet<>();
         for ( BioAssay assay : ee.getBioAssays() ) {
             BioMaterial sample = assay.getSampleUsed();

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionDataFileUploadController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionDataFileUploadController.java
@@ -153,8 +153,7 @@ public class ExpressionDataFileUploadController {
 
             Long arrayDesignId = arrayDesignIds.iterator().next();
 
-            ArrayDesign design = arrayDesignService.load( arrayDesignId );
-            design = arrayDesignService.thaw( design );
+            ArrayDesign design = arrayDesignService.loadAndThaw( arrayDesignId );
 
             // check that the probes can be matched up...
             int numRowsMatchingArrayDesign = 0;
@@ -222,7 +221,7 @@ public class ExpressionDataFileUploadController {
         public TaskResult execute() {
             File file = ExpressionDataFileUploadController.this.getFile( taskCommand );
 
-            try (InputStream stream = FileTools.getInputStreamFromPlainOrCompressedFile( file.getAbsolutePath() )) {
+            try ( InputStream stream = FileTools.getInputStreamFromPlainOrCompressedFile( file.getAbsolutePath() ) ) {
 
                 this.populateCommandObject( taskCommand );
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentFormController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentFormController.java
@@ -171,12 +171,10 @@ public class ExpressionExperimentFormController extends BaseFormController {
         BaseFormController.log.debug( id );
         ExpressionExperimentEditValueObject obj;
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
         if ( ee == null ) {
             throw new IllegalArgumentException( "Could not load experiment with id=" + id );
         }
-
-        ee = expressionExperimentService.thawLite( ee );
 
         List<QuantitationTypeValueObject> qts = new ArrayList<>(
                 quantitationTypeService.loadValueObjects( expressionExperimentService.getQuantitationTypes( ee ) ) );
@@ -219,13 +217,11 @@ public class ExpressionExperimentFormController extends BaseFormController {
             BindException errors ) {
 
         ExpressionExperimentEditValueObject eeCommand = ( ExpressionExperimentEditValueObject ) command;
-        ExpressionExperiment expressionExperiment = expressionExperimentService.load( eeCommand.getId() );
+        ExpressionExperiment expressionExperiment = expressionExperimentService.loadAndThawLite( eeCommand.getId() );
 
         if ( expressionExperiment == null ) {
             throw new IllegalArgumentException( "Could not load experiment" );
         }
-
-        expressionExperiment = expressionExperimentService.thawLite( expressionExperiment );
 
         /*
          * Much more complicated

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentQCController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentQCController.java
@@ -146,13 +146,12 @@ public class ExpressionExperimentQCController extends BaseController {
             return null;
         }
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( id );
         if ( ee == null ) {
             log.warn( "Could not load experiment with id " + id );
             return null;
         }
 
-        ee = expressionExperimentService.thawLite( ee );
         Collection<BioAssay> bioAssays = new HashSet<>();
         for ( BioAssay assay : ee.getBioAssays() ) {
             if ( assay.getIsOutlier() ) {
@@ -299,13 +298,12 @@ public class ExpressionExperimentQCController extends BaseController {
             return;
         }
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLiter( id );
         if ( ee == null ) {
             log.warn( "Could not load experiment with id " + id );
             return;
         }
 
-        ee = expressionExperimentService.thawLiter( ee );
         DoubleMatrix<BioAssay, BioAssay> omatrix = ( reg != null && reg ) ? sampleCoexpressionAnalysisService.loadTryRegressedThenFull( ee )
                 : sampleCoexpressionAnalysisService.loadFullMatrix( ee );
         if ( omatrix == null ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/genome/gene/GeneController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/genome/gene/GeneController.java
@@ -39,6 +39,7 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.model.genome.gene.GeneProductValueObject;
 import ubic.gemma.model.genome.gene.GeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneValueObject;
+import ubic.gemma.model.genome.gene.TransientGeneSetValueObject;
 import ubic.gemma.model.genome.gene.phenotype.EvidenceFilter;
 import ubic.gemma.model.genome.gene.phenotype.valueObject.CharacteristicValueObject;
 import ubic.gemma.model.genome.gene.phenotype.valueObject.EvidenceValueObject;
@@ -241,7 +242,7 @@ public class GeneController extends BaseController {
         }
         if ( geneSetIds != null ) {
             for ( Long id : geneSetIds ) {
-                genes.addAll( geneSetService.getGenesInGroup( new GeneSetValueObject( id ) ) );
+                genes.addAll( geneSetService.getGenesInGroup( new TransientGeneSetValueObject( id ) ) );
             }
         }
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/genome/gene/GeneSetController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/genome/gene/GeneSetController.java
@@ -33,6 +33,7 @@ import ubic.gemma.model.genome.TaxonValueObject;
 import ubic.gemma.model.genome.gene.DatabaseBackedGeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneValueObject;
+import ubic.gemma.model.genome.gene.TransientGeneSetValueObject;
 import ubic.gemma.web.persistence.SessionListManager;
 
 import javax.servlet.http.HttpServletRequest;
@@ -176,7 +177,7 @@ public class GeneSetController {
      * @param geneId gene id
      * @return collection of geneSetValueObject
      */
-    public Collection<GeneSetValueObject> findGeneSetsByGene( Long geneId ) {
+    public Collection<DatabaseBackedGeneSetValueObject> findGeneSetsByGene( Long geneId ) {
 
         return geneSetService.findGeneSetsByGene( geneId );
     }
@@ -186,7 +187,7 @@ public class GeneSetController {
      * @param taxonId taxon id
      * @return collection of GeneSetValueObject
      */
-    public Collection<GeneSetValueObject> findGeneSetsByName( String query, Long taxonId ) {
+    public Collection<DatabaseBackedGeneSetValueObject> findGeneSetsByName( String query, Long taxonId ) {
         return geneSetService.findGeneSetsByName( query, taxonId );
     }
 
@@ -202,7 +203,7 @@ public class GeneSetController {
             throw new IllegalArgumentException( "Must be a persistent gene group" );
 
         // FIXME inefficient way to implement the limit
-        Collection<GeneValueObject> genesInGroup = geneSetService.getGenesInGroup( new GeneSetValueObject( groupId ) );
+        Collection<GeneValueObject> genesInGroup = geneSetService.getGenesInGroup( new TransientGeneSetValueObject( groupId ) );
 
         if ( limit != null && limit > 0 && limit < genesInGroup.size() ) {
             return CollectionUtils.select( genesInGroup, new Predicate<GeneValueObject>() {
@@ -226,7 +227,7 @@ public class GeneSetController {
     public Collection<Long> getGeneIdsInGroup( Long groupId ) {
         if ( groupId == null || groupId < 0 )
             throw new IllegalArgumentException( "Must be a persistent gene group" );
-        return geneSetService.getGeneIdsInGroup( new GeneSetValueObject( groupId ) );
+        return geneSetService.getGeneIdsInGroup( new TransientGeneSetValueObject( groupId ) );
     }
 
     /**

--- a/gemma-web/src/main/java/ubic/gemma/web/services/AbstractGemmaEndpoint.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/AbstractGemmaEndpoint.java
@@ -340,7 +340,7 @@ public abstract class AbstractGemmaEndpoint extends AbstractDomPayloadEndpoint {
             return null;
 
         // OLDTODO: only load file if it is not out of date
-        try (InputStream is = new FileInputStream( path + fileName )) {
+        try ( InputStream is = new FileInputStream( path + fileName ) ) {
             return this.readReport( is );
         }
     }
@@ -364,8 +364,12 @@ public abstract class AbstractGemmaEndpoint extends AbstractDomPayloadEndpoint {
             File file = new File( path, fullFileName );
 
             if ( !file.exists() ) {
-                new File( path ).mkdirs(); // in case of the subdirs doesn't exisit.
-                try (FileOutputStream out = new FileOutputStream( path + fullFileName )) {
+                // in case of the subdirs doesn't exisit.
+                if ( !new File( path ).mkdirs() ) {
+                    log.error( "Could not create directories structure for " + file );
+                    return;
+                }
+                try ( FileOutputStream out = new FileOutputStream( path + fullFileName ) ) {
                     OutputFormat format = new OutputFormat( document );
                     format.setIndenting( true );
                     // to generate a file output use fileoutputstream
@@ -384,7 +388,7 @@ public abstract class AbstractGemmaEndpoint extends AbstractDomPayloadEndpoint {
                         + ", already exists.  A new report was not created." );
 
         } catch ( IOException e ) {
-            e.printStackTrace();
+            log.error( "Failed to generate a report to " + filename + ".", e );
         }
 
     }

--- a/gemma-web/src/main/java/ubic/gemma/web/services/DEDVfromEEIDGeneIDEndpoint.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/DEDVfromEEIDGeneIDEndpoint.java
@@ -80,10 +80,7 @@ public class DEDVfromEEIDGeneIDEndpoint extends AbstractGemmaEndpoint {
             eeIDLong.add( Long.parseLong( id ) );
 
         // Need to get and thawRawAndProcessed the experiments.
-        Collection<ExpressionExperiment> eeObjs = expressionExperimentService.load( eeIDLong );
-        for ( ExpressionExperiment ee : eeObjs ) {
-            ee = expressionExperimentService.thawLite( ee );
-        }
+        Collection<ExpressionExperiment> eeObjs = expressionExperimentService.loadAndThawLite( eeIDLong );
 
         // get gene id's from request
         Collection<String> geneIdResult = this.getArrayValues( requestElement, "gene_ids" );

--- a/gemma-web/src/main/java/ubic/gemma/web/services/ExperimentAnnotationEndpoint.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/ExperimentAnnotationEndpoint.java
@@ -1,8 +1,8 @@
 /*
  * The Gemma project
- * 
+ *
  * Copyright (c) 2008 University of British Columbia
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,7 +35,7 @@ import java.util.Collection;
  * category often just an ontology URI and the term is the URI of the annotation. The category is left blank for terms
  * that are not from ontologies (free text). The evidence code represents how the annotation came to be.
  * (http://www.geneontology.org/GO.evidence.shtml)
- * 
+ *
  * @author klc, gavin
  *
  */
@@ -60,7 +60,7 @@ public class ExperimentAnnotationEndpoint extends AbstractGemmaEndpoint {
 
     /**
      * Reads the given <code>requestElement</code>, and sends a the response back.
-     * 
+     *
      * @param requestElement the contents of the SOAP message as DOM elements
      * @param document a DOM document to be used for constructing <code>Node</code>s
      * @return the response element
@@ -86,13 +86,12 @@ public class ExperimentAnnotationEndpoint extends AbstractGemmaEndpoint {
         for ( String eeString : eeResult ) {
 
             eeId = Long.parseLong( eeString );
-            ExpressionExperiment ee = expressionExperimentService.load( eeId );
+            ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( eeId );
 
             if ( ee == null ) {
                 String msg = "No expression experiment with id, " + eeId + ", can be found.";
                 return buildBadResponse( document, msg );
             }
-            ee = expressionExperimentService.thawLite( ee );
             Collection<Characteristic> characterCol = ee.getCharacteristics();
 
             for ( Characteristic character : characterCol ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/services/ExperimentDEDVEndpoint.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/ExperimentDEDVEndpoint.java
@@ -108,8 +108,7 @@ public class ExperimentDEDVEndpoint extends AbstractGemmaEndpoint {
         }
 
         // Build the matrix
-        ExpressionExperiment ee = expressionExperimentService.load( Long.parseLong( eeid ) );
-        ee = expressionExperimentService.thawLite( ee );
+        ExpressionExperiment ee = expressionExperimentService.loadAndThawLite( Long.parseLong( eeid ) );
 
         ExpressionDataDoubleMatrix dmatrix = expressionDataMatrixService.getProcessedExpressionDataMatrix( ee );
 

--- a/gemma-web/src/main/java/ubic/gemma/web/services/rest/DatasetsWebService.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/services/rest/DatasetsWebService.java
@@ -50,9 +50,7 @@ import ubic.gemma.persistence.util.Filters;
 import ubic.gemma.web.services.rest.util.*;
 import ubic.gemma.web.services.rest.util.args.*;
 
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -219,7 +217,7 @@ public class DatasetsWebService {
             @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(ref = "ResponseDataObjectListDifferentialExpressionAnalysisValueObject"))),
             @ApiResponse(responseCode = "404", description = "The dataset does not exist.",
                     content = @Content(schema = @Schema(implementation = ResponseErrorObject.class))) })
-    public ResponseDataObject<List<DifferentialExpressionAnalysisValueObject>> getDatasetDifferentialExpressionAnalyses( // Params:
+    public ResponseDataObject<Set<DifferentialExpressionAnalysisValueObject>> getDatasetDifferentialExpressionAnalyses( // Params:
             @PathParam("dataset") DatasetArg<Object> datasetArg, // Required
             @QueryParam("offset") @DefaultValue("0") OffsetArg offset, // Optional, default 0
             @QueryParam("limit") @DefaultValue("20") LimitArg limit // Optional, default 20
@@ -524,11 +522,11 @@ public class DatasetsWebService {
                 .build();
     }
 
-    private List<DifferentialExpressionAnalysisValueObject> getDiffExVos( Long eeId, int offset, int limit ) {
-        Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> map = differentialExpressionAnalysisService
+    private Set<DifferentialExpressionAnalysisValueObject> getDiffExVos( Long eeId, int offset, int limit ) {
+        Map<ExpressionExperimentDetailsValueObject, Set<DifferentialExpressionAnalysisValueObject>> map = differentialExpressionAnalysisService
                 .getAnalysesByExperiment( Collections.singleton( eeId ), offset, limit );
         if ( map == null || map.size() < 1 ) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
         return map.get( map.keySet().iterator().next() );
     }

--- a/gemma-web/src/test/java/ubic/gemma/web/util/upload/FileUploadUtilTest.java
+++ b/gemma-web/src/test/java/ubic/gemma/web/util/upload/FileUploadUtilTest.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class FileUploadUtilTest {
 
@@ -51,7 +52,7 @@ public class FileUploadUtilTest {
         assert ( copiedFile.exists() );
         assertEquals( expectedSize, copiedFile.length() );
 
-        copiedFile.delete();
+        assertTrue( copiedFile.delete() );
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -435,6 +435,11 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
These changes made me reconsider #159. If we make thaw() part of BaseDao and BaseService, there's no reason we could not add its persist() counterpart in the interface.

We could also consider a subclass of BaseDao and BaseService such as BaseLazyService and BaseLazyDao that would add thaw/persist interfaces. However, almost all of our models uses thaw/persist mechanisms.

Important changes:

 - thaw() in BaseService is deprecated, use loadAndThaw() instead as it skips reloading altogether
 - thaw() in BaseService expect that you use the return value since it implies an entity reload
 - thaw() in BaseDao is expected to work in-place just like Hibernate.initialize()
 - thaw() for a collection in BaseDao can be implemented with a database query as it can clear() and addAll() to the input collection

## Hierarchy of loading data

How does that fit in existing code? 

We want fast `load` and for that, we mark most relationships as lazy. When we need those, we have to invoke thaw.

 1. load and thaw later: most inefficient, deprecated
 2. loadAndThaw: generic and a little more efficient than 1
 3. loadWithWhatEverRelationshipYouAreInterestedIn: the best, but require a implementation-specific details

## Few side changes while we're at it

 - countAll should return a `long`
 - thaw() should consume a List<T> so that it can preserve the order of its input
 - load() should return a `List<T>` (we lose useful information by casting Hibernate's List<?> to a Collection<T>)
 - type specialization for some of our entities: unique collections should be using a Set<T>, ordered ones a List<T>, etc. This was brought up when tweaking thaw() because we used to assign a List<T> where a Set<T> would usually be expected (that was allowed because of polymorphism with Collection<T>)