### PR TITLE
Revamp VO conversion for search

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/core/apps/ExpressionExperimentManipulatingCLI.java
+++ b/gemma-cli/src/main/java/ubic/gemma/core/apps/ExpressionExperimentManipulatingCLI.java
@@ -322,7 +322,8 @@ public abstract class ExpressionExperimentManipulatingCLI extends AbstractCLICon
         }
 
         Collection<SearchResult<ExpressionExperiment>> eeSearchResults = searchService
-                .search( SearchSettings.expressionExperimentSearch( query ), ExpressionExperiment.class );
+                .search( SearchSettings.expressionExperimentSearch( query ) )
+                .getByResultObjectType( ExpressionExperiment.class );
 
         // Filter out all the ee that are not of correct taxon
         for ( SearchResult<ExpressionExperiment> sr : eeSearchResults ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/annotation/reference/BibliographicReferenceServiceImpl.java
@@ -237,9 +237,8 @@ public class BibliographicReferenceServiceImpl
     public List<BibliographicReferenceValueObject> search( SearchSettingsValueObject settings ) throws SearchException {
         SearchSettings ss = SearchSettings.bibliographicReferenceSearch( settings.getQuery() );
 
-        //noinspection unchecked
-        List<SearchResult<BibliographicReference>> resultEntities = searchService
-                .search( ss, BibliographicReference.class );
+        List<SearchResult<BibliographicReference>> resultEntities = searchService.search( ss )
+                .getByResultObjectType( BibliographicReference.class );
 
         List<BibliographicReferenceValueObject> results = new ArrayList<>();
 
@@ -277,7 +276,8 @@ public class BibliographicReferenceServiceImpl
     @Transactional(readOnly = true)
     public List<BibliographicReferenceValueObject> search( String query ) throws SearchException {
         List<SearchResult<BibliographicReference>> resultEntities = searchService
-                .search( SearchSettings.bibliographicReferenceSearch( query ), BibliographicReference.class );
+                .search( SearchSettings.bibliographicReferenceSearch( query ) )
+                .getByResultObjectType( BibliographicReference.class );
         List<BibliographicReferenceValueObject> results = new ArrayList<>();
         for ( SearchResult<BibliographicReference> sr : resultEntities ) {
             BibliographicReference entity = sr.getResultObject();

--- a/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssociationManagerServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssociationManagerServiceImpl.java
@@ -425,7 +425,7 @@ public class PhenotypeAssociationManagerServiceImpl implements PhenotypeAssociat
             taxon = this.taxonService.load( taxonId );
         }
         SearchSettings settings = SearchSettings.geneSearch( query, taxon );
-        List<SearchResult<Gene>> geneSearchResults = this.searchService.search( settings, Gene.class );
+        List<SearchResult<Gene>> geneSearchResults = this.searchService.search( settings ).getByResultObjectType( Gene.class );
 
         Collection<Gene> genes = new HashSet<>();
         if ( geneSearchResults == null || geneSearchResults.isEmpty() ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/service/ExpressionExperimentSearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/expression/experiment/service/ExpressionExperimentSearchServiceImpl.java
@@ -28,7 +28,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.core.search.*;
 import ubic.gemma.model.analysis.expression.ExpressionExperimentSet;
-import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.common.search.SearchSettings;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.expression.experiment.ExpressionExperimentSetValueObject;
@@ -85,7 +84,7 @@ public class ExpressionExperimentSearchServiceImpl implements ExpressionExperime
     public Collection<ExpressionExperimentValueObject> searchExpressionExperiments( String query ) throws SearchException {
 
         SearchSettings settings = SearchSettings.expressionExperimentSearch( query );
-        List<SearchResult<ExpressionExperiment>> experimentSearchResults = searchService.search( settings, ExpressionExperiment.class );
+        List<SearchResult<ExpressionExperiment>> experimentSearchResults = searchService.search( settings ).getByResultObjectType( ExpressionExperiment.class );
 
         if ( experimentSearchResults == null || experimentSearchResults.isEmpty() ) {
             ExpressionExperimentSearchServiceImpl.log.info( "No experiments for search: " + query );
@@ -269,13 +268,15 @@ public class ExpressionExperimentSearchServiceImpl implements ExpressionExperime
                 return eeIds;
 
             // Initial list
-            List<SearchResult<ExpressionExperiment>> results = searchService.search( SearchSettings.expressionExperimentSearch( query, taxon ),
-                            false /* no fill */, false /*
-                             * speed
-                             * search,
-                             * irrelevant
-                             */ )
-                    .get( ExpressionExperiment.class );
+            SearchSettings settings = SearchSettings.expressionExperimentSearch( query, taxon );
+            /* no fill */
+            /*
+             * speed
+             * search,
+             * irrelevant
+             */
+            List<SearchResult<ExpressionExperiment>> results = searchService.search( settings.withFillResults( false ).withMode( SearchSettings.SearchMode.NORMAL ) )
+                    .getByResultObjectType( ExpressionExperiment.class );
             for ( SearchResult<ExpressionExperiment> result : results ) {
                 eeIds.add( result.getResultId() );
             }
@@ -288,7 +289,7 @@ public class ExpressionExperimentSearchServiceImpl implements ExpressionExperime
 
     private List<SearchResultDisplayObject> getExpressionExperimentResults( SearchService.SearchResultMap results ) {
         // get all expressionExperiment results and convert result object into a value object
-        List<SearchResult<ExpressionExperiment>> srEEs = results.get( ExpressionExperiment.class );
+        List<SearchResult<ExpressionExperiment>> srEEs = results.getByResultObjectType( ExpressionExperiment.class );
 
         List<Long> eeIds = new ArrayList<>();
         for ( SearchResult<ExpressionExperiment> sr : srEEs ) {
@@ -308,7 +309,7 @@ public class ExpressionExperimentSearchServiceImpl implements ExpressionExperime
         List<SearchResultDisplayObject> experimentSets = new ArrayList<>();
 
         List<Long> eeSetIds = new ArrayList<>();
-        for ( SearchResult<ExpressionExperimentSet> sr : results.get( ExpressionExperimentSet.class ) ) {
+        for ( SearchResult<ExpressionExperimentSet> sr : results.getByResultObjectType( ExpressionExperimentSet.class ) ) {
             eeSetIds.add( sr.getResultId() );
         }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneSearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneSearchServiceImpl.java
@@ -31,7 +31,6 @@ import ubic.basecode.ontology.search.OntologySearchException;
 import ubic.gemma.core.genome.gene.*;
 import ubic.gemma.core.ontology.providers.GeneOntologyService;
 import ubic.gemma.core.search.*;
-import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.common.search.SearchSettings;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
@@ -173,7 +172,7 @@ public class GeneSearchServiceImpl implements GeneSearchService {
 
         GeneSearchServiceImpl.log.debug( "getting results from searchService for " + query );
 
-        SearchService.SearchResultMap results = searchService.speedSearch( settings );
+        SearchService.SearchResultMap results = searchService.search( settings.withMode( SearchSettings.SearchMode.FAST ) );
 
         List<SearchResult<GeneSet>> geneSetSearchResults = new ArrayList<>();
         List<SearchResult<Gene>> geneSearchResults = new ArrayList<>();
@@ -181,14 +180,14 @@ public class GeneSearchServiceImpl implements GeneSearchService {
         boolean exactGeneSymbolMatch = false;
         if ( !results.isEmpty() ) {
             if ( settings.hasResultType( GeneSet.class ) ) {
-                geneSetSearchResults.addAll( results.get( GeneSet.class ) );
+                geneSetSearchResults.addAll( results.getByResultObjectType( GeneSet.class ) );
             }
             if ( settings.hasResultType( Gene.class ) ) {
-                geneSearchResults.addAll( results.get( Gene.class ) );
+                geneSearchResults.addAll( results.getByResultObjectType( Gene.class ) );
             }
 
             // Check to see if we have an exact match, if so, return earlier abstaining from doing other searches
-            for ( SearchResult<Gene> geneResult : results.get( Gene.class ) ) {
+            for ( SearchResult<Gene> geneResult : results.getByResultObjectType( Gene.class ) ) {
                 Gene g = geneResult.getResultObject();
                 // aliases too?
                 if ( g != null && g.getOfficialSymbol() != null && g.getOfficialSymbol().startsWith( query.trim() ) ) {
@@ -369,7 +368,7 @@ public class GeneSearchServiceImpl implements GeneSearchService {
 
             // searching one gene at a time is a bit slow; we do a quick search for symbols.
             SearchSettings settings = SearchSettings.geneSearch( line, taxon );
-            List<SearchResult<Gene>> geneSearchResults = searchService.speedSearch( settings ).get( Gene.class );
+            List<SearchResult<Gene>> geneSearchResults = searchService.search( settings.withMode( SearchSettings.SearchMode.FAST ) ).getByResultObjectType( Gene.class );
 
             if ( geneSearchResults.isEmpty() ) {
                 // an empty set is an indication of no results.

--- a/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/genome/gene/service/GeneServiceImpl.java
@@ -353,7 +353,7 @@ public class GeneServiceImpl extends AbstractFilteringVoEnabledService<Gene, Gen
             SearchService.SearchResultMap r;
             try {
                 r = searchService.search( s );
-                List<SearchResult<ExpressionExperiment>> hits = r.get( ExpressionExperiment.class );
+                List<SearchResult<ExpressionExperiment>> hits = r.getByResultObjectType( ExpressionExperiment.class );
                 gvo.setAssociatedExperimentCount( hits.size() );
             } catch ( SearchException e ) {
                 log.error( "Failed to retrieve the associated EE count for " + s + ".", e );
@@ -495,7 +495,7 @@ public class GeneServiceImpl extends AbstractFilteringVoEnabledService<Gene, Gen
             taxon = this.taxonService.load( taxonId );
         }
         SearchSettings settings = SearchSettings.geneSearch( query, taxon );
-        List<SearchResult<Gene>> geneSearchResults = this.searchService.search( settings, Gene.class );
+        List<SearchResult<Gene>> geneSearchResults = this.searchService.search( settings ).getByResultObjectType( Gene.class );
 
         Collection<Gene> genes = new HashSet<>();
         if ( geneSearchResults == null || geneSearchResults.isEmpty() ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyServiceImpl.java
@@ -849,9 +849,9 @@ public class OntologyServiceImpl implements OntologyService, InitializingBean {
                 .taxon( taxon )
                 .resultType( Gene.class )
                 .build();
-        SearchService.SearchResultMap geneResults = this.searchService.search( ss, true, false );
+        SearchService.SearchResultMap geneResults = this.searchService.search( ss.withFillResults( true ).withMode( SearchSettings.SearchMode.NORMAL ) );
 
-        for ( SearchResult<Gene> sr : geneResults.get( Gene.class ) ) {
+        for ( SearchResult<Gene> sr : geneResults.getByResultObjectType( Gene.class ) ) {
             if ( sr.getResultObject() == null ) {
                 log.warn( String.format( "There is no gene with ID=%d (in response to search for %s) - index out of date?",
                         sr.getResultId(), queryString ) );

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchResult.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchResult.java
@@ -66,7 +66,7 @@ public class SearchResult<T extends Identifiable> implements Comparable<SearchRe
      * Shorthand for {@link #from(Class, Identifiable, double, String, Object)} if you don't need to set the score and
      * highlighted text.
      */
-    public static <T extends Identifiable> SearchResult<T> from( Class<? extends Identifiable> resultType, T entity, double score, String source ) {
+    public static <T extends Identifiable> SearchResult<T> from( Class<? extends Identifiable> resultType, T entity, double score, Object source ) {
         if ( entity.getId() == null ) {
             throw new IllegalArgumentException( "Entity ID cannot be null." );
         }
@@ -82,7 +82,7 @@ public class SearchResult<T extends Identifiable> implements Comparable<SearchRe
         return new SearchResult<>( resultType, entityId, score, highlightedText, source );
     }
 
-    public static <T extends Identifiable> SearchResult<T> from( Class<? extends Identifiable> resultType, long entityId, double score, String source ) {
+    public static <T extends Identifiable> SearchResult<T> from( Class<? extends Identifiable> resultType, long entityId, double score, Object source ) {
         return new SearchResult<>( resultType, entityId, score, null, source );
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchService.java
@@ -14,14 +14,10 @@
  */
 package ubic.gemma.core.search;
 
-import org.springframework.util.MultiValueMap;
 import ubic.gemma.model.IdentifiableValueObject;
 import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.common.search.SearchSettings;
-import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -31,14 +27,20 @@ import java.util.Set;
  */
 public interface SearchService {
 
-    interface SearchResultMap extends MultiValueMap<Class<? extends Identifiable>, SearchResult<?>> {
+    interface SearchResultMap {
+
+        List<SearchResult<?>> getByResultType( Class<? extends Identifiable> searchResultType );
 
         /**
-         * Specialization of {@link #get(Object)} that correctly types the output.
-         *
+         * Obtain results where the result object is of a given type, regardless of the result type.
          */
-        @Nonnull
-        <T extends Identifiable> List<SearchResult<T>> get( Class<T> searchResultType );
+        <T extends Identifiable> List<SearchResult<T>> getByResultObjectType( Class<T> clazz );
+
+        boolean isEmpty();
+
+        Set<Class<? extends Identifiable>> getResultTypes();
+
+        List<SearchResult<?>> toList();
     }
 
     /**
@@ -60,62 +62,8 @@ public interface SearchService {
     SearchResultMap search( SearchSettings settings ) throws SearchException;
 
     /**
-     * This speedSearch method is probably unnecessary right now considering we only call from geneSearch, just putting
-     * it in
-     * because we probably want to use something like this on the general search page
-     *
-     * @param  settings settings
-     * @return Map of Class to SearchResults. The results are already filtered for security considerations.
-     * @see             #search(SearchSettings)
-     * @deprecated use {@link #search(SearchSettings)} with {@link SearchSettings#setFillResults(boolean)} and
-     * {@link SearchSettings#setMode(SearchSettings.SearchMode)} instead
-     */
-    @Deprecated
-    SearchResultMap speedSearch( SearchSettings settings ) throws SearchException;
-
-    /**
-     * Makes an attempt at determining of the query term is a valid URI from an Ontology in Gemma or a Gene URI (a GENE
-     * URI is in the form: http://purl.org/commons/record/ncbi_gene/20655 (but is not a valid ontology loaded in gemma)
-     * ). If so then searches for objects that have been tagged with that term or any of that terms children. If not a
-     * URI then proceeds with the generalSearch.
-     *
-     * @param  fillObjects    If false, the entities will not be filled in inside the SearchSettings; instead, they will
-     *                        be
-     *                        nullified (for security purposes). You can then use the id and Class stored in the
-     *                        SearchSettings to load the
-     *                        entities at your leisure. If true, the entities are loaded in the usual secure fashion.
-     *                        Setting this to
-     *                        false can be an optimization if all you need is the id.
-     * @param  webSpeedSearch If true, the search will be faster but the results may not be as broad as when this is
-     *                        false.
-     *                        Set to true for frontend combo boxes like the gene combo
-     * @param  settings       settings
-     * @return Map of Class to SearchResults. The results are already filtered for security
-     *                        considerations.
-     * @deprecated use {@link #search(SearchSettings)} with {@link SearchSettings#setFillResults(boolean)} and
-     * {@link SearchSettings#setMode(SearchSettings.SearchMode)} set to {@link ubic.gemma.model.common.search.SearchSettings.SearchMode#FAST}
-     * instead
-     */
-    @Deprecated
-    SearchResultMap search( SearchSettings settings, boolean fillObjects, boolean webSpeedSearch ) throws SearchException;
-
-    /**
-     * Search results for a specific class.
-     *
-     * Note: the {@link SearchSettings#getResultTypes()} is entirely ignored, and a narrow search in {@link T} is
-     * performed.
-     *
-     * @param  <T> result type to search for
-     *
-     * @param  settings    search settings
-     * @param  resultClass the result type class from which the type is inferred
-     * @return only search results from one class
-     */
-    <T extends Identifiable> List<SearchResult<T>> search( SearchSettings settings, Class<T> resultClass ) throws SearchException;
-
-    /**
      * Returns a set of supported result types.
-     *
+     * <p>
      * This is mainly used to perform a search for everything via {@link SearchSettings#getResultTypes()}.
      */
     Set<Class<? extends Identifiable>> getSupportedResultTypes();
@@ -132,4 +80,20 @@ public interface SearchService {
      * @throws IllegalArgumentException if the passed search result is not supported for VO conversion
      */
     <T extends Identifiable, U extends IdentifiableValueObject<T>> SearchResult<U> loadValueObject( SearchResult<T> searchResult ) throws IllegalArgumentException;
+
+    /**
+     * Convert a collection of {@link SearchResult} to their VO flavours.
+     * <p>
+     * Note that since the results might contain a mixture of different result types, the implementation can take
+     * advantage of grouping result by types in order to use {@link ubic.gemma.persistence.service.BaseVoEnabledService#loadValueObjects(Collection)},
+     * which is generally more efficient than loading each result individually.
+     *
+     * @see ubic.gemma.persistence.service.BaseVoEnabledService#loadValueObjects(Collection)
+     *
+     * @param searchResults a collection of {@link SearchResult}, which may contain a mixture of different {@link Identifiable}
+     *                      result objects
+     * @throws IllegalArgumentException if any of the supplied search results cannot be converted to VO
+     * @return converted search results as per {@link #loadValueObject(SearchResult)}
+     */
+    List<SearchResult<? extends IdentifiableValueObject<?>>> loadValueObjects( Collection<SearchResult<?>> searchResults ) throws IllegalArgumentException;
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
@@ -855,8 +855,7 @@ public class SearchServiceImpl implements SearchService, InitializingBean {
         // we would have to first deal with the separate queries, and then apply the logic.
         Collection<SearchResult<ExpressionExperiment>> allResults = new SearchResultSet<>();
 
-        SearchServiceImpl.log
-                .info( "Starting characteristic search: '" + settings.getQuery() );
+        SearchServiceImpl.log.info( "Starting characteristic search for: " + settings );
         for ( String rawTerm : subparts ) {
             String trimmed = StringUtils.strip( rawTerm );
             if ( StringUtils.isBlank( trimmed ) ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchSource.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchSource.java
@@ -37,7 +37,7 @@ public interface SearchSource {
      * @deprecated use {@link #searchBioSequence(SearchSettings)} (SearchSettings)} instead
      */
     @Deprecated
-    Collection<SearchResult<? extends Identifiable>> searchBioSequenceAndGene( SearchSettings settings,
+    Collection<SearchResult<?>> searchBioSequenceAndGene( SearchSettings settings,
             @Nullable Collection<SearchResult<Gene>> previousGeneSearchResults ) throws SearchException;
 
     @SuppressWarnings("unused")
@@ -52,7 +52,7 @@ public interface SearchSource {
      * @deprecated use {@link #searchCompositeSequence(SearchSettings)} instead
      */
     @Deprecated
-    Collection<SearchResult<? extends Identifiable>> searchCompositeSequenceAndGene( SearchSettings settings ) throws SearchException;
+    Collection<SearchResult<?>> searchCompositeSequenceAndGene( SearchSettings settings ) throws SearchException;
 
     Collection<SearchResult<ExpressionExperiment>> searchExpressionExperiment( SearchSettings settings ) throws SearchException;
 

--- a/gemma-core/src/main/java/ubic/gemma/core/search/source/CompassSearchSource.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/source/CompassSearchSource.java
@@ -124,7 +124,7 @@ public class CompassSearchSource implements SearchSource {
      *                                  for the genes are added to the final results.
      */
     @Override
-    public Collection<SearchResult<? extends Identifiable>> searchBioSequenceAndGene( SearchSettings settings,
+    public Collection<SearchResult<?>> searchBioSequenceAndGene( SearchSettings settings,
             @Nullable Collection<SearchResult<Gene>> previousGeneSearchResults ) throws SearchException {
         Collection<SearchResult<?>> results = new HashSet<>( this.compassSearch( compassBiosequence, settings, BioSequence.class ) );
 
@@ -161,7 +161,7 @@ public class CompassSearchSource implements SearchSource {
     }
 
     @Override
-    public Collection<SearchResult<? extends Identifiable>> searchCompositeSequenceAndGene( final SearchSettings settings ) throws SearchException {
+    public Collection<SearchResult<?>> searchCompositeSequenceAndGene( final SearchSettings settings ) throws SearchException {
         return new ArrayList<>( this.searchBioSequence( settings ) );
     }
 
@@ -289,7 +289,7 @@ public class CompassSearchSource implements SearchSource {
             }
 
             //noinspection unchecked
-            results.add( SearchResult.from( clazz, ( T ) resultObject, score * CompassSearchSource.COMPASS_HIT_SCORE_PENALTY_FACTOR, ht, source ) );
+            results.add( SearchResult.from( clazz, ( ( T ) resultObject ).getId(), score * CompassSearchSource.COMPASS_HIT_SCORE_PENALTY_FACTOR, ht, source ) );
         }
 
         watch.stop();

--- a/gemma-core/src/main/java/ubic/gemma/core/search/source/CompositeSearchSource.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/source/CompositeSearchSource.java
@@ -58,9 +58,9 @@ public class CompositeSearchSource implements SearchSource {
     }
 
     @Override
-    public Collection<SearchResult<? extends Identifiable>> searchBioSequenceAndGene( SearchSettings settings, @Nullable Collection<SearchResult<Gene>> previousGeneSearchResults ) throws SearchException {
+    public Collection<SearchResult<?>> searchBioSequenceAndGene( SearchSettings settings, @Nullable Collection<SearchResult<Gene>> previousGeneSearchResults ) throws SearchException {
         // FIXME: use searchWith
-        Set<SearchResult<? extends Identifiable>> results = new HashSet<>();
+        Set<SearchResult<?>> results = new HashSet<>();
         for ( SearchSource source : sources ) {
             results.addAll( source.searchBioSequenceAndGene( settings, previousGeneSearchResults ) );
         }
@@ -73,9 +73,9 @@ public class CompositeSearchSource implements SearchSource {
     }
 
     @Override
-    public Collection<SearchResult<? extends Identifiable>> searchCompositeSequenceAndGene( SearchSettings settings ) throws SearchException {
+    public Collection<SearchResult<?>> searchCompositeSequenceAndGene( SearchSettings settings ) throws SearchException {
         // FIXME: use searchWith
-        Set<SearchResult<? extends Identifiable>> results = new HashSet<>();
+        Set<SearchResult<?>> results = new HashSet<>();
         for ( SearchSource source : sources ) {
             results.addAll( source.searchCompositeSequenceAndGene( settings ) );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/search/source/DatabaseSearchSource.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/source/DatabaseSearchSource.java
@@ -151,7 +151,7 @@ public class DatabaseSearchSource implements SearchSource {
     }
 
     @Override
-    public Collection<SearchResult<? extends Identifiable>> searchBioSequenceAndGene( SearchSettings settings, @Nullable Collection<SearchResult<Gene>> previousGeneSearchResults ) {
+    public Collection<SearchResult<?>> searchBioSequenceAndGene( SearchSettings settings, @Nullable Collection<SearchResult<Gene>> previousGeneSearchResults ) {
         return new HashSet<>( this.searchBioSequence( settings ) );
     }
 
@@ -164,7 +164,7 @@ public class DatabaseSearchSource implements SearchSource {
      * Search the DB for composite sequences and the genes that are matched to them.
      */
     @Override
-    public Collection<SearchResult<? extends Identifiable>> searchCompositeSequenceAndGene( SearchSettings settings ) {
+    public Collection<SearchResult<?>> searchCompositeSequenceAndGene( SearchSettings settings ) {
         Set<SearchResult<Gene>> geneSet = new SearchResultSet<>();
         Collection<SearchResult<CompositeSequence>> matchedCs = this.searchCompositeSequenceAndPopulateGenes( settings, geneSet );
         Collection<SearchResult<?>> combinedResults = new HashSet<>();

--- a/gemma-core/src/main/java/ubic/gemma/model/common/description/BibliographicReferenceValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/description/BibliographicReferenceValueObject.java
@@ -72,7 +72,9 @@ public class BibliographicReferenceValueObject extends IdentifiableValueObject<B
         super( ref );
         this.abstractText = ref.getAbstractText();
         this.authorList = ref.getAuthorList();
-        this.pubAccession = ref.getPubAccession().getAccession();
+        if ( ref.getPubAccession() != null ) {
+            this.pubAccession = ref.getPubAccession().getAccession();
+        }
         this.publicationDate = ref.getPublicationDate();
         this.publisher = ref.getPublisher();
         this.pages = ref.getPages();

--- a/gemma-core/src/main/java/ubic/gemma/model/common/description/CitationValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/description/CitationValueObject.java
@@ -91,7 +91,7 @@ public class CitationValueObject implements Comparable<CitationValueObject>, Ser
                 .append( ": " ).append( pages );
 
         this.setCitation( buf.toString() );
-        if ( Hibernate.isInitialized(ref.getPubAccession())) {
+        if ( ref.getPubAccession() != null ) {
             this.setPubmedAccession( ref.getPubAccession().getAccession() );
             this.setPubmedURL( CitationValueObject.PUBMED_URL_ROOT + ref.getPubAccession().getAccession() );
         }

--- a/gemma-core/src/main/java/ubic/gemma/model/common/search/SearchSettings.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/search/SearchSettings.java
@@ -32,6 +32,7 @@ import ubic.gemma.model.genome.Taxon;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Configuration options for searching.
@@ -41,7 +42,6 @@ import java.util.Set;
 @Data
 @Builder
 @With
-@ToString(of = { "query", "taxon", "platformConstraint", "resultTypes" })
 public class SearchSettings implements Serializable {
 
     public static final char
@@ -271,5 +271,18 @@ public class SearchSettings implements Serializable {
      */
     public boolean hasResultType( Class<?> cls ) {
         return resultTypes.contains( cls );
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder( "'" + query + "'" );
+        s.append( " in " ).append( resultTypes.stream().map( Class::getSimpleName ).sorted().collect( Collectors.joining( ", " ) ) );
+        if ( platformConstraint != null ) {
+            s.append( " " ).append( "[" ).append( platformConstraint ).append( "]" );
+        }
+        if ( taxon != null ) {
+            s.append( " " ).append( "[" ).append( taxon ).append( "]" );
+        }
+        return s.toString();
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
@@ -300,7 +300,7 @@ public class ExpressionExperimentServiceImpl
 
         assert searchResultsMap != null;
 
-        List<SearchResult<ExpressionExperiment>> searchResults = searchResultsMap.get( ExpressionExperiment.class );
+        List<SearchResult<ExpressionExperiment>> searchResults = searchResultsMap.getByResultObjectType( ExpressionExperiment.class );
 
         Collection<Long> ids = new ArrayList<>( searchResults.size() );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/GenericValueObjectConverter.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/GenericValueObjectConverter.java
@@ -1,0 +1,67 @@
+package ubic.gemma.persistence.util;
+
+import org.springframework.core.convert.ConverterNotFoundException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+import org.springframework.core.convert.converter.Converter;
+import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.common.Identifiable;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Generic value object converter.
+ * <p>
+ * Performs conversion from entity to value object using a provided {@link Converter}.
+ *
+ * @author poirigui
+ */
+public class GenericValueObjectConverter<O extends Identifiable, VO extends IdentifiableValueObject<?>> implements ConditionalGenericConverter {
+
+    private final Converter<O, VO> converter;
+    private final Set<ConvertiblePair> convertibleTypes;
+    private final TypeDescriptor sourceType;
+    private final TypeDescriptor sourceCollectionType;
+    private final TypeDescriptor targetType;
+    private final TypeDescriptor targetListType;
+
+    public GenericValueObjectConverter( Converter<O, VO> converter, Class<O> fromClazz, Class<? super VO> clazz ) {
+        this.converter = converter;
+        Set<ConvertiblePair> convertibleTypes = new HashSet<>();
+        convertibleTypes.add( new ConvertiblePair( Identifiable.class, IdentifiableValueObject.class ) );
+        convertibleTypes.add( new ConvertiblePair( Collection.class, Collection.class ) );
+        this.convertibleTypes = Collections.unmodifiableSet( convertibleTypes );
+        this.sourceType = TypeDescriptor.valueOf( fromClazz );
+        this.sourceCollectionType = TypeDescriptor.collection( Collection.class, this.sourceType );
+        this.targetType = TypeDescriptor.valueOf( clazz );
+        this.targetListType = TypeDescriptor.collection( List.class, this.targetType );
+    }
+
+    @Override
+    public Set<ConvertiblePair> getConvertibleTypes() {
+        return convertibleTypes;
+    }
+
+    @Override
+    public boolean matches( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.sourceType ) && this.targetType.isAssignableTo( targetType ) ||
+                sourceType.isAssignableTo( this.sourceCollectionType ) && this.targetListType.isAssignableTo( targetType );
+    }
+
+    @Override
+    public Object convert( @Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        if ( sourceType.isAssignableTo( this.sourceType ) && this.targetType.isAssignableTo( targetType ) ) {
+            //noinspection unchecked
+            return source != null ? converter.convert( ( O ) source ) : null;
+        }
+        if ( sourceType.isAssignableTo( sourceCollectionType ) && this.targetListType.isAssignableTo( targetType ) ) {
+            //noinspection unchecked
+            return source != null ? ( ( Collection<O> ) source ).stream()
+                    .map( converter::convert )
+                    .collect( Collectors.toList() ) : null;
+        }
+        throw new ConverterNotFoundException( sourceType, targetType );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/ServiceBasedEntityConverter.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/ServiceBasedEntityConverter.java
@@ -1,0 +1,74 @@
+package ubic.gemma.persistence.util;
+
+import org.springframework.core.convert.ConverterNotFoundException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+import ubic.gemma.model.common.Identifiable;
+import ubic.gemma.persistence.service.BaseReadOnlyService;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * Performs conversion by identifier and collection of identifier for a {@link BaseReadOnlyService}.
+ * <p>
+ * The converter recognize two cases: {@link Long} -> {@link O} and {@link Collection} of {@link Long} to {@link List}
+ * of {@link O} using {@link BaseReadOnlyService#load(Long)} and {@link BaseReadOnlyService#load(Collection)} respectively.
+ * <p>
+ * The conversion also works with supertypes of {@link O} up to {@link Identifiable}.
+ *
+ * @param <O> the type of entity this converter produces
+ * @see BaseReadOnlyService#load(Long)
+ * @see BaseReadOnlyService#load(Collection)
+ * @author poirigui
+ */
+public class ServiceBasedEntityConverter<O extends Identifiable> implements ConditionalGenericConverter {
+
+    private final BaseReadOnlyService<? extends O> service;
+    private final TypeDescriptor entityType;
+    private final TypeDescriptor entityListType;
+    private final TypeDescriptor entityIdType = TypeDescriptor.valueOf( Long.class );
+    private final TypeDescriptor entityIdCollectionType = TypeDescriptor.collection( Collection.class, entityIdType );
+    protected final Set<ConvertiblePair> convertibleTypes = new HashSet<>();
+
+    public ServiceBasedEntityConverter( BaseReadOnlyService<? extends O> service, Class<O> entityType ) {
+        this.service = service;
+        this.entityType = TypeDescriptor.valueOf( entityType );
+        this.entityListType = TypeDescriptor.collection( List.class, this.entityType );
+        this.convertibleTypes.add( new ConvertiblePair( Long.class, Identifiable.class ) );
+        this.convertibleTypes.add( new ConvertiblePair( Collection.class, Collection.class ) );
+    }
+
+
+    @Override
+    public boolean matches( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return entityFromId( sourceType, targetType ) || entityListFromIds( sourceType, targetType );
+    }
+
+    @Override
+    public Set<ConvertiblePair> getConvertibleTypes() {
+        return Collections.unmodifiableSet( convertibleTypes );
+    }
+
+    @Override
+    public Object convert( @Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        if ( entityFromId( sourceType, targetType ) ) {
+            return source != null ? service.load( ( Long ) source ) : null;
+        }
+
+        if ( entityListFromIds( sourceType, targetType ) ) {
+            //noinspection unchecked
+            return source != null ? service.load( ( Collection<Long> ) source ) : null;
+        }
+
+        throw new ConverterNotFoundException( sourceType, targetType );
+    }
+
+    private boolean entityFromId( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.entityIdType ) && this.entityType.isAssignableTo( targetType );
+    }
+
+    private boolean entityListFromIds( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.entityIdCollectionType ) && this.entityListType.isAssignableTo( targetType );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/ServiceBasedValueObjectConverter.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/ServiceBasedValueObjectConverter.java
@@ -1,0 +1,114 @@
+package ubic.gemma.persistence.util;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.common.Identifiable;
+import ubic.gemma.persistence.service.BaseVoEnabledService;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Perform conversion to value object by entity, ID and collections of entities and IDs and also to entity by ID and
+ * collection of IDs.
+ * <p>
+ * The converter recognize two cases: converting {@link O} -> {@link VO} and converting {@link Collection} of {@link O}
+ * to {@link List} of {@link VO} by calling respectively {@link BaseVoEnabledService#loadValueObject(Identifiable)} and
+ * {@link BaseVoEnabledService#loadValueObjects(Collection)}.
+ * <p>
+ * This implementation also work with supertypes of the designated {@link VO}  and subtypes of the {@link O}. For example,
+ * you can perform generic conversion to {@link IdentifiableValueObject} without having to mention the specific type of
+ * value object you ultimately want.
+ *
+ * @param <O>  the type of value object this converter consumes and also produces (as inherited from
+ *             {@link ServiceBasedEntityConverter}
+ * @param <VO> the type of value object this converter produces
+ * @see ServiceBasedEntityConverter
+ * @see BaseVoEnabledService#loadValueObject(Identifiable)
+ * @see BaseVoEnabledService#loadValueObjects(Collection)
+ * @see BaseVoEnabledService#loadValueObjectById(Long)
+ * @see BaseVoEnabledService#loadValueObjectsByIds(Collection)
+ * @author poirigui
+ */
+public class ServiceBasedValueObjectConverter<O extends Identifiable, VO extends IdentifiableValueObject<O>> extends ServiceBasedEntityConverter<O> implements ConditionalGenericConverter {
+
+    /**
+     * We need a service that can produce something can can be cast into a {@link VO}.
+     */
+    private final BaseVoEnabledService<O, ? extends VO> service;
+
+    /* enables very efficient type checks */
+    private final TypeDescriptor sourceType;
+    private final TypeDescriptor sourceIdType;
+    private final TypeDescriptor targetType;
+    private final TypeDescriptor sourceCollectionType;
+    private final TypeDescriptor sourceIdCollectionType;
+    private final TypeDescriptor targetListType;
+
+    /**
+     */
+    public ServiceBasedValueObjectConverter( BaseVoEnabledService<O, ? extends VO> service, Class<O> sourceType, Class<VO> targetType ) {
+        super( service, sourceType );
+        this.service = service;
+        this.convertibleTypes.add( new ConvertiblePair( Long.class, IdentifiableValueObject.class ) );
+        this.convertibleTypes.add( new ConvertiblePair( Identifiable.class, IdentifiableValueObject.class ) );
+        this.convertibleTypes.add( new ConvertiblePair( Collection.class, Collection.class ) );
+        this.sourceType = TypeDescriptor.valueOf( sourceType );
+        this.sourceIdType = TypeDescriptor.valueOf( Long.class );
+        this.targetType = TypeDescriptor.valueOf( targetType );
+        this.sourceCollectionType = TypeDescriptor.collection( Collection.class, this.sourceType );
+        this.sourceIdCollectionType = TypeDescriptor.collection( Collection.class, this.sourceIdType );
+        this.targetListType = TypeDescriptor.collection( List.class, this.targetType );
+    }
+
+    @Override
+    public boolean matches( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        // this is necessary because Collection and List types are too broad and will result in conflicts with
+        // converters for other VOs
+        return voFromEntity( sourceType, targetType ) || voListFromEntities( sourceType, targetType ) ||
+                voFromId( sourceType, targetType ) || voListFromIds( sourceType, targetType ) ||
+                super.matches( sourceType, targetType );
+    }
+
+    @Override
+    public Object convert( @Nullable Object object, TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        if ( voFromEntity( sourceType, targetType ) ) {
+            //noinspection unchecked
+            return object != null ? service.loadValueObject( ( O ) object ) : null;
+        }
+
+        if ( voListFromEntities( sourceType, targetType ) ) {
+            //noinspection unchecked
+            return object != null ? service.loadValueObjects( ( Collection<O> ) object ) : null;
+        }
+
+        if ( voFromId( sourceType, targetType ) ) {
+            return object != null ? service.loadValueObjectById( ( Long ) object ) : null;
+        }
+
+        if ( voListFromIds( sourceType, targetType ) ) {
+            //noinspection unchecked
+            return object != null ? service.loadValueObjectsByIds( ( Collection<Long> ) object ) : null;
+        }
+
+        return super.convert( object, sourceType, targetType );
+    }
+
+    private boolean voFromEntity( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.sourceType ) && this.targetType.isAssignableTo( targetType );
+    }
+
+    private boolean voListFromEntities( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.sourceCollectionType ) && this.targetListType.isAssignableTo( targetType );
+    }
+
+    private boolean voFromId( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.sourceIdType ) && this.targetType.isAssignableTo( targetType );
+    }
+
+    private boolean voListFromIds( TypeDescriptor sourceType, TypeDescriptor targetType ) {
+        return sourceType.isAssignableTo( this.sourceIdCollectionType ) && this.targetListType.isAssignableTo( targetType );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/ValueObjectConfig.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/ValueObjectConfig.java
@@ -1,0 +1,63 @@
+package ubic.gemma.persistence.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ConversionServiceFactoryBean;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import ubic.gemma.core.annotation.reference.BibliographicReferenceService;
+import ubic.gemma.core.genome.gene.service.GeneService;
+import ubic.gemma.core.genome.gene.service.GeneSetService;
+import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.analysis.expression.ExpressionExperimentSet;
+import ubic.gemma.model.association.phenotype.PhenotypeAssociation;
+import ubic.gemma.model.common.description.BibliographicReference;
+import ubic.gemma.model.common.description.BibliographicReferenceValueObject;
+import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
+import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
+import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.designElement.CompositeSequenceValueObject;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.model.expression.experiment.ExpressionExperimentSetValueObject;
+import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
+import ubic.gemma.model.genome.Gene;
+import ubic.gemma.model.genome.biosequence.BioSequence;
+import ubic.gemma.model.genome.gene.GeneSet;
+import ubic.gemma.model.genome.gene.GeneSetValueObject;
+import ubic.gemma.model.genome.gene.GeneValueObject;
+import ubic.gemma.model.genome.gene.phenotype.valueObject.CharacteristicValueObject;
+import ubic.gemma.model.genome.gene.phenotype.valueObject.PhenotypeValueObject;
+import ubic.gemma.model.genome.sequenceAnalysis.BioSequenceValueObject;
+import ubic.gemma.persistence.service.association.phenotype.service.PhenotypeAssociationService;
+import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
+import ubic.gemma.persistence.service.expression.designElement.CompositeSequenceService;
+import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentSetService;
+import ubic.gemma.persistence.service.genome.biosequence.BioSequenceService;
+
+@Configuration
+public class ValueObjectConfig {
+
+    @Bean
+    public ConversionService valueObjectConversionService(
+            ArrayDesignService arrayDesignService,
+            BibliographicReferenceService bibliographicReferenceService,
+            BioSequenceService bioSequenceService,
+            CompositeSequenceService compositeSequenceService,
+            ExpressionExperimentService expressionExperimentService,
+            ExpressionExperimentSetService experimentSetService,
+            GeneService geneService,
+            GeneSetService geneSetService ) {
+        GenericConversionService conversionService = new GenericConversionService();
+        conversionService.addConverter( new GenericValueObjectConverter<>( o -> o, CharacteristicValueObject.class, CharacteristicValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( arrayDesignService, ArrayDesign.class, ArrayDesignValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( bibliographicReferenceService, BibliographicReference.class, BibliographicReferenceValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( bioSequenceService, BioSequence.class, BioSequenceValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( compositeSequenceService, CompositeSequence.class, CompositeSequenceValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( expressionExperimentService, ExpressionExperiment.class, ExpressionExperimentValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( experimentSetService, ExpressionExperimentSet.class, ExpressionExperimentSetValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( geneService, Gene.class, GeneValueObject.class ) );
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( geneSetService, GeneSet.class, GeneSetValueObject.class ) );
+        return conversionService;
+    }
+}

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceTest.java
@@ -9,14 +9,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import ubic.basecode.ontology.search.OntologySearchException;
-import ubic.gemma.core.analysis.report.ExpressionExperimentReportService;
 import ubic.gemma.core.ontology.OntologyService;
 import ubic.gemma.model.common.search.SearchSettings;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.common.description.CharacteristicService;
-import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 import ubic.gemma.persistence.util.TestComponent;
 

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceTestContextConfiguration.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceTestContextConfiguration.java
@@ -3,6 +3,7 @@ package ubic.gemma.core.search;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import ubic.gemma.core.annotation.reference.BibliographicReferenceService;
 import ubic.gemma.core.association.phenotype.PhenotypeAssociationManagerService;
 import ubic.gemma.core.genome.gene.service.GeneSearchService;
@@ -18,6 +19,7 @@ import ubic.gemma.persistence.service.expression.experiment.ExpressionExperiment
 import ubic.gemma.persistence.service.genome.biosequence.BioSequenceService;
 import ubic.gemma.persistence.service.genome.gene.GeneProductService;
 import ubic.gemma.persistence.service.genome.taxon.TaxonService;
+import ubic.gemma.persistence.util.ValueObjectConfig;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.when;
 /**
  * Base class for mocking beans for
  */
+@Import(ValueObjectConfig.class)
 class SearchServiceTestContextConfiguration {
 
     @Bean

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceVoConversionTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceVoConversionTest.java
@@ -7,11 +7,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import ubic.gemma.core.annotation.reference.BibliographicReferenceService;
 import ubic.gemma.core.genome.gene.service.GeneSetService;
+import ubic.gemma.model.IdentifiableValueObject;
 import ubic.gemma.model.analysis.expression.diff.ContrastResult;
 import ubic.gemma.model.association.phenotype.PhenotypeAssociation;
+import ubic.gemma.model.common.Identifiable;
+import ubic.gemma.model.common.description.BibliographicReference;
+import ubic.gemma.model.common.description.BibliographicReferenceValueObject;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
+import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.designElement.CompositeSequenceValueObject;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
 import ubic.gemma.model.genome.Taxon;
@@ -19,12 +26,27 @@ import ubic.gemma.model.genome.gene.DatabaseBackedGeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneSet;
 import ubic.gemma.model.genome.gene.phenotype.valueObject.CharacteristicValueObject;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
+import ubic.gemma.persistence.service.expression.designElement.CompositeSequenceService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.persistence.util.ServiceBasedValueObjectConverter;
 import ubic.gemma.persistence.util.TestComponent;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+/**
+ * Test conversion to VOs for search results.
+ * <p>
+ * The conversion is typically performed with a {@link ServiceBasedValueObjectConverter} which in turn
+ * relies upon specific {@link ubic.gemma.persistence.service.BaseVoEnabledService} logic for performing the VO
+ * conversion. Thus, we want to make sure that the service will produce the expected VOs.
+ *
+ * @author poirigui
+ */
 @ContextConfiguration
 public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTests {
 
@@ -40,13 +62,19 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
     @Autowired
     private ArrayDesignService arrayDesignService;
     @Autowired
+    private CompositeSequenceService compositeSequenceService;
+    @Autowired
     private ExpressionExperimentService expressionExperimentService;
     @Autowired
     private GeneSetService geneSetService;
+    @Autowired
+    private BibliographicReferenceService bibliographicReferenceService;
 
     /* fixtures */
     private ArrayDesign ad;
+    private CompositeSequence cs;
     private ExpressionExperiment ee;
+    private ExpressionExperimentValueObject eevo;
     private GeneSet gs;
     private CharacteristicValueObject phenotypeAssociation;
 
@@ -55,12 +83,23 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
         ad = new ArrayDesign();
         ad.setId( 11L );
         ad.setPrimaryTaxon( Taxon.Factory.newInstance( "Homo sapiens", "Human", 9606, false ) );
+        cs = new CompositeSequence();
+        cs.setId( 10L );
+        cs.setArrayDesign( ad );
         ee = new ExpressionExperiment();
         ee.setId( 12L );
+        eevo = new ExpressionExperimentValueObject();
+        eevo.setId( 12L );
         gs = new GeneSet();
         gs.setId( 13L );
         phenotypeAssociation = new CharacteristicValueObject( 14L );
         when( arrayDesignService.loadValueObject( any( ArrayDesign.class ) ) ).thenAnswer( a -> new ArrayDesignValueObject( a.getArgument( 0, ArrayDesign.class ) ) );
+        //noinspection unchecked
+        when( arrayDesignService.loadValueObjects( anyCollection() ) ).thenAnswer( a -> ( ( Collection<ArrayDesign> ) a.getArgument( 0, Collection.class ) )
+                .stream()
+                .map( ArrayDesignValueObject::new )
+                .collect( Collectors.toList() ) );
+        when( compositeSequenceService.loadValueObject( any( CompositeSequence.class ) ) ).thenAnswer( a -> new CompositeSequenceValueObject( a.getArgument( 0, CompositeSequence.class ) ) );
         when( expressionExperimentService.loadValueObject( any( ExpressionExperiment.class ) ) ).thenAnswer( a -> new ExpressionExperimentValueObject( a.getArgument( 0, ExpressionExperiment.class ) ) );
         when( geneSetService.loadValueObject( any( GeneSet.class ) ) ).thenAnswer( a -> {
             GeneSet geneSet = a.getArgument( 0, GeneSet.class );
@@ -68,16 +107,45 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
         } );
     }
 
-
     @After
     public void tearDown() {
-        reset( arrayDesignService, expressionExperimentService, geneSetService );
+        reset( arrayDesignService, expressionExperimentService, geneSetService, compositeSequenceService, bibliographicReferenceService );
     }
 
     @Test
     public void testConvertArrayDesign() {
         searchService.loadValueObject( SearchResult.from( ArrayDesign.class, ad, 1.0, "test object" ) );
         verify( arrayDesignService ).loadValueObject( ad );
+    }
+
+    @Test
+    public void testConvertArrayDesignCollection() {
+        searchService.loadValueObjects( Collections.singleton( SearchResult.from( ArrayDesign.class, ad, 1.0, "test object" ) ) );
+        verify( arrayDesignService ).loadValueObjects( Collections.singletonList( ad ) );
+    }
+
+    @Test
+    public void testConvertBibliographicReference() {
+        BibliographicReference br = new BibliographicReference();
+        when( bibliographicReferenceService.loadValueObject( any( BibliographicReference.class ) ) )
+                .thenAnswer( arg -> new BibliographicReferenceValueObject( arg.getArgument( 0, BibliographicReference.class ) ) );
+        br.setId( 13L );
+        searchService.loadValueObject( SearchResult.from( BibliographicReference.class, br, 1.0, "test object" ) );
+        verify( bibliographicReferenceService ).loadValueObject( br );
+    }
+
+    @Test
+    public void testConvertCompositeSequence() {
+        searchService.loadValueObject( SearchResult.from( CompositeSequence.class, cs, 1.0, "test object" ) );
+        verify( compositeSequenceService ).loadValueObject( cs );
+    }
+
+    @Test
+    public void testConvertCompositeSequenceCollection() {
+        when( compositeSequenceService.loadValueObjects( any() ) ).thenReturn( Collections.singletonList( new CompositeSequenceValueObject( cs ) ) );
+        // this is a special case because of how it's implemented
+        searchService.loadValueObjects( Collections.singleton( SearchResult.from( CompositeSequence.class, cs, 1.0, "test object" ) ) );
+        verify( compositeSequenceService ).loadValueObjects( Collections.singletonList( cs ) );
     }
 
     @Test
@@ -88,10 +156,13 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
 
     @Test
     public void testConvertPhenotypeAssociation() {
-        // this is a complicated one because
+        // this is a complicated one because the result type does not match the entity
         assertThat( searchService.loadValueObject( SearchResult.from( PhenotypeAssociation.class, phenotypeAssociation, 1.0, "test object" ) ) )
                 .extracting( "resultObject" )
                 .isSameAs( phenotypeAssociation );
+        assertThat( searchService.loadValueObjects( Collections.singleton( SearchResult.from( PhenotypeAssociation.class, phenotypeAssociation, 1.0, "test object" ) ) ) )
+                .extracting( "resultObject" )
+                .containsExactly( phenotypeAssociation );
     }
 
     @Test
@@ -101,6 +172,21 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
         verify( geneSetService ).loadValueObject( gs );
     }
 
+    @Test
+    public void testConvertUninitializedResult() {
+        DatabaseBackedGeneSetValueObject gsvo = new DatabaseBackedGeneSetValueObject( gs, new Taxon(), 1L );
+        when( geneSetService.loadValueObjectById( 13L ) ).thenReturn( gsvo );
+        SearchResult<IdentifiableValueObject<Identifiable>> sr = searchService.loadValueObject( SearchResult.from( GeneSet.class, 13L, 1.0, "test object" ) );
+        assertThat( sr )
+                .isNotNull()
+                .hasFieldOrPropertyWithValue( "resultType", GeneSet.class )
+                .hasFieldOrPropertyWithValue( "resultId", 13L )
+                .hasFieldOrPropertyWithValue( "resultObject", gsvo )
+                .hasFieldOrPropertyWithValue( "score", 1.0 )
+                .hasFieldOrPropertyWithValue( "highlightedText", null );
+        verify( geneSetService ).loadValueObjectById( 13L );
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testUnsupportedResultTypeRaisesIllegalArgumentException() {
         ContrastResult cr = new ContrastResult();
@@ -108,4 +194,14 @@ public class SearchServiceVoConversionTest extends AbstractJUnit4SpringContextTe
         searchService.loadValueObject( SearchResult.from( ContrastResult.class, cr, 1.0, "test object" ) );
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedResultTypeInCollectionRaisesIllegalArgumentException() {
+        searchService.loadValueObjects( Collections.singleton( SearchResult.from( ContrastResult.class, new ContrastResult(), 0.0f, "test object" ) ) );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConvertAlreadyConvertedCollection() {
+        searchService.loadValueObjects( Collections.singletonList(
+                SearchResult.from( ExpressionExperiment.class, eevo, 0.0f, "test value object" ) ) );
+    }
 }

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/GenericValueObjectConverterTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/GenericValueObjectConverterTest.java
@@ -1,0 +1,72 @@
+package ubic.gemma.persistence.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.convert.ConverterNotFoundException;
+import org.springframework.core.convert.support.ConfigurableConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
+import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericValueObjectConverterTest {
+
+    private final ConfigurableConversionService converter = new GenericConversionService();
+
+    @Before
+    public void setUp() {
+        converter.addConverter( new GenericValueObjectConverter<>( ExpressionExperimentValueObject::new, ExpressionExperiment.class, ExpressionExperimentValueObject.class ) );
+    }
+
+    @Test
+    public void test() {
+        Object converted = converter.convert( new ExpressionExperiment(), ExpressionExperimentValueObject.class );
+        assertThat( converted ).isInstanceOf( ExpressionExperimentValueObject.class );
+    }
+
+    @Test
+    public void testConvertToSuperClass() {
+        Object converted = converter.convert( new ExpressionExperiment(), IdentifiableValueObject.class );
+        assertThat( converted ).isInstanceOf( ExpressionExperimentValueObject.class );
+    }
+
+    @Test
+    public void testConvertFromSubClass() {
+        Object converted = converter.convert( new SpecificExpressionExperiment(), ExpressionExperimentValueObject.class );
+        assertThat( converted ).isInstanceOf( ExpressionExperimentValueObject.class );
+    }
+
+    private static class SpecificExpressionExperiment extends ExpressionExperiment {
+
+    }
+
+    @Test
+    public void testConvertCollection() {
+        Object converted = converter.convert( Collections.singleton( new ExpressionExperiment() ), List.class );
+        assertThat( converted ).isInstanceOf( List.class );
+    }
+
+    @Test
+    public void testConvertCollectionToListSuperType() {
+        Object converted = converter.convert( Collections.singleton( new ExpressionExperiment() ), Collection.class );
+        assertThat( converted ).isInstanceOf( List.class );
+    }
+
+    @Test(expected = ConverterNotFoundException.class)
+    public void testConvertUnsupportedType() {
+        converter.convert( new ArrayDesign(), ArrayDesignValueObject.class );
+    }
+
+    @Test
+    public void testConvertNull() {
+        assertThat( converter.convert( null, ExpressionExperimentValueObject.class ) ).isNull();
+    }
+}

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/ServiceBasedValueObjectConverterTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/ServiceBasedValueObjectConverterTest.java
@@ -1,0 +1,186 @@
+package ubic.gemma.persistence.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConverterNotFoundException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.support.ConfigurableConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import ubic.gemma.model.IdentifiableValueObject;
+import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
+import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
+import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.*;
+
+@ContextConfiguration
+public class ServiceBasedValueObjectConverterTest extends AbstractJUnit4SpringContextTests {
+
+    @Configuration
+    @TestComponent
+    public static class VoConverterTestContextConfiguration {
+        @Bean
+        public ExpressionExperimentService expressionExperimentService() {
+            return mock( ExpressionExperimentService.class );
+        }
+    }
+
+    @Autowired
+    private ExpressionExperimentService expressionExperimentService;
+
+    /* fixtures */
+    private ConfigurableConversionService conversionService;
+
+    private ExpressionExperiment ee;
+
+    @Before
+    public void setUp() {
+        ee = new ExpressionExperiment();
+        ee.setId( 1L );
+        conversionService = new GenericConversionService();
+        conversionService.addConverter( new ServiceBasedValueObjectConverter<>( expressionExperimentService, ExpressionExperiment.class, ExpressionExperimentValueObject.class ) );
+        when( expressionExperimentService.load( 1L ) ).thenReturn( ee );
+        //noinspection unchecked
+        when( expressionExperimentService.load( anyCollection() ) )
+                .thenAnswer( arg -> ( ( Collection<Long> ) arg.getArgument( 0, Collection.class ) ).stream().map( expressionExperimentService::load ).collect( Collectors.toList() ) );
+        when( expressionExperimentService.loadValueObject( any( ExpressionExperiment.class ) ) )
+                .thenAnswer( arg -> new ExpressionExperimentValueObject( arg.getArgument( 0, ExpressionExperiment.class ) ) );
+        when( expressionExperimentService.loadValueObjectById( 1L ) )
+                .thenAnswer( arg -> new ExpressionExperimentValueObject() );
+        //noinspection unchecked
+        when( expressionExperimentService.loadValueObjects( anyCollection() ) )
+                .thenAnswer( arg -> ( ( Collection<ExpressionExperiment> ) arg.getArgument( 0, Collection.class ) ).stream().map( expressionExperimentService::loadValueObject ).collect( Collectors.toList() ) );
+        //noinspection unchecked
+        when( expressionExperimentService.loadValueObjectsByIds( anyCollection() ) )
+                .thenAnswer( arg -> ( ( Collection<Long> ) arg.getArgument( 0, Collection.class ) ).stream().map( expressionExperimentService::loadValueObjectById ).collect( Collectors.toList() ) );
+        ;
+    }
+
+    @After
+    public void tearDown() {
+        reset( expressionExperimentService );
+    }
+
+    @Test
+    public void testConvertEntityFromId() {
+        Object converted = conversionService.convert( ee.getId(), ExpressionExperiment.class );
+        assertThat( converted ).isNotNull()
+                .isInstanceOf( ExpressionExperiment.class );
+        verify( expressionExperimentService ).load( ee.getId() );
+    }
+
+    @Test
+    public void testConvertEntitiesFromIds() {
+        Object converted = conversionService.convert( Collections.singleton( ee.getId() ), TypeDescriptor.collection( Collection.class, TypeDescriptor.valueOf( Long.class ) ), TypeDescriptor.collection( List.class, TypeDescriptor.valueOf( ExpressionExperiment.class ) ) );
+        assertThat( converted ).isNotNull()
+                .isInstanceOf( List.class );
+        verify( expressionExperimentService ).load( Collections.singleton( ee.getId() ) );
+    }
+
+    @Test
+    public void testConvertSingleEntity() {
+        Object converted = conversionService.convert( ee, ExpressionExperimentValueObject.class );
+        assertThat( converted )
+                .isNotNull()
+                .isInstanceOf( ExpressionExperimentValueObject.class );
+        verify( expressionExperimentService ).loadValueObject( ee );
+    }
+
+    @Test
+    public void testConvertSingleEntityById() {
+        Object converted = conversionService.convert( ee.getId(), ExpressionExperimentValueObject.class );
+        assertThat( converted )
+                .isNotNull()
+                .isInstanceOf( ExpressionExperimentValueObject.class );
+        verify( expressionExperimentService ).loadValueObjectById( ee.getId() );
+    }
+
+    @Test
+    public void testConvertSingleEntityToSuperType() {
+        Object converted = conversionService.convert( ee, IdentifiableValueObject.class );
+        assertThat( converted )
+                .isNotNull()
+                .isInstanceOf( ExpressionExperimentValueObject.class );
+        verify( expressionExperimentService ).loadValueObject( ee );
+    }
+
+    @Test
+    public void testConvertSingleEntityFromSubType() {
+        SpecificExpressionExperiment see = new SpecificExpressionExperiment();
+        Object converted = conversionService.convert( see, IdentifiableValueObject.class );
+        assertThat( converted )
+                .isNotNull()
+                .isInstanceOf( ExpressionExperimentValueObject.class );
+        verify( expressionExperimentService ).loadValueObject( see );
+    }
+
+    private static class SpecificExpressionExperiment extends ExpressionExperiment {
+    }
+
+    @Test
+    public void testConvertCollection() {
+        Collection<ExpressionExperiment> ees = Collections.singleton( ee );
+        Object converted = conversionService.convert( ees,
+                TypeDescriptor.collection( Collection.class, TypeDescriptor.valueOf( ExpressionExperiment.class ) ),
+                TypeDescriptor.collection( List.class, TypeDescriptor.valueOf( ExpressionExperimentValueObject.class ) ) );
+        assertThat( converted ).isInstanceOf( List.class );
+        verify( expressionExperimentService ).loadValueObjects( ees );
+    }
+
+    @Test
+    public void testConvertCollectionToListSuperType() {
+        Collection<ExpressionExperiment> ees = Collections.singleton( ee );
+        Object converted = conversionService.convert( ees, Collection.class );
+        assertThat( converted ).isInstanceOf( List.class );
+        verify( expressionExperimentService ).loadValueObjects( ees );
+    }
+
+    @Test
+    public void testConvertCollectionOfIds() {
+        Collection<Long> ees = Collections.singleton( ee.getId() );
+        Object converted = conversionService.convert( ees,
+                TypeDescriptor.collection( Collection.class, TypeDescriptor.valueOf( Long.class ) ),
+                TypeDescriptor.collection( List.class, TypeDescriptor.valueOf( ExpressionExperimentValueObject.class ) ) );
+        assertThat( converted ).isInstanceOf( List.class );
+        verify( expressionExperimentService ).loadValueObjectsByIds( ees );
+    }
+
+    @Test
+    public void testConvertCollectionToSuperType() {
+        Collection<ExpressionExperiment> ees = Collections.singleton( ee );
+        Object converted = conversionService.convert( ees,
+                TypeDescriptor.collection( Collection.class, TypeDescriptor.valueOf( ExpressionExperiment.class ) ),
+                TypeDescriptor.collection( List.class, TypeDescriptor.valueOf( IdentifiableValueObject.class ) ) );
+        assertThat( converted ).isInstanceOf( List.class );
+        verify( expressionExperimentService ).loadValueObjects( ees );
+    }
+
+    @Test
+    public void testConvertNullEntity() {
+        Object converted = conversionService.convert( null, ExpressionExperimentValueObject.class );
+        assertThat( converted ).isNull();
+        verifyNoInteractions( expressionExperimentService );
+    }
+
+    @Test(expected = ConverterNotFoundException.class)
+    public void testConvertUnknownType() {
+        conversionService.convert( new ArrayDesign(), TypeDescriptor.valueOf( ArrayDesign.class ), TypeDescriptor.valueOf( ArrayDesignValueObject.class ) );
+    }
+
+}

--- a/gemma-rest/src/main/java/ubic/gemma/rest/AnnotationsWebService.java
+++ b/gemma-rest/src/main/java/ubic/gemma/rest/AnnotationsWebService.java
@@ -297,7 +297,8 @@ public class AnnotationsWebService {
             SearchSettings settings = SearchSettings.builder()
                     .fillResults( false )
                     .build();
-            List<SearchResult<ExpressionExperiment>> eeResults = searchService.search( settings, ExpressionExperiment.class );
+            List<SearchResult<ExpressionExperiment>> eeResults = searchService.search( settings )
+                    .getByResultObjectType( ExpressionExperiment.class );
 
             // Working only with IDs
             for ( SearchResult<ExpressionExperiment> result : eeResults ) {

--- a/gemma-rest/src/test/java/ubic/gemma/rest/AnnotationsWebServiceTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/AnnotationsWebServiceTest.java
@@ -114,8 +114,11 @@ public class AnnotationsWebServiceTest extends AbstractJUnit4SpringContextTests 
     public void testSearchTaxonDatasets() throws SearchException {
         ExpressionExperiment ee = ExpressionExperiment.Factory.newInstance();
         ee.setId( 1L );
-        when( searchService.search( any( SearchSettings.class ), eq( ExpressionExperiment.class ) ) )
+        SearchService.SearchResultMap mockedSrMap = mock( SearchService.SearchResultMap.class );
+        when( mockedSrMap.getByResultObjectType( ExpressionExperiment.class ) )
                 .thenReturn( Collections.singletonList( SearchResult.from( ExpressionExperiment.class, ee, 1.0, "test object" ) ) );
+        when( searchService.search( any( SearchSettings.class ) ) )
+                .thenReturn( mockedSrMap );
         when( taxonService.getFilter( eq( "commonName" ), eq( Filter.Operator.eq ), any( String.class ) ) ).thenAnswer( a -> Filter.by( "t", "commonName", String.class, Filter.Operator.eq, a.getArgument( 2, String.class ), a.getArgument( 0 ) ) );
         when( taxonService.getFilter( eq( "scientificName" ), eq( Filter.Operator.eq ), any( String.class ) ) ).thenAnswer( a -> Filter.by( "t", "scientificName", String.class, Filter.Operator.eq, a.getArgument( 2, String.class ), a.getArgument( 0 ) ) );
         when( expressionExperimentService.getIdentifierPropertyName() ).thenReturn( "id" );
@@ -137,7 +140,7 @@ public class AnnotationsWebServiceTest extends AbstractJUnit4SpringContextTests 
                 .hasFieldOrPropertyWithValue( "offset", 0 )
                 .hasFieldOrPropertyWithValue( "limit", 20 )
                 .hasFieldOrPropertyWithValue( "totalElements", 10000L );
-        verify( searchService ).search( any( SearchSettings.class ), eq( ExpressionExperiment.class ) );
+        verify( searchService ).search( any( SearchSettings.class ) );
         verify( taxonService ).getFilter( "commonName", Filter.Operator.eq, "human" );
         verify( taxonService ).getFilter( "scientificName", Filter.Operator.eq, "human" );
         verify( expressionExperimentService ).getFilter( "id", Filter.Operator.in, Collections.singletonList( "1" ) );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/GeneralSearchControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/GeneralSearchControllerImpl.java
@@ -18,9 +18,8 @@
  */
 package ubic.gemma.web.controller;
 
-import gemma.gsec.util.SecurityUtil;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -31,39 +30,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
-import ubic.gemma.core.annotation.reference.BibliographicReferenceService;
-import ubic.gemma.core.genome.gene.service.GeneService;
-import ubic.gemma.core.genome.gene.service.GeneSetService;
 import ubic.gemma.core.search.SearchException;
 import ubic.gemma.core.search.SearchResult;
 import ubic.gemma.core.search.SearchService;
-import ubic.gemma.core.security.audit.AuditableUtil;
-import ubic.gemma.model.IdentifiableValueObject;
 import ubic.gemma.model.analysis.expression.ExpressionExperimentSet;
 import ubic.gemma.model.association.phenotype.PhenotypeAssociation;
 import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.common.description.BibliographicReference;
 import ubic.gemma.model.common.search.SearchSettings;
 import ubic.gemma.model.common.search.SearchSettingsValueObject;
-import ubic.gemma.model.expression.BlacklistedEntity;
-import ubic.gemma.model.expression.BlacklistedValueObject;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
-import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
-import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.gene.GeneSet;
-import ubic.gemma.model.genome.gene.phenotype.valueObject.CharacteristicValueObject;
-import ubic.gemma.model.genome.sequenceAnalysis.BioSequenceValueObject;
-import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
-import ubic.gemma.persistence.service.expression.designElement.CompositeSequenceService;
-import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
-import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentSetService;
 import ubic.gemma.persistence.service.genome.taxon.TaxonService;
-import ubic.gemma.persistence.util.EntityUtils;
 import ubic.gemma.web.propertyeditor.TaxonPropertyEditor;
 import ubic.gemma.web.remote.JsonReaderResponse;
 
@@ -71,7 +54,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Note: do not use parametrized collections as parameters for ajax methods in this class! Type information is lost
@@ -86,23 +68,7 @@ public class GeneralSearchControllerImpl extends BaseFormController implements G
     @Autowired
     private SearchService searchService;
     @Autowired
-    private ExpressionExperimentService expressionExperimentService;
-    @Autowired
-    private ArrayDesignService arrayDesignService;
-    @Autowired
-    private GeneService geneService;
-    @Autowired
-    private BibliographicReferenceService bibliographicReferenceService;
-    @Autowired
     private TaxonService taxonService;
-    @Autowired
-    private AuditableUtil auditableUtil;
-    @Autowired
-    private GeneSetService geneSetService;
-    @Autowired
-    private ExpressionExperimentSetService experimentSetService;
-    @Autowired
-    private CompositeSequenceService compositeSequenceService;
     @Autowired
     private ServletContext servletContext;
 
@@ -138,24 +104,22 @@ public class GeneralSearchControllerImpl extends BaseFormController implements G
         // FIXME: sort by the number of hits per class, so the smallest number of hits is at the top.
         fillVosTimer.start();
         List<SearchResultValueObject<?>> finalResults = new ArrayList<>();
-        if ( searchResults != null ) {
-            for ( Class<? extends Identifiable> clazz : searchResults.keySet() ) {
-                List<SearchResult<?>> results = searchResults.get( ( Object ) clazz );
+        for ( Class<? extends Identifiable> clazz : searchResults.getResultTypes() ) {
+            List<SearchResult<?>> results = searchResults.getByResultType( clazz );
 
-                if ( results.size() == 0 )
-                    continue;
+            if ( results.size() == 0 )
+                continue;
 
-                BaseFormController.log
+            BaseFormController.log.info( String.format( "Search for: %s; result: %d %ss",
+                    searchSettings, results.size(), clazz.getSimpleName() ) );
 
-                        .info( "Search for: " + searchSettings + "; result: " + results.size() + " " + clazz.getSimpleName()
-                                + "s" );
-
-                /*
-                 * Now put the valueObjects inside the SearchResults in score order.
-                 */
-                results = results.stream().sorted().collect( Collectors.toList() );
-                finalResults.addAll( this.fillValueObjects( clazz, results, searchSettings ) );
-            }
+            /*
+             * Now put the valueObjects inside the SearchResults in score order.
+             */
+            searchService.loadValueObjects( results ).stream()
+                    .sorted()
+                    .map( SearchResultValueObject::new )
+                    .forEachOrdered( finalResults::add );
         }
 
         fillVosTimer.stop();
@@ -291,119 +255,6 @@ public class GeneralSearchControllerImpl extends BaseFormController implements G
         this.populateTaxonReferenceData( mapping );
 
         return mapping;
-    }
-
-    /**
-     * Populate the search results with the value objects - we generally only have the entity class and ID (or, in some
-     * cases, possibly the entity)
-     */
-    @SuppressWarnings("unchecked")
-    private List<SearchResultValueObject<?>> fillValueObjects( Class<?> entityClass, List<SearchResult<?>> results, SearchSettings settings ) {
-        StopWatch timer = StopWatch.createStarted();
-        Collection<? extends IdentifiableValueObject<?>> vos;
-
-        Collection<Long> ids = new ArrayList<>();
-        for ( SearchResult<?> r : results ) {
-            ids.add( r.getResultId() );
-        }
-
-        if ( ExpressionExperiment.class.isAssignableFrom( entityClass ) ) {
-            vos = expressionExperimentService.loadValueObjectsByIds( ids );
-            if ( !SecurityUtil.isUserAdmin() ) {
-                auditableUtil.removeTroubledEes( ( Collection<ExpressionExperimentValueObject> ) vos );
-            }
-
-        } else if ( ArrayDesign.class.isAssignableFrom( entityClass ) ) {
-            vos = this.filterAD( arrayDesignService.loadValueObjectsByIds( ids ), settings );
-
-            if ( !SecurityUtil.isUserAdmin() ) {
-                auditableUtil.removeTroubledArrayDesigns( ( Collection<ArrayDesignValueObject> ) vos );
-            }
-        } else if ( CompositeSequence.class.isAssignableFrom( entityClass ) ) {
-            Collection<CompositeSequence> compositeSequences = results.stream()
-                    .map( SearchResult::getResultObject )
-                    .filter( Objects::nonNull )
-                    .map( o -> ( CompositeSequence ) o )
-                    .collect( Collectors.toSet() );
-            vos = compositeSequenceService.loadValueObjects( compositeSequences );
-        } else if ( BibliographicReference.class.isAssignableFrom( entityClass ) ) {
-            Collection<BibliographicReference> bss = bibliographicReferenceService
-                    .load( ids );
-            vos = bibliographicReferenceService.loadValueObjects( bss );
-        } else if ( Gene.class.isAssignableFrom( entityClass ) ) {
-            Collection<Gene> genes = geneService.load( ids );
-            genes = geneService.thawLite( genes );
-            vos = geneService.loadValueObjects( genes );
-        } else if ( PhenotypeAssociation.class.isAssignableFrom( entityClass ) ) {
-            // This is used for phenotypes.
-            Collection<CharacteristicValueObject> cvos = new ArrayList<>();
-            for ( SearchResult<?> sr : results ) {
-                CharacteristicValueObject ch = ( CharacteristicValueObject ) sr.getResultObject();
-                if ( ch != null ) {
-                    cvos.add( ch );
-                }
-            }
-            vos = cvos;
-        } else if ( BioSequenceValueObject.class.isAssignableFrom( entityClass ) ) {
-            return results.stream()
-                    .map( s -> new SearchResultValueObject<>( ( SearchResult<BioSequenceValueObject> ) s ) )
-                    .collect( Collectors.toList() );
-        } else if ( GeneSet.class.isAssignableFrom( entityClass ) ) {
-            vos = geneSetService.loadValueObjectsByIds( ids );
-        } else if ( ExpressionExperimentSet.class.isAssignableFrom( entityClass ) ) {
-            vos = experimentSetService.loadValueObjects( experimentSetService.load( ids ) );
-        } else if ( BlacklistedEntity.class.isAssignableFrom( entityClass ) ) {
-            Collection<BlacklistedValueObject> bvos = new ArrayList<>();
-            for ( SearchResult<?> sr : results ) {
-                if ( sr.getResultObject() != null ) {
-                    bvos.add( BlacklistedValueObject.fromEntity( ( BlacklistedEntity ) sr.getResultObject() ) );
-                }
-            }
-            vos = bvos;
-        } else {
-            throw new UnsupportedOperationException( "Don't know how to make value objects for class=" + entityClass );
-        }
-
-        if ( vos == null || vos.isEmpty() ) {
-            // bug 3475: if there are search results but they are all removed because they are troubled, then results
-            // has ExpressionExperiments in
-            // it causing front end errors, if vos is empty make sure to get rid of all search results
-            return Collections.emptyList();
-        }
-
-        // retained objects...
-        Map<Long, ? extends IdentifiableValueObject<?>> idMap = EntityUtils.getIdMap( vos );
-
-        List<SearchResultValueObject<?>> convertResults = new ArrayList<>( results.size() );
-        for ( SearchResult<?> sr : results ) {
-            if ( idMap.containsKey( sr.getResultId() ) ) {
-                convertResults.add( new SearchResultValueObject<>( SearchResult.from( sr, idMap.get( sr.getResultId() ) ) ) );
-            }
-        }
-
-        timer.stop();
-
-        if ( timer.getTime() > 200 ) {
-            BaseFormController.log.info( "Value object conversion for " + ids.size() + " " + entityClass + " after search took " + timer.getTime() + " ms." );
-        }
-
-        return convertResults;
-    }
-
-    private Collection<ArrayDesignValueObject> filterAD( final Collection<ArrayDesignValueObject> toFilter,
-            SearchSettings settings ) {
-        // Note: if possible we should move filtering into the search service (as is done for EEs) (this is not a big deal)
-        Taxon tax = settings.getTaxon();
-        if ( tax == null )
-            return toFilter;
-        Collection<ArrayDesignValueObject> filtered = new HashSet<>();
-        for ( ArrayDesignValueObject aavo : toFilter ) {
-            if ( ( aavo.getTaxon() == null ) || ( aavo.getTaxon().equalsIgnoreCase( tax.getCommonName() ) ) ) {
-                filtered.add( aavo );
-            }
-        }
-
-        return filtered;
     }
 
     //    private Collection<ExpressionExperimentValueObject> filterEE(

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignControllerImpl.java
@@ -237,7 +237,8 @@ public class ArrayDesignControllerImpl implements ArrayDesignController {
 
         Collection<SearchResult<ArrayDesign>> searchResults = null;
         try {
-            searchResults = searchService.search( SearchSettings.arrayDesignSearch( filter ), ArrayDesign.class );
+            searchResults = searchService.search( SearchSettings.arrayDesignSearch( filter ) )
+                    .getByResultObjectType( ArrayDesign.class );
         } catch ( SearchException e ) {
             return new ModelAndView( new RedirectView( "/arrays/showAllArrayDesigns.html", true ) )
                     .addObject( "message", "Invalid search settings: " + e.getMessage() );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/designElement/CompositeSequenceController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/designElement/CompositeSequenceController.java
@@ -32,7 +32,6 @@ import ubic.gemma.core.genome.gene.service.GeneService;
 import ubic.gemma.core.search.SearchException;
 import ubic.gemma.core.search.SearchResult;
 import ubic.gemma.core.search.SearchService;
-import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.common.search.SearchSettings;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
@@ -45,10 +44,7 @@ import ubic.gemma.web.remote.EntityDelegator;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.awt.*;
 import java.util.*;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author joseph
@@ -175,7 +171,7 @@ public class CompositeSequenceController extends BaseController {
         SearchService.SearchResultMap search = searchService.search( SearchSettings.compositeSequenceSearch( searchString, arrayDesign ) );
 
         Collection<CompositeSequence> css = new HashSet<>();
-        Collection<SearchResult<CompositeSequence>> searchResults = search.get( CompositeSequence.class );
+        Collection<SearchResult<CompositeSequence>> searchResults = search.getByResultObjectType( CompositeSequence.class );
         for ( SearchResult<CompositeSequence> sr : searchResults ) {
             CompositeSequence cs = sr.getResultObject();
             if ( cs != null && ( arrayDesign == null || cs.getArrayDesign().equals( arrayDesign ) ) ) {

--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
 		</plugins>
 	</reporting>
 	<properties>
-		<gsec.version>0.0.11</gsec.version>
+		<gsec.version>0.0.12-SNAPSHOT</gsec.version>
 		<spring.version>3.2.18.RELEASE</spring.version>
 		<spring.security.version>3.2.10.RELEASE</spring.security.version>
 		<jersey.version>2.25.1</jersey.version>


### PR DESCRIPTION
Some work was introduced in b8dc05028b1a138cce40c9f9c4ebec77be277541 to add VO conversion capabilities to the `SearchService`. 

This PR builds upon these changes so that the `GeneralSearchController`-specific logic can be reused for the RESTful API as well.

I took the liberty to make some improvements:

 - no more late loading (we used to thaw models when loading VOs, but we don't need to do that anymore)
 - improve EE by characteristic search using a single query
 - explicitly load entities from the database in CompassSearchSource (if `fillObjects` is set)
 - move fast-search, fill objects, etc. modes in SearchSettings
- fill any missing entities in bulk
- load VOs in bulk either by IDs or entities