### PR TITLE
Hotfix 1.27.11

### DIFF
--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -171,14 +171,6 @@
                                             <outputDirectory>${project.build.directory}/schema</outputDirectory>
                                             <includes>**/*.sql</includes>
                                         </artifactItem>
-                                        <artifactItem>
-                                            <groupId>gemma</groupId>
-                                            <artifactId>gemma-model</artifactId>
-                                            <version>1.10.1</version>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/schema</outputDirectory>
-                                            <includes>**/*.sql</includes>
-                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>

--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -14,7 +14,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
+                <version>3.0.0</version>
                 <configuration>
                     <target>
                         <taskdef name="schemaexport" classname="org.hibernate.tool.hbm2ddl.SchemaExportTask">
@@ -120,7 +120,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-antrun-plugin</artifactId>
-                                        <versionRange>[1.7,)</versionRange>
+                                        <versionRange>[3.0.0,)</versionRange>
                                         <goals>
                                             <goal>run</goal>
                                         </goals>
@@ -150,7 +150,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.1.2</version>
                         <executions>
                             <execution>
                                 <phase>process-resources</phase>

--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -264,7 +264,7 @@
             <version>1.7</version>
         </dependency>
 
-        <!-- Lucene (version is synced with baseCode -->
+        <!-- Lucene (version is synced with baseCode) -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
@@ -276,7 +276,7 @@
             <version>${lucene.version}</version>
         </dependency>
 
-        <!-- Jena -->
+        <!-- Jena (version is synced with baseCode) -->
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
@@ -375,7 +375,7 @@
             <version>1.7.4</version>
         </dependency>
         <!-- bit array -->
-        <!-- it can't be updated though because the binary format has changed and we store those in the database -->
+        <!-- it can't be updated though because the binary format has changed, and we store those in the database -->
         <dependency>
             <groupId>com.googlecode.javaewah</groupId>
             <artifactId>JavaEWAH</artifactId>

--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -15,21 +15,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
-                <configuration>
-                    <target>
-                        <taskdef name="schemaexport" classname="org.hibernate.tool.hbm2ddl.SchemaExportTask">
-                            <classpath>
-                                <path refid="maven.dependency.classpath"/>
-                            </classpath>
-                        </taskdef>
-                        <mkdir dir="target/schema"/>
-                        <schemaexport quiet="true" text="true" create="true" drop="false" delimiter=";"
-                                      output="${project.build.directory}/schema/gemma-ddl.sql"
-                                      config="${project.basedir}/src/main/resources/hibernate.cfg.xml">
-                            <fileset dir="src/main/resources" includes="**/*.hbm.xml"/>
-                        </schemaexport>
-                    </target>
-                </configuration>
                 <executions>
                     <execution>
                         <id>version-file</id>
@@ -46,12 +31,31 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>schema-export</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
+                        <configuration>
+                            <target>
+                                <taskdef name="schemaexport" classname="org.hibernate.tool.hbm2ddl.SchemaExportTask"/>
+                                <mkdir dir="${project.build.directory}/schema"/>
+                                <schemaexport quiet="true" text="true" create="true" drop="false" delimiter=";"
+                                         output="${project.build.directory}/schema/gemma-ddl.sql"
+                                         config="${project.basedir}/src/main/resources/hibernate.cfg.xml">
+                                    <fileset dir="${project.basedir}/src/main/resources" includes="**/*.hbm.xml"/>
+                                </schemaexport>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-core</artifactId>
+                        <version>${hibernate.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>gemma</artifactId>
         <groupId>gemma</groupId>
-        <version>1.27.10</version>
+        <version>1.27.11</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gemma-core</artifactId>

--- a/gemma-core/src/main/config/log4j.properties
+++ b/gemma-core/src/main/config/log4j.properties
@@ -19,7 +19,7 @@ log4j.appender.file.File=${gemma.log.dir}/gemma.log
 log4j.appender.file.MaxFileSize=10000KB
 log4j.appender.file.MaxBackupIndex=10
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=[Gemma - %t (%d)] %p %C.%M(%L) | %m%nLso
+log4j.appender.file.layout.ConversionPattern=[Gemma - %t (%d)] %p %C.%M(%L) | %m%n
 
 # Log file for WARNING and higher level errors
 log4j.appender.warningFile=org.apache.log4j.DailyRollingFileAppender

--- a/gemma-core/src/main/config/log4j.properties
+++ b/gemma-core/src/main/config/log4j.properties
@@ -10,7 +10,7 @@
 log4j.appender.stderr=org.apache.log4j.ConsoleAppender
 log4j.appender.stderr.target=System.err
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
-log4j.appender.stderr.layout.ConversionPattern=[Gemma %d] %p [%t] %C.%M(%L) | %m%n
+log4j.appender.stderr.layout.ConversionPattern=%d %highlight{%p} %style{%pid}{magenta} [%t] %style{%C.%M(%L)}{cyan} | %m%n
 
 # Log to a file. Note that if File is a relative path, the output file goes wherever the application JVM was started from.
 # Define gemma.log.dir as a parameter to your JAVA_OPTS and make sure this is passed to java when you start it.

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/coexpression/links/AbstractMatrixRowPairAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/coexpression/links/AbstractMatrixRowPairAnalysis.java
@@ -21,7 +21,7 @@ package ubic.gemma.core.analysis.expression.coexpression.links;
 import cern.colt.bitvector.BitMatrix;
 import cern.colt.list.DoubleArrayList;
 import cern.colt.list.ObjectArrayList;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.logging.Log;

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/LinearModelAnalyzer.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/LinearModelAnalyzer.java
@@ -20,8 +20,8 @@ package ubic.gemma.core.analysis.expression.diff;
 
 import cern.colt.matrix.DoubleMatrix1D;
 import cern.colt.matrix.impl.DenseDoubleMatrix1D;
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.TransformerUtils;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/LinearModelAnalyzer.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/expression/diff/LinearModelAnalyzer.java
@@ -27,7 +27,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Component;
 import ubic.basecode.dataStructure.matrix.DenseDoubleMatrix;
 import ubic.basecode.dataStructure.matrix.DoubleMatrix;
@@ -139,6 +142,9 @@ public class LinearModelAnalyzer extends AbstractDifferentialExpressionAnalyzer 
 
         return reorderedDim;
     }
+
+    @Autowired
+    private AsyncTaskExecutor taskExecutor;
 
     /**
      * Determine if any factor should be treated as the intercept term.
@@ -1432,9 +1438,8 @@ public class LinearModelAnalyzer extends AbstractDifferentialExpressionAnalyzer 
     private Future<?> runAnalysisFuture( final DesignMatrix designMatrix, final DoubleMatrix<String, String> data,
             final Map<String, LinearModelSummary> rawResults, final DoubleMatrix1D librarySize,
             final DifferentialExpressionAnalysisConfig config ) {
-        ExecutorService service = Executors.newSingleThreadExecutor();
 
-        Future<?> f = service.submit( new Runnable() {
+        Future<?> f = taskExecutor.submit( new Runnable() {
             @Override
             public void run() {
                 StopWatch timer = new StopWatch();
@@ -1476,7 +1481,6 @@ public class LinearModelAnalyzer extends AbstractDifferentialExpressionAnalyzer 
             }
         } );
 
-        service.shutdown();
         return f;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ArrayDesignAnnotationServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ArrayDesignAnnotationServiceImpl.java
@@ -18,8 +18,8 @@
  */
 package ubic.gemma.core.analysis.service;
 
-import org.apache.commons.collections.Transformer;
-import org.apache.commons.collections.iterators.TransformIterator;
+import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/ExperimentalDesignImportCli.java
@@ -57,8 +57,7 @@ public class ExperimentalDesignImportCli extends AbstractCLIContextCLI {
 
         Option expOption = Option.builder( "e" ).required().hasArg().argName( "Expression experiment name" )
                 .desc(
-                        "Expression experiment short name. Most tools recognize comma-delimited values given on the command line, "
-                                + "and if this option is omitted, the tool will be applied to all expression experiments." )
+                        "Expression experiment short name" )
                 .longOpt( "experiment" ).build();
 
         options.addOption( expOption );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
@@ -21,6 +21,7 @@ package ubic.gemma.core.apps;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.association.NCBIGene2GOAssociationLoader;
@@ -65,7 +66,7 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
     @Override
     protected void doWork() throws Exception {
         TaxonService taxonService = this.getBean( TaxonService.class );
-        TaskExecutor taskExecutor = this.getBean( TaskExecutor.class );
+        AsyncTaskExecutor taskExecutor = this.getBean( AsyncTaskExecutor.class );
 
         NCBIGene2GOAssociationLoader gene2GOAssLoader = new NCBIGene2GOAssociationLoader( taskExecutor );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NCBIGene2GOAssociationLoaderCLI.java
@@ -21,6 +21,7 @@ package ubic.gemma.core.apps;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.springframework.core.task.TaskExecutor;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.association.NCBIGene2GOAssociationLoader;
 import ubic.gemma.core.loader.association.NCBIGene2GOAssociationParser;
@@ -64,8 +65,9 @@ public class NCBIGene2GOAssociationLoaderCLI extends AbstractCLIContextCLI {
     @Override
     protected void doWork() throws Exception {
         TaxonService taxonService = this.getBean( TaxonService.class );
+        TaskExecutor taskExecutor = this.getBean( TaskExecutor.class );
 
-        NCBIGene2GOAssociationLoader gene2GOAssLoader = new NCBIGene2GOAssociationLoader();
+        NCBIGene2GOAssociationLoader gene2GOAssLoader = new NCBIGene2GOAssociationLoader( taskExecutor );
 
         gene2GOAssLoader.setPersisterHelper( this.getPersisterHelper() );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.task.TaskExecutor;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.genome.gene.ncbi.NcbiGeneLoader;
 import ubic.gemma.core.util.AbstractCLI;
@@ -98,7 +99,7 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
 
     @Override
     protected void doWork() throws Exception {
-        loader = new NcbiGeneLoader();
+        loader = new NcbiGeneLoader( this.getBean( TaskExecutor.class ) );
         TaxonService taxonService = this.getBean( TaxonService.class );
         loader.setTaxonService( taxonService );
         loader.setPersisterHelper( this.getPersisterHelper() );

--- a/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/apps/NcbiGeneLoaderCLI.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import ubic.gemma.core.apps.GemmaCLI.CommandGroup;
 import ubic.gemma.core.loader.genome.gene.ncbi.NcbiGeneLoader;
@@ -99,7 +100,7 @@ public class NcbiGeneLoaderCLI extends AbstractCLIContextCLI {
 
     @Override
     protected void doWork() throws Exception {
-        loader = new NcbiGeneLoader( this.getBean( TaskExecutor.class ) );
+        loader = new NcbiGeneLoader( this.getBean( AsyncTaskExecutor.class ) );
         TaxonService taxonService = this.getBean( TaxonService.class );
         loader.setTaxonService( taxonService );
         loader.setPersisterHelper( this.getPersisterHelper() );

--- a/gemma-core/src/main/java/ubic/gemma/core/externalDb/GoldenPathSequenceAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/externalDb/GoldenPathSequenceAnalysis.java
@@ -18,7 +18,7 @@
  */
 package ubic.gemma.core.externalDb;
 
-import org.apache.commons.collections.map.LRUMap;
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ResultSetExtractor;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/AffyPowerToolsProbesetSummarize.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/AffyPowerToolsProbesetSummarize.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.lang3.RandomStringUtils;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/arrayDesign/ArrayDesignProbeMapperServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/arrayDesign/ArrayDesignProbeMapperServiceImpl.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -91,6 +92,7 @@ public class ArrayDesignProbeMapperServiceImpl implements ArrayDesignProbeMapper
     private final GeneService geneService;
     private final Persister persisterHelper;
     private final ProbeMapper probeMapper;
+    private final TaskExecutor taskExecutor;
 
     @Autowired
     public ArrayDesignProbeMapperServiceImpl( AnnotationAssociationService annotationAssociationService,
@@ -98,7 +100,7 @@ public class ArrayDesignProbeMapperServiceImpl implements ArrayDesignProbeMapper
             ArrayDesignReportService arrayDesignReportService, ArrayDesignService arrayDesignService,
             ProbeMapper probeMapper, BioSequenceService bioSequenceService, BlatResultService blatResultService,
             CompositeSequenceService compositeSequenceService, ExpressionDataFileService expressionDataFileService,
-            GeneProductService geneProductService, GeneService geneService, Persister persisterHelper ) {
+            GeneProductService geneProductService, GeneService geneService, Persister persisterHelper, TaskExecutor taskExecutor ) {
         this.annotationAssociationService = annotationAssociationService;
         this.arrayDesignAnnotationService = arrayDesignAnnotationService;
         this.arrayDesignReportService = arrayDesignReportService;
@@ -111,6 +113,7 @@ public class ArrayDesignProbeMapperServiceImpl implements ArrayDesignProbeMapper
         this.geneProductService = geneProductService;
         this.geneService = geneService;
         this.persisterHelper = persisterHelper;
+        this.taskExecutor = taskExecutor;
     }
 
     @Override
@@ -516,16 +519,14 @@ public class ArrayDesignProbeMapperServiceImpl implements ArrayDesignProbeMapper
         final SecurityContext context = SecurityContextHolder.getContext();
         assert context != null;
 
-        Thread loadThread = new Thread( new Runnable() {
+        this.taskExecutor.execute( new Runnable() {
             @Override
             public void run() {
                 SecurityContextHolder.setContext( context );
                 ArrayDesignProbeMapperServiceImpl.this.doLoad( queue, generatorDone, loaderDone, persist );
             }
 
-        }, "PersistBlatAssociations" );
-
-        loadThread.start();
+        });
 
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/service/GeoServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/service/GeoServiceImpl.java
@@ -21,6 +21,7 @@ package ubic.gemma.core.loader.expression.geo.service;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.core.analysis.report.ArrayDesignReportService;
 import ubic.gemma.core.analysis.report.ExpressionExperimentReportService;
 import ubic.gemma.core.loader.entrez.pubmed.PubMedXMLFetcher;
@@ -76,6 +77,7 @@ public class GeoServiceImpl extends AbstractGeoService {
     }
 
     @Override
+    @Transactional
     public ArrayDesign addElements( ArrayDesign targetPlatform ) {
 
         if ( !targetPlatform.getCompositeSequences().isEmpty() ) {
@@ -125,6 +127,7 @@ public class GeoServiceImpl extends AbstractGeoService {
     }
 
     @Override
+    @Transactional
     public Collection<?> fetchAndLoad( String geoAccession, boolean loadPlatformOnly, boolean doSampleMatching,
             boolean splitByPlatform ) {
         return this.fetchAndLoad( geoAccession, loadPlatformOnly, doSampleMatching, splitByPlatform, true, true );
@@ -140,6 +143,7 @@ public class GeoServiceImpl extends AbstractGeoService {
      * </ol>
      */
     @Override
+    @Transactional
     public Collection<?> fetchAndLoad( String geoAccession, boolean loadPlatformOnly, boolean doSampleMatching,
             boolean splitByPlatform, boolean allowSuperSeriesImport, boolean allowSubSeriesImport ) {
 

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneConverter.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneConverter.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import ubic.gemma.core.loader.genome.gene.ncbi.model.NCBIGene2Accession;
 import ubic.gemma.core.loader.genome.gene.ncbi.model.NCBIGeneInfo;
 import ubic.gemma.core.loader.util.converter.Converter;
@@ -41,7 +41,7 @@ import ubic.gemma.persistence.util.SequenceBinUtils;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
 
 /**
  * Convert NCBIGene2Accession objects into Gemma Gene objects with associated GeneProducts. Genes without products are
@@ -64,12 +64,9 @@ public class NcbiGeneConverter implements Converter<Object, Object> {
         NcbiGeneConverter.ensembl.setName( "Ensembl" );
     }
 
-    private final TaskExecutor taskExecutor;
+    private final AsyncTaskExecutor taskExecutor;
 
-    AtomicBoolean producerDone = new AtomicBoolean( false );
-    AtomicBoolean sourceDone = new AtomicBoolean( false );
-
-    public NcbiGeneConverter( TaskExecutor taskExecutor ) {
+    public NcbiGeneConverter( AsyncTaskExecutor taskExecutor ) {
         this.taskExecutor = taskExecutor;
     }
 
@@ -239,18 +236,20 @@ public class NcbiGeneConverter implements Converter<Object, Object> {
         return gene;
     }
 
-    /*
+    /**
      * Threaded conversion of domain objects to Gemma objects.
+     *
+     * @return a future that completes when the conversion is done, that is when the gene info queue is empty and the
+     * source is done as well
      */
-    public void convert( final BlockingQueue<NcbiGeneData> geneInfoQueue, final BlockingQueue<Gene> geneQueue ) {
+    public Future<?> convert( final BlockingQueue<NcbiGeneData> geneInfoQueue, final BlockingQueue<Gene> geneQueue, Future<?> sourceFuture ) {
         // start up thread to convert a member of geneInfoQueue to a gene/geneproduct/databaseentry
         // then push the gene onto the geneQueue for loading
 
-        this.taskExecutor.execute( new Runnable() {
+        return this.taskExecutor.submit( new Runnable() {
             @Override
-            @SuppressWarnings("synthetic-access")
             public void run() {
-                while ( !( sourceDone.get() && geneInfoQueue.isEmpty() ) ) {
+                while ( !( sourceFuture.isDone() && geneInfoQueue.isEmpty() ) ) {
                     try {
                         NcbiGeneData data = geneInfoQueue.poll();
                         if ( data == null ) {
@@ -273,21 +272,8 @@ public class NcbiGeneConverter implements Converter<Object, Object> {
                         break;
                     }
                 }
-                producerDone.set( true );
             }
-        });
-    }
-
-    public boolean isProducerDone() {
-        return this.producerDone.get();
-    }
-
-    public void setProducerDoneFlag( AtomicBoolean flag ) {
-        this.producerDone = flag;
-    }
-
-    public void setSourceDoneFlag( AtomicBoolean flag ) {
-        this.sourceDone = flag;
+        } );
     }
 
     private PhysicalLocation getPhysicalLocation( NCBIGene2Accession acc, Gene gene ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneDomainObjectGenerator.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneDomainObjectGenerator.java
@@ -20,7 +20,7 @@ package ubic.gemma.core.loader.genome.gene.ncbi;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import ubic.basecode.util.FileTools;
 import ubic.gemma.core.loader.genome.gene.ncbi.model.NCBIGeneInfo;
 import ubic.gemma.core.loader.genome.gene.ncbi.model.NcbiGeneHistory;
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
 
 /**
  * Combines information from the gene2accession and gene_info files from NCBI Gene.
@@ -51,7 +51,6 @@ public class NcbiGeneDomainObjectGenerator {
     private static final String GENE2ACCESSION_FILE = "gene2accession";
     private static final String GENEHISTORY_FILE = "gene_history";
     private static final String GENEENSEMBL_FILE = "gene2ensembl";
-    private AtomicBoolean producerDone = new AtomicBoolean( false );
     private Map<Integer, Taxon> supportedTaxa = null;
     private Collection<Taxon> supportedTaxaWithNCBIGenes = null;
     private boolean filter = true;
@@ -59,9 +58,9 @@ public class NcbiGeneDomainObjectGenerator {
     // whether to fetch files from ncbi or use existing ones
     private boolean doDownload = true;
     private Integer startingNcbiId = null;
-    private final TaskExecutor taskExecutor;
+    private final AsyncTaskExecutor taskExecutor;
 
-    public NcbiGeneDomainObjectGenerator( Collection<Taxon> taxa, TaskExecutor taskExecutor ) {
+    public NcbiGeneDomainObjectGenerator( Collection<Taxon> taxa, AsyncTaskExecutor taskExecutor ) {
         this.taskExecutor = taskExecutor;
 
         if ( taxa != null ) {
@@ -90,10 +89,7 @@ public class NcbiGeneDomainObjectGenerator {
         this.doDownload = doDownload;
     }
 
-    /**
-     * @param queue queue
-     */
-    public void generate( final BlockingQueue<NcbiGeneData> queue ) {
+    public Future<?> generate( final BlockingQueue<NcbiGeneData> queue ) {
 
         NcbiGeneDomainObjectGenerator.log.info( "Fetching..." );
         NCBIGeneFileFetcher fetcher = new NCBIGeneFileFetcher();
@@ -104,10 +100,10 @@ public class NcbiGeneDomainObjectGenerator {
         LocalFile geneHistoryFile = fetcher.fetch( NcbiGeneDomainObjectGenerator.GENEHISTORY_FILE ).iterator().next();
         LocalFile geneEnsemblFile = fetcher.fetch( NcbiGeneDomainObjectGenerator.GENEENSEMBL_FILE ).iterator().next();
 
-        this.processLocalFiles( geneInfoFile, gene2AccessionFile, geneHistoryFile, geneEnsemblFile, queue );
+        return this.processLocalFiles( geneInfoFile, gene2AccessionFile, geneHistoryFile, geneEnsemblFile, queue );
     }
 
-    public void generateLocal( String geneInfoFilePath, String gene2AccesionFilePath, String geneHistoryFilePath,
+    public Future<?> generateLocal( String geneInfoFilePath, String gene2AccesionFilePath, String geneHistoryFilePath,
             String geneEnsemblFilePath, BlockingQueue<NcbiGeneData> queue ) {
 
         assert gene2AccesionFilePath != null;
@@ -136,19 +132,11 @@ public class NcbiGeneDomainObjectGenerator {
                 geneEnsemblFile.setLocalURL( geneEnsemblUrl );
             }
 
-            this.processLocalFiles( geneInfoFile, gene2AccessionFile, geneHistoryFile, geneEnsemblFile, queue );
+            return this.processLocalFiles( geneInfoFile, gene2AccessionFile, geneHistoryFile, geneEnsemblFile, queue );
 
         } catch ( IOException e ) {
             throw new RuntimeException( e );
         }
-    }
-
-    public boolean isProducerDone() {
-        return producerDone.get();
-    }
-
-    public void setProducerDoneFlag( AtomicBoolean flag ) {
-        this.producerDone = flag;
     }
 
     /**
@@ -164,7 +152,7 @@ public class NcbiGeneDomainObjectGenerator {
         this.startingNcbiId = startingNcbiId;
     }
 
-    private void processLocalFiles( final LocalFile geneInfoFile, final LocalFile gene2AccessionFile,
+    private Future<?> processLocalFiles( final LocalFile geneInfoFile, final LocalFile gene2AccessionFile,
             LocalFile geneHistoryFile, LocalFile geneEnsemblFile, final BlockingQueue<NcbiGeneData> geneDataQueue ) {
 
         final NcbiGeneInfoParser infoParser = new NcbiGeneInfoParser();
@@ -250,7 +238,7 @@ public class NcbiGeneDomainObjectGenerator {
         // all accessions for the gene are done.
         // 1b) Create a Collection<Gene2Accession>, and push into BlockingQueue
 
-        this.taskExecutor.execute( new Runnable() {
+        return this.taskExecutor.submit( new Runnable() {
             @Override
             public void run() {
                 try {
@@ -262,7 +250,6 @@ public class NcbiGeneDomainObjectGenerator {
                     throw new RuntimeException( e );
                 }
                 NcbiGeneDomainObjectGenerator.log.debug( "Domain object generator done" );
-                producerDone.set( true );
             }
         } );
 

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceImpl.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.jena.larq.IndexLARQ;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 import ubic.basecode.ontology.OntologyLoader;
 import ubic.basecode.ontology.model.AnnotationProperty;
@@ -132,6 +133,9 @@ public class GeneOntologyServiceImpl implements GeneOntologyService {
     private final Collection<SearchIndex> indices = new HashSet<>();
 
     private OntModel model;
+
+    @Autowired
+    private TaskExecutor taskExecutor;
 
     /**
      * Cache of go term -> parent terms
@@ -816,7 +820,7 @@ public class GeneOntologyServiceImpl implements GeneOntologyService {
         if ( GeneOntologyServiceImpl.running.get() )
             return;
 
-        Thread loadThread = new Thread( new Runnable() {
+        this.taskExecutor.execute( new Runnable() {
             @Override
             public void run() {
                 GeneOntologyServiceImpl.running.set( true );
@@ -844,8 +848,6 @@ public class GeneOntologyServiceImpl implements GeneOntologyService {
             }
 
         } );
-
-        loadThread.start();
 
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/core/security/audit/AuditableUtilImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/security/audit/AuditableUtilImpl.java
@@ -18,8 +18,8 @@
  */
 package ubic.gemma.core.security.audit;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.springframework.stereotype.Component;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
 import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
@@ -40,12 +40,7 @@ public class AuditableUtilImpl implements AuditableUtil {
             return;
         }
 
-        CollectionUtils.filter( valueObjects, new Predicate() {
-            @Override
-            public boolean evaluate( Object vo ) {
-                return !( ( ArrayDesignValueObject ) vo ).getTroubled();
-            }
-        } );
+        CollectionUtils.filter( valueObjects, vo -> !vo.getTroubled() );
     }
 
     @Override
@@ -54,12 +49,7 @@ public class AuditableUtilImpl implements AuditableUtil {
             return;
         }
 
-        CollectionUtils.filter( eevos, new Predicate() {
-            @Override
-            public boolean evaluate( Object e ) {
-                return !( ( ExpressionExperimentValueObject ) e ).getTroubled();
-            }
-        } );
+        CollectionUtils.filter( eevos, vo -> !vo.getTroubled() );
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/pca/PrincipalComponentAnalysis.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/pca/PrincipalComponentAnalysis.java
@@ -18,8 +18,7 @@
  */
 package ubic.gemma.model.analysis.expression.pca;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import ubic.basecode.io.ByteArrayConverter;
 import ubic.gemma.model.analysis.SingleExperimentAnalysis;
@@ -27,10 +26,7 @@ import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
 
 import javax.persistence.Transient;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 public class PrincipalComponentAnalysis extends SingleExperimentAnalysis {
 
@@ -130,12 +126,7 @@ public class PrincipalComponentAnalysis extends SingleExperimentAnalysis {
             result.set( index, dA );
         }
 
-        CollectionUtils.filter( result, new Predicate() {
-            @Override
-            public boolean evaluate( Object object ) {
-                return object != null;
-            }
-        } );
+        CollectionUtils.filter( result, Objects::nonNull );
         return result;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/persister/GenomePersister.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/persister/GenomePersister.java
@@ -614,7 +614,7 @@ abstract public class GenomePersister extends CommonPersister {
         }
 
         // I don't fully understand what's going on here, but if we don't do this we fail to synchronize changes.
-        this.getSession().evict( existingBioSequence );
+        this.getSessionFactory().getCurrentSession().evict( existingBioSequence );
         bioSequenceDao.update( existingBioSequence ); // also tried merge, without the update, doesn't work.
         return existingBioSequence;
 
@@ -647,7 +647,7 @@ abstract public class GenomePersister extends CommonPersister {
          * This allows stale data to exist in this Session, but flushing prematurely causes constraint violations.
          * Probably we should fix this some other way.
          */
-        this.getSession().setFlushMode( FlushMode.COMMIT );
+        this.getSessionFactory().getCurrentSession().setFlushMode( FlushMode.COMMIT );
 
         return this.updateGene( existingGene, gene );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
@@ -136,6 +136,11 @@ public abstract class AbstractDao<T extends Identifiable> extends HibernateDaoSu
     }
 
     @Override
+    public void removeAll() {
+        this.remove( this.loadAll() );
+    }
+
+    @Override
     @Transactional
     public void update( Collection<T> entities ) {
         int i = 0;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
@@ -118,8 +118,13 @@ public abstract class AbstractDao<T extends Identifiable> extends HibernateDaoSu
 
     @Override
     public void remove( Collection<T> entities ) {
+        int i = 0;
         for ( T e : entities ) {
             this.remove( e );
+            if ( ++i % BATCH_SIZE == 0 ) {
+                this.getSessionFactory().getCurrentSession().flush();
+                this.getSessionFactory().getCurrentSession().clear();
+            }
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractService.java
@@ -92,6 +92,12 @@ public abstract class AbstractService<O extends Identifiable> implements BaseSer
 
     @Override
     @Transactional
+    public void removeAll() {
+        mainDao.removeAll();
+    }
+
+    @Override
+    @Transactional
     public void update( Collection<O> entities ) {
         mainDao.update( entities );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseDao.java
@@ -94,6 +94,11 @@ public interface BaseDao<T> {
     void remove( T entity );
 
     /**
+     * Remove all entities from persistent storage.
+     */
+    void removeAll();
+
+    /**
      * @param entities Update the entities. Not supported if the entities are immutable.
      */
     void update( Collection<T> entities );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseService.java
@@ -92,6 +92,11 @@ public interface BaseService<O extends Identifiable> {
     void remove( O entity );
 
     /**
+     * Remove all entities from the persistent storage.
+     */
+    void removeAll();
+
+    /**
      * Updates all entities in the given collection in the persistent storage.
      *
      * @param entities the entities to be updated.

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
@@ -18,7 +18,7 @@
  */
 package ubic.gemma.persistence.service.analysis.expression.diff;
 
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.hibernate.*;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionQueryQueueImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionQueryQueueImpl.java
@@ -23,6 +23,7 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -47,6 +48,8 @@ class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements Coexpres
     private CoexpressionDao coexpressionDao;
     @Autowired
     private GeneDao geneDao;
+    @Autowired
+    private TaskExecutor taskExecutor;
 
     @Autowired
     public CoexpressionQueryQueueImpl( SessionFactory sessionFactory ) {
@@ -88,7 +91,7 @@ class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements Coexpres
         super.initDao();
         final SecurityContext context = SecurityContextHolder.getContext();
 
-        Thread loadThread = new Thread( new Runnable() {
+        taskExecutor.execute(new Runnable() {
 
             private final int MAX_WARNINGS = 5;
 
@@ -128,9 +131,7 @@ class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements Coexpres
                 }
             }
 
-        }, "Fetching coexpression for recently used genes" );
-        loadThread.setDaemon( true );
-        loadThread.start();
+        });
     }
 
     private void queryForCache( QueuedGene gene ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionQueryQueueImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionQueryQueueImpl.java
@@ -23,11 +23,9 @@ import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Repository;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.persistence.service.genome.GeneDao;
 
@@ -38,8 +36,7 @@ import java.util.concurrent.BlockingQueue;
 /**
  * @author Paul
  */
-@Repository
-@Lazy
+// @Repository
 class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements CoexpressionQueryQueue {
 
     private static final int QUEUE_SIZE = 1000;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionServiceImpl.java
@@ -52,11 +52,11 @@ public class CoexpressionServiceImpl implements CoexpressionService {
     @Autowired
     private CoexpressionDao coexpressionDao;
 
-    @Autowired
-    private CoexpressionQueryQueue coexpressionQueryQueue;
+    // @Autowired
+    // private CoexpressionQueryQueue coexpressionQueryQueue;
 
-    @Autowired
-    private CoexpressionCache coexpressionCache;
+    // @Autowired
+    // private CoexpressionCache coexpressionCache;
 
     @Autowired
     private ExpressionExperimentDao experimentDao;
@@ -82,12 +82,12 @@ public class CoexpressionServiceImpl implements CoexpressionService {
         this.coexpressionDao.createOrUpdate( bioAssaySet, links, c, genesTested );
 
         // remove these from the queue, in case they are there.
-        Collection<Long> genes = new HashSet<>();
-        for ( NonPersistentNonOrderedCoexpLink link : links ) {
-            genes.add( link.getFirstGene() );
-            genes.add( link.getSecondGene() );
-        }
-        this.coexpressionQueryQueue.removeFromQueue( genes );
+        // Collection<Long> genes = new HashSet<>();
+        // for ( NonPersistentNonOrderedCoexpLink link : links ) {
+        //     genes.add( link.getFirstGene() );
+        //     genes.add( link.getSecondGene() );
+        // }
+        // this.coexpressionQueryQueue.removeFromQueue( genes );
     }
 
     @Override
@@ -102,9 +102,9 @@ public class CoexpressionServiceImpl implements CoexpressionService {
         List<CoexpressionValueObject> results = this.coexpressionDao
                 .findCoexpressionRelationships( gene, bas, maxResults, quick );
 
-        if ( quick || maxResults > 0 ) {
-            this.coexpressionQueryQueue.addToFullQueryQueue( gene );
-        }
+        // if ( quick || maxResults > 0 ) {
+        //     this.coexpressionQueryQueue.addToFullQueryQueue( gene );
+        // }
 
         return results;
     }
@@ -133,7 +133,7 @@ public class CoexpressionServiceImpl implements CoexpressionService {
 
         // since we require these links occur in all the given data sets, we assume we should cache (if not there
         // already) - don't bother checking 'quick' and 'maxResults'.
-        this.possiblyAddToCacheQueue( results );
+        // this.possiblyAddToCacheQueue( results );
 
         return results;
     }
@@ -141,25 +141,20 @@ public class CoexpressionServiceImpl implements CoexpressionService {
     @Override
     public Map<Long, List<CoexpressionValueObject>> findCoexpressionRelationships( Taxon t, Collection<Long> genes,
             Collection<Long> bas, int stringency, int maxResults, boolean quick ) {
-        Map<Long, List<CoexpressionValueObject>> results = this.coexpressionDao
+        // if ( stringency > CoexpressionCache.CACHE_QUERY_STRINGENCY || quick || maxResults > 0 ) {
+        //     this.possiblyAddToCacheQueue( results );
+        // }
+        return this.coexpressionDao
                 .findCoexpressionRelationships( t, genes, bas, stringency, maxResults, quick );
-
-        if ( stringency > CoexpressionCache.CACHE_QUERY_STRINGENCY || quick || maxResults > 0 ) {
-            this.possiblyAddToCacheQueue( results );
-        }
-
-        return results;
     }
 
     @Override
     public Map<Long, List<CoexpressionValueObject>> findInterCoexpressionRelationships( Taxon t, Collection<Long> genes,
             Collection<Long> bas, int stringency, boolean quick ) {
-        Map<Long, List<CoexpressionValueObject>> results = this.coexpressionDao
-                .findInterCoexpressionRelationships( t, genes, bas, stringency, quick );
-
         // these are always candidates for queuing since the constraint on genes is done at the query level.
-        this.possiblyAddToCacheQueue( results );
-        return results;
+        // this.possiblyAddToCacheQueue( results );
+        return this.coexpressionDao
+                .findInterCoexpressionRelationships( t, genes, bas, stringency, quick );
     }
 
     @Override
@@ -264,26 +259,26 @@ public class CoexpressionServiceImpl implements CoexpressionService {
     /**
      * Check for results which were not in the cache, and which were not cached; make sure we fully query them.
      */
-    private void possiblyAddToCacheQueue( Map<Long, List<CoexpressionValueObject>> links ) {
+    // private void possiblyAddToCacheQueue( Map<Long, List<CoexpressionValueObject>> links ) {
 
-        if ( !coexpressionCache.isEnabled() )
-            return;
+    //     if ( !coexpressionCache.isEnabled() )
+    //         return;
 
-        Set<Long> toQueue = new HashSet<>();
-        for ( Long id : links.keySet() ) {
-            for ( CoexpressionValueObject link : links.get( id ) ) {
-                if ( link.isFromCache() ) {
-                    continue;
-                }
-                toQueue.add( link.getQueryGeneId() );
-            }
-        }
-        if ( !toQueue.isEmpty() ) {
-            CoexpressionServiceImpl.log.info( "Queuing " + toQueue.size() + " genes for coexpression cache warm" );
-            coexpressionQueryQueue.addToFullQueryQueue( toQueue );
-        }
+    //     Set<Long> toQueue = new HashSet<>();
+    //     for ( Long id : links.keySet() ) {
+    //         for ( CoexpressionValueObject link : links.get( id ) ) {
+    //             if ( link.isFromCache() ) {
+    //                 continue;
+    //             }
+    //             toQueue.add( link.getQueryGeneId() );
+    //         }
+    //     }
+    //     if ( !toQueue.isEmpty() ) {
+    //         CoexpressionServiceImpl.log.info( "Queuing " + toQueue.size() + " genes for coexpression cache warm" );
+    //         coexpressionQueryQueue.addToFullQueryQueue( toQueue );
+    //     }
 
-    }
+    // }
 
     private GeneCoexpressionNodeDegreeValueObject updateNodeDegree( Gene gene ) {
         GeneCoexpressionNodeDegree nd = this.geneCoexpressionNodeDegreeDao.findOrCreate( gene );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/AuditEventDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/AuditEventDaoImpl.java
@@ -18,8 +18,8 @@
  */
 package ubic.gemma.persistence.service.common.auditAndSecurity;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.time.StopWatch;
 import org.hibernate.Hibernate;
 import org.hibernate.Query;
@@ -193,13 +193,7 @@ public class AuditEventDaoImpl extends AbstractDao<AuditEvent> implements AuditE
 
         final Map<Auditable, AuditEvent> events = this.getLastEvent( a, type );
 
-        CollectionUtils.filter( a, new Predicate() {
-            @Override
-            public boolean evaluate( Object arg0 ) {
-                //noinspection SuspiciousMethodCalls // this is perfectly fine since we are passing this directly into the filter
-                return events.containsKey( arg0 );
-            }
-        } );
+        CollectionUtils.filter( a, events::containsKey );
 
     }
 
@@ -211,13 +205,7 @@ public class AuditEventDaoImpl extends AbstractDao<AuditEvent> implements AuditE
         final Map<Auditable, AuditEvent> events = this.getLastEvent( a, type );
         AbstractDao.log.info( "Phase I: " + timer.getTime() + "ms" );
 
-        CollectionUtils.filter( a, new Predicate() {
-            @Override
-            public boolean evaluate( Object arg0 ) {
-                //noinspection SuspiciousMethodCalls // this is perfectly fine since we are passing this directly into the filter
-                return !events.containsKey( arg0 );
-            }
-        } );
+        CollectionUtils.filter( a, ( Predicate<Auditable> ) arg0 -> !events.containsKey( arg0 ) );
 
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/AuditEventDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/AuditEventDaoImpl.java
@@ -282,7 +282,7 @@ public class AuditEventDaoImpl extends AbstractDao<AuditEvent> implements AuditE
             //noinspection unchecked
             result.addAll( queryObject.list() );
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/CharacteristicDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/description/CharacteristicDaoImpl.java
@@ -78,7 +78,7 @@ public class CharacteristicDaoImpl extends AbstractVoEnabledDao<Characteristic, 
     public Collection<? extends Characteristic> findByCategory( String query ) {
 
         //noinspection unchecked
-        return this.getSession()
+        return this.getSessionFactory().getCurrentSession()
                 .createQuery( "select distinct char from Characteristic as char where char.category like :search" )
                 .setParameter( "search", query + "%" ).list();
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/measurement/UnitDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/measurement/UnitDaoImpl.java
@@ -63,7 +63,7 @@ public class UnitDaoImpl extends AbstractDao<Unit> implements UnitDao {
             }
             return ( Unit ) result;
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorDaoImpl.java
@@ -502,7 +502,7 @@ public class ProcessedExpressionDataVectorDaoImpl extends DesignElementDataVecto
                             new ExpressionDataDoubleMatrix( rawPreferredDataVectors ) );
             preferredDataVectors.addAll( matrix.toRawDataVectors() );
             preferredMaskedDataQuantitationType.setScale( ScaleType.LOG2 );
-            this.getSession().update( preferredMaskedDataQuantitationType );
+            this.getSessionFactory().getCurrentSession().update( preferredMaskedDataQuantitationType );
         } else {
             preferredDataVectors.addAll( rawPreferredDataVectors );
         }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorService.java
@@ -170,7 +170,13 @@ public interface ProcessedExpressionDataVectorService
     @Secured({ "GROUP_USER", "ACL_SECURABLE_EDIT" })
     void removeProcessedDataVectors( final ExpressionExperiment expressionExperiment );
 
+    /**
+     * @deprecated never use this method, you can use {@link #removeProcessedDataVectors(ExpressionExperiment)}
+     * instead, or clear {@link ExpressionExperiment#getProcessedExpressionDataVectors()} directly. The relationship is
+     * actually managed by Hibernate.
+     */
     @Override
+    @Deprecated
     void remove( Collection<ProcessedExpressionDataVector> processedExpressionDataVectors );
 
     List<DoubleVectorValueObject> getDiffExVectors( Long resultSetId, Double threshold, int maxNumberOfResults );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/RawExpressionDataVectorService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/RawExpressionDataVectorService.java
@@ -20,6 +20,7 @@ package ubic.gemma.persistence.service.expression.bioAssayData;
 
 import org.springframework.security.access.annotation.Secured;
 import ubic.gemma.model.expression.bioAssayData.RawExpressionDataVector;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 
 import java.util.Collection;
 
@@ -28,17 +29,26 @@ import java.util.Collection;
  */
 public interface RawExpressionDataVectorService extends DesignElementDataVectorService<RawExpressionDataVector> {
 
-  
     @Override
     @Secured({ "GROUP_ADMIN" })
     RawExpressionDataVector load( Long id );
 
+    /**
+     * @deprecated never use this method, instead clear {@link ExpressionExperiment#getProcessedExpressionDataVectors()}
+     * directly. The relationship is actually managed by Hibernate.
+     */
     @Override
     @Secured({ "GROUP_ADMIN" })
+    @Deprecated
     void remove( Collection<RawExpressionDataVector> vectors );
 
+    /**
+     * @deprecated never use this method, instead clear {@link ExpressionExperiment#getProcessedExpressionDataVectors()}
+     * directly. The relationship is actually managed by Hibernate.
+     */
     @Override
     @Secured({ "GROUP_ADMIN" })
+    @Deprecated
     void remove( RawExpressionDataVector designElementDataVector );
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/designElement/CompositeSequenceDaoImpl.java
@@ -155,7 +155,7 @@ public class CompositeSequenceDaoImpl extends AbstractQueryFilteringVoEnabledDao
             compositeSequences = queryObject.list();
 
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
         return compositeSequences;
     }
@@ -173,7 +173,7 @@ public class CompositeSequenceDaoImpl extends AbstractQueryFilteringVoEnabledDao
             compositeSequences = queryObject.list();
 
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
         return compositeSequences;
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
@@ -930,10 +930,8 @@ public class ExpressionExperimentServiceImpl
         for ( RawExpressionDataVector oldV : eeToUpdate.getRawExpressionDataVectors() ) {
             qtsToRemove.add( oldV.getQuantitationType() );
         }
-        rawExpressionDataVectorDao.remove( eeToUpdate.getRawExpressionDataVectors() ); // should not be necessary
-        processedVectorService.remove( eeToUpdate.getProcessedExpressionDataVectors() ); // should not be necessary
-        eeToUpdate.getProcessedExpressionDataVectors().clear(); // this should be sufficient
-        eeToUpdate.getRawExpressionDataVectors().clear(); // should be sufficient
+        eeToUpdate.getProcessedExpressionDataVectors().clear();
+        eeToUpdate.getRawExpressionDataVectors().clear();
 
         // These QTs might still be getting used by the replaced vectors.
         for ( RawExpressionDataVector newVec : newVectors ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/FactorValueDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/FactorValueDaoImpl.java
@@ -131,7 +131,7 @@ public class FactorValueDaoImpl extends AbstractQueryFilteringVoEnabledDao<Facto
             }
             return ( FactorValue ) result;
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/GeneDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/GeneDaoImpl.java
@@ -242,7 +242,7 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
             compSeq = queryObject.list();
 
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
         return compSeq;
     }
@@ -295,7 +295,7 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                 "select count(distinct cs.arrayDesign) from Gene as gene inner join gene.products gp,  BioSequence2GeneProduct"
                         + " as bs2gp, CompositeSequence as cs where gp=bs2gp.geneProduct "
                         + " and cs.biologicalCharacteristic=bs2gp.bioSequence " + " and gene.id = :id ";
-        List r = this.getSession().createQuery( queryString ).setParameter( "id", id ).list();
+        List r = this.getSessionFactory().getCurrentSession().createQuery( queryString ).setParameter( "id", id ).list();
         return ( ( Long ) r.iterator().next() ).intValue();
 
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceDaoImpl.java
@@ -149,7 +149,7 @@ public class BioSequenceDaoImpl extends AbstractVoEnabledDao<BioSequence, BioSeq
                     .setString( "search", search ).list();
 
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/gene/GeneProductDaoImpl.java
@@ -73,7 +73,7 @@ public class GeneProductDaoImpl extends AbstractVoEnabledDao<GeneProduct, GenePr
                     .setString( "search", search ).list();
 
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 
@@ -86,7 +86,7 @@ public class GeneProductDaoImpl extends AbstractVoEnabledDao<GeneProduct, GenePr
                     .setString( "search", search ).list();
 
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 
@@ -198,7 +198,7 @@ public class GeneProductDaoImpl extends AbstractVoEnabledDao<GeneProduct, GenePr
             AbstractDao.log.debug( "Found: " + result );
             return ( GeneProduct ) result;
         } catch ( org.hibernate.HibernateException ex ) {
-            throw super.convertHibernateAccessException( ex );
+            throw getHibernateTemplate().convertHibernateAccessException( ex );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/CommonQueries.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/CommonQueries.java
@@ -18,7 +18,7 @@
  */
 package ubic.gemma.persistence.util;
 
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/gemma-core/src/main/resources/default.properties
+++ b/gemma-core/src/main/resources/default.properties
@@ -212,6 +212,10 @@ gemma.coexpressionSearch.maxGenesForQueryGenesOnly=500
 #controls the maximum number of genes that can be used for the large coexpression 'my genes only' query, that is, no 'complete the graph' operations.
 gemma.coexpressionSearch.maxGenesPerCoexLargeQuery=1000
 ############################################################
+# Configuration for the local tasks' executor (based on Spring TaskExecutor and AsyncTaskExecutor)
+gemma.localTasks.corePoolSize=1
+gemma.localTasks.maxPoolSize=16
+############################################################
 # REMOTE TASKS (JMS) CONFIGURATION
 gemma.jms.brokerURL=localhost:61616
 gemma.test.jms.brokerURL=localhost:61617

--- a/gemma-core/src/main/resources/ubic/gemma/applicationContext-serviceBeans.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/applicationContext-serviceBeans.xml
@@ -11,8 +11,10 @@
 
     <aop:aspectj-autoproxy/>
 
+    <!-- Local tasks executor -->
     <bean id="taskExecutor" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
-        <property name="maxPoolSize" value="16"/>
+        <property name="corePoolSize" value="${gemma.localTasks.corePoolSize}"/>
+        <property name="maxPoolSize" value="${gemma.localTasks.maxPoolSize}"/>
     </bean>
 
     <!-- Message source for this context, loaded from localized "messages_xx" files -->

--- a/gemma-core/src/main/resources/ubic/gemma/applicationContext-serviceBeans.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/applicationContext-serviceBeans.xml
@@ -11,6 +11,10 @@
 
     <aop:aspectj-autoproxy/>
 
+    <bean id="taskExecutor" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+        <property name="maxPoolSize" value="16"/>
+    </bean>
+
     <!-- Message source for this context, loaded from localized "messages_xx" files -->
     <bean id="messageSource" class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
         <property name="basename" value="messages"/>

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/service/CompositeSequenceGeneMapperServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/service/CompositeSequenceGeneMapperServiceTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import ubic.basecode.util.FileTools;
 import ubic.gemma.core.apps.Blat;
 import ubic.gemma.core.apps.ShellDelegatingBlat;
@@ -89,7 +89,7 @@ public class CompositeSequenceGeneMapperServiceTest extends AbstractGeoServiceTe
     private ArrayDesignSequenceProcessingService sequenceProcessingService;
 
     @Autowired
-    private TaskExecutor taskExecutor;
+    private AsyncTaskExecutor taskExecutor;
 
     @After
     public void cleanup() {

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/service/CompositeSequenceGeneMapperServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/service/CompositeSequenceGeneMapperServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import ubic.basecode.util.FileTools;
 import ubic.gemma.core.apps.Blat;
 import ubic.gemma.core.apps.ShellDelegatingBlat;
@@ -86,6 +87,9 @@ public class CompositeSequenceGeneMapperServiceTest extends AbstractGeoServiceTe
 
     @Autowired
     private ArrayDesignSequenceProcessingService sequenceProcessingService;
+
+    @Autowired
+    private TaskExecutor taskExecutor;
 
     @After
     public void cleanup() {
@@ -206,7 +210,7 @@ public class CompositeSequenceGeneMapperServiceTest extends AbstractGeoServiceTe
     }
 
     private void loadGeneData() throws Exception {
-        NcbiGeneLoader loader = new NcbiGeneLoader();
+        NcbiGeneLoader loader = new NcbiGeneLoader( taskExecutor );
         loader.setTaxonService( taxonService );
         loader.setPersisterHelper( this.persisterHelper );
 

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/association/NCBIGene2GOAssociationParserTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/association/NCBIGene2GOAssociationParserTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import org.springframework.core.task.TaskExecutor;
 import ubic.gemma.core.util.test.BaseSpringContextTest;
 import ubic.gemma.persistence.service.association.Gene2GOAssociationService;
 
@@ -42,13 +43,16 @@ public class NCBIGene2GOAssociationParserTest extends BaseSpringContextTest {
     @Autowired
     private Gene2GOAssociationService gene2GOAssociationService;
 
+    @Autowired
+    private TaskExecutor taskExecutor;
+
     /*
      * Configure parser and loader. Injecting the parser and loader with their dependencies.
      */
     @Before
     public void setup() {
         gene2GOAssociationService.removeAll();
-        gene2GOAssLoader = new NCBIGene2GOAssociationLoader();
+        gene2GOAssLoader = new NCBIGene2GOAssociationLoader( taskExecutor );
         gene2GOAssLoader.setParser( new NCBIGene2GOAssociationParser( taxonService.loadAll() ) );
         gene2GOAssLoader.setPersisterHelper( this.persisterHelper );
     }

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/association/NCBIGene2GOAssociationParserTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/association/NCBIGene2GOAssociationParserTest.java
@@ -21,8 +21,7 @@ package ubic.gemma.core.loader.association;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import ubic.gemma.core.util.test.BaseSpringContextTest;
 import ubic.gemma.persistence.service.association.Gene2GOAssociationService;
 
@@ -44,7 +43,7 @@ public class NCBIGene2GOAssociationParserTest extends BaseSpringContextTest {
     private Gene2GOAssociationService gene2GOAssociationService;
 
     @Autowired
-    private TaskExecutor taskExecutor;
+    private AsyncTaskExecutor taskExecutor;
 
     /*
      * Configure parser and loader. Injecting the parser and loader with their dependencies.
@@ -64,8 +63,8 @@ public class NCBIGene2GOAssociationParserTest extends BaseSpringContextTest {
     @Test
     public void testParseAndLoad() throws Exception {
 
-        try (InputStream is = this.getClass().getResourceAsStream( "/data/loader/association/gene2go.gz" );
-                InputStream gZipIs = new GZIPInputStream( is )) {
+        try ( InputStream is = this.getClass().getResourceAsStream( "/data/loader/association/gene2go.gz" );
+                InputStream gZipIs = new GZIPInputStream( is ) ) {
             gene2GOAssLoader.load( gZipIs );
 
             gZipIs.close();

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/genome/gene/ncbi/NCBIGeneLoadingTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/genome/gene/ncbi/NCBIGeneLoadingTest.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import ubic.basecode.util.FileTools;
 import ubic.gemma.core.genome.gene.service.GeneService;
 import ubic.gemma.core.genome.gene.service.GeneSetService;
@@ -51,6 +52,8 @@ public class NCBIGeneLoadingTest extends BaseSpringContextTest {
     private GeneSetService geneSetService;
     @Autowired
     private GeneProductService geneProductService;
+    @Autowired
+    private TaskExecutor taskExecutor;
 
     @Before
     public void setup() {
@@ -64,7 +67,7 @@ public class NCBIGeneLoadingTest extends BaseSpringContextTest {
 
     @Test
     public void testGeneLoader() throws Exception {
-        NcbiGeneLoader loader = new NcbiGeneLoader( persisterHelper );
+        NcbiGeneLoader loader = new NcbiGeneLoader( taskExecutor, persisterHelper );
         loader.setTaxonService( taxonService );
 
         String geneInfoTestFile = "/data/loader/genome/gene/gene_info.human.sample";

--- a/gemma-web/pom.xml
+++ b/gemma-web/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>gemma</artifactId>
 		<groupId>gemma</groupId>
-		<version>1.27.10</version>
+		<version>1.27.11</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gemma-web</artifactId>

--- a/gemma-web/pom.xml
+++ b/gemma-web/pom.xml
@@ -352,19 +352,13 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>
-			<version>1.1.2</version>
+			<version>1.2</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>taglibs</groupId>
-			<artifactId>standard</artifactId>
-			<version>1.1.2</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>taglibs</groupId>
-			<artifactId>request</artifactId>
-			<version>1.0.1</version>
+			<groupId>org.apache.taglibs</groupId>
+			<artifactId>taglibs-standard-impl</artifactId>
+			<version>1.2.5</version>
 			<scope>runtime</scope>
 		</dependency>
 

--- a/gemma-web/pom.xml
+++ b/gemma-web/pom.xml
@@ -22,7 +22,7 @@
 			<plugin>
 				<groupId>com.github.klieber</groupId>
 				<artifactId>phantomjs-maven-plugin</artifactId>
-				<version>0.4</version>
+				<version>0.7</version>
 				<executions>
 					<execution>
 						<phase>test-compile</phase>

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentSetController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentSetController.java
@@ -18,8 +18,8 @@
  */
 package ubic.gemma.web.controller.expression.experiment;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -179,12 +179,11 @@ public class ExpressionExperimentSetController extends BaseController {
                 .getExperimentValueObjectsInSet( groupId );
 
         if ( limit != null && limit > 0 && limit < experimentInSet.size() ) {
-            //noinspection unchecked
-            return CollectionUtils.select( experimentInSet, new Predicate() {
+            return CollectionUtils.select( experimentInSet, new Predicate<ExpressionExperimentDetailsValueObject>() {
                 int i = 0;
 
                 @Override
-                public boolean evaluate( Object object ) {
+                public boolean evaluate( ExpressionExperimentDetailsValueObject object ) {
                     return i++ < limit;
                 }
             } );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/genome/gene/GeneSetController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/genome/gene/GeneSetController.java
@@ -19,8 +19,8 @@
 package ubic.gemma.web.controller.genome.gene;
 
 import gemma.gsec.SecurityService;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -205,11 +205,11 @@ public class GeneSetController {
         Collection<GeneValueObject> genesInGroup = geneSetService.getGenesInGroup( new GeneSetValueObject( groupId ) );
 
         if ( limit != null && limit > 0 && limit < genesInGroup.size() ) {
-            return CollectionUtils.select( genesInGroup, new Predicate() {
+            return CollectionUtils.select( genesInGroup, new Predicate<GeneValueObject>() {
                 int i = 0;
 
                 @Override
-                public boolean evaluate( Object object ) {
+                public boolean evaluate( GeneValueObject object ) {
                     return i++ < limit;
                 }
             } );

--- a/gemma-web/src/main/webapp/WEB-INF/web.xml
+++ b/gemma-web/src/main/webapp/WEB-INF/web.xml
@@ -96,6 +96,8 @@
     <servlet>
         <servlet-name>gemma</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <!-- this is always after the JAWR servlets are loaded -->
+        <load-on-startup>2</load-on-startup>
     </servlet>
 
     <!-- Defines the Spring-WS MessageDispatcherServlet -->
@@ -107,6 +109,7 @@
             <param-name>transformWsdlLocations</param-name>
             <param-value>false</param-value>
         </init-param>
+        <load-on-startup>0</load-on-startup>
     </servlet>
 
     <servlet>
@@ -121,6 +124,7 @@
             <param-name>openApi.configuration.location</param-name>
             <param-value>/WEB-INF/classes/openapi-configuration.yaml</param-value>
         </init-param>
+        <load-on-startup>0</load-on-startup>
     </servlet>
 
     <servlet>

--- a/gemma-web/src/main/webapp/WEB-INF/web.xml
+++ b/gemma-web/src/main/webapp/WEB-INF/web.xml
@@ -91,9 +91,6 @@
     <listener>
         <listener-class>org.springframework.security.web.session.HttpSessionEventPublisher</listener-class>
     </listener>
-    <listener><!-- this may not be necessary, see http://ehcache.org/documentation/user-guide/shutdown -->
-        <listener-class>net.sf.ehcache.constructs.web.ShutdownListener</listener-class>
-    </listener>
 
     <!-- Dispatch Servlet Configuration -->
     <servlet>

--- a/gemma-web/src/main/webapp/WEB-INF/web.xml
+++ b/gemma-web/src/main/webapp/WEB-INF/web.xml
@@ -57,7 +57,7 @@
     <!-- Page decoration -->
     <filter>
         <filter-name>sitemesh</filter-name>
-        <filter-class>com.opensymphony.module.sitemesh.filter.PageFilter</filter-class>
+        <filter-class>com.opensymphony.sitemesh.webapp.SiteMeshFilter</filter-class>
     </filter>
 
     <!-- Spring Security -->

--- a/gemma-web/src/test/java/ubic/gemma/web/services/rest/DatasetsRestTest.java
+++ b/gemma-web/src/test/java/ubic/gemma/web/services/rest/DatasetsRestTest.java
@@ -41,7 +41,7 @@ public class DatasetsRestTest extends BaseSpringWebTest {
     @Before
     public void setUp() {
         // FIXME: this should not be necessary, but other tests are not cleaning up their fixtures
-        expressionExperimentService.remove( expressionExperimentService.loadAll() );
+        expressionExperimentService.removeAll();
         for ( int i = 0; i < 10; i++ ) {
             ees.add( this.getNewTestPersistentCompleteExpressionExperiment() );
         }

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
 		<module>gemma-web</module>
 	</modules>
 	<packaging>pom</packaging>
+	<scm>
+		<connection>scm:git:https://github.com/PavlidisLab/Gemma.git</connection>
+		<url>https://github.com/PavlidisLab/Gemma</url>
+	</scm>
 	<issueManagement>
 		<system>GitHub</system>
 		<url>https://github.com/PavlidisLab/Gemma/issues</url>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,26 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>[3.1.1,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>com.amashchenko.maven.plugin</groupId>
 				<artifactId>gitflow-maven-plugin</artifactId>
 				<version>1.16.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,14 @@
 			<artifactId>commons-collections4</artifactId>
 			<version>4.4</version>
 		</dependency>
+		<!-- We don't use this directly thus the runtime scope, but some of our dependencies (hibernate-core, velocity)
+		indirectly import a vulnerable version of this package (see CVE-2015-6420 and CVE-2017-15708) -->
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.2</version>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-configuration2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -344,9 +344,9 @@
 			<version>1.9.4</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
-			<version>3.2.2</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<version>4.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
 			<version>${jackson.version}</version>
 		</dependency>
 
-		<!-- XML and XSLT -->
+		<!-- XML, XSLT and XPath -->
 		<dependency>
 			<groupId>xml-apis</groupId>
 			<artifactId>xml-apis</artifactId>
@@ -391,6 +391,7 @@
 			<artifactId>xercesImpl</artifactId>
 			<version>2.10.0</version>
 		</dependency>
+		<!-- This is also used at runtime by taglibs-standard-impl in gemma-web -->
 		<dependency>
 			<groupId>xalan</groupId>
 			<artifactId>xalan</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<name>Gemma</name>
 	<groupId>gemma</groupId>
 	<artifactId>gemma</artifactId>
-	<version>1.27.10</version>
+	<version>1.27.11</version>
 	<inceptionYear>2005</inceptionYear>
 	<description>The Gemma Project for meta-analysis of genomics data</description>
 	<url>https://gemma.msl.ubc.ca</url>

--- a/pom.xml
+++ b/pom.xml
@@ -670,7 +670,7 @@
 		<tomcat.version>8.5.72</tomcat.version>
 		<mysql.version>8.0.28</mysql.version>
 		<lucene.version>3.6.2</lucene.version>
-		<log4j2.version>2.17.1</log4j2.version>
+		<log4j2.version>2.17.2</log4j2.version>
 		<slf4j.version>1.7.32</slf4j.version>
 		<slack.version>1.18.0</slack.version>
 	</properties>


### PR DESCRIPTION
I'll cherry-pick a couple of fixes from the development branch here.

Important stuff I want in this release:

 - fix of broken interpolation in Log4j (breaks SlackAppender)
 - 48686beb8422627f797fbe15f0710a0a6dea365b which will likely address #234 
 - b4ffe449d5483ee3989ff1c2202a03c1aec0857d which caused raw and processed data vectors to be removed twice and generating a slient issue
 - nothing touching the RESTful API for now, this is exclusive to the 1.28
 - maybe a few deprecated API usages from 240b64fc8c8e8b773eceea6a669c0ad15ca8a790 and 8cb9d5d4e296d8bc552d87fcfa94ad75b3460ca7
 - a few minor dependencies update would be welcome too