### PR TITLE
Remove HibernateDaoSupport and HibernateTemplate usages

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/persistence/persister/AbstractPersister.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/persister/AbstractPersister.java
@@ -23,10 +23,11 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.FlushMode;
+import org.hibernate.SessionFactory;
 import org.hibernate.classic.Session;
 import org.hibernate.engine.ForeignKeys;
 import org.hibernate.engine.SessionImplementor;
-import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.persistence.util.EntityUtils;
 
@@ -39,7 +40,7 @@ import java.util.HashSet;
  *
  * @author pavlidis
  */
-public abstract class AbstractPersister extends HibernateDaoSupport implements Persister {
+public abstract class AbstractPersister implements Persister {
 
     static final Log log = LogFactory.getLog( AbstractPersister.class.getName() );
     /**
@@ -50,6 +51,13 @@ public abstract class AbstractPersister extends HibernateDaoSupport implements P
      * How many times per collection to update us (at most)
      */
     private static final int COLLECTION_INFO_FREQUENCY = 10;
+
+    @Autowired
+    private SessionFactory sessionFactory;
+
+    protected SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
 
     @Override
     @Transactional

--- a/gemma-core/src/main/java/ubic/gemma/persistence/persister/PersisterHelper.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/persister/PersisterHelper.java
@@ -19,8 +19,6 @@
 package ubic.gemma.persistence.persister;
 
 import org.hibernate.FlushMode;
-import org.hibernate.SessionFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.Auditable;
@@ -36,11 +34,6 @@ import ubic.gemma.model.common.auditAndSecurity.AuditTrail;
  */
 @Service
 public class PersisterHelper extends RelationshipPersister {
-
-    @Autowired
-    public PersisterHelper( SessionFactory sessionFactory ) {
-        super.setSessionFactory( sessionFactory );
-    }
 
     @Override
     @Transactional

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/AbstractDao.java
@@ -26,7 +26,6 @@ import org.hibernate.FlushMode;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
-import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.common.Identifiable;
 
@@ -44,7 +43,7 @@ import java.util.stream.Collectors;
  */
 @Transactional
 @ParametersAreNonnullByDefault
-public abstract class AbstractDao<T extends Identifiable> extends HibernateDaoSupport implements BaseDao<T> {
+public abstract class AbstractDao<T extends Identifiable> implements BaseDao<T> {
 
     protected static final Log log = LogFactory.getLog( AbstractDao.class );
 
@@ -60,10 +59,12 @@ public abstract class AbstractDao<T extends Identifiable> extends HibernateDaoSu
 
     protected final Class<T> elementClass;
 
+    private final SessionFactory sessionFactory;
+
     private int batchSize = DEFAULT_BATCH_SIZE;
 
     protected AbstractDao( Class<T> elementClass, SessionFactory sessionFactory ) {
-        super.setSessionFactory( sessionFactory );
+        this.sessionFactory = sessionFactory;
         this.elementClass = elementClass;
     }
 
@@ -196,6 +197,10 @@ public abstract class AbstractDao<T extends Identifiable> extends HibernateDaoSu
     public T findOrCreate( T entity ) {
         T found = this.find( entity );
         return found == null ? this.create( entity ) : found;
+    }
+
+    protected SessionFactory getSessionFactory() {
+        return sessionFactory;
     }
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisDaoBase.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/AnalysisDaoBase.java
@@ -77,7 +77,9 @@ public abstract class AnalysisDaoBase<T extends Analysis> extends AbstractDao<T>
                 + " an inner join an.experimentAnalyzed ee inner join ee.bioAssays ba "
                 + "inner join ba.sampleUsed sample where sample.sourceTaxon = :taxon ";
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam( queryString, "taxon", taxon );
+        return getSessionFactory().getCurrentSession().createQuery( queryString )
+                .setParameter( "taxon", taxon )
+                .list();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/ExpressionExperimentSetDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/ExpressionExperimentSetDaoImpl.java
@@ -137,9 +137,9 @@ public class ExpressionExperimentSetDaoImpl
 
     private Collection<Long> getExperimentIdsInSet( Long setId ) {
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam(
-                "select i.id from ExpressionExperimentSet eset join eset.experiments i where eset.id = :id", "id",
-                setId );
+        return getSessionFactory().getCurrentSession().createQuery( "select i.id from ExpressionExperimentSet eset join eset.experiments i where eset.id = :id" )
+                .setParameter( "id", setId )
+                .list();
     }
 
     private void populateAnalysisInformation( Collection<ExpressionExperimentSetValueObject> vo ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.hibernate.*;
 import org.hibernate.type.DoubleType;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.orm.hibernate3.HibernateTemplate;
 import org.springframework.stereotype.Repository;
 import ubic.basecode.io.ByteArrayConverter;
 import ubic.basecode.math.distribution.Histogram;
@@ -128,12 +127,7 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         String qs = DifferentialExpressionResultDaoImpl.fetchResultsByGeneAndExperimentsQuery
                 + " and r.correctedPvalue < :threshold";
 
-        HibernateTemplate tpl = new HibernateTemplate( this.getSessionFactory() );
-        tpl.setQueryCacheRegion( "diffExResult" );
-        tpl.setCacheQueries( true );
-
         if ( limit != null ) {
-            tpl.setMaxResults( limit );
             qs += " order by r.correctedPvalue";
         }
 
@@ -143,10 +137,15 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
             return results;
         }
 
-        String[] paramNames = { "gene", "experimentsAnalyzed", "threshold" };
-        Object[] objectValues = { gene, experimentsAnalyzed, threshold };
-
-        List<?> qResult = tpl.findByNamedParam( qs, paramNames, objectValues );
+        List<?> qResult = getSessionFactory().getCurrentSession()
+                .createQuery( qs )
+                .setParameter( "gene", gene )
+                .setParameterList( "experimentsAnalyzed", experimentsAnalyzed )
+                .setParameter( "threshold", threshold )
+                .setMaxResults( limit != null ? limit : -1 )
+                .setCacheable( true )
+                .setCacheRegion( "diffExResult" )
+                .list();
 
         for ( Object o : qResult ) {
 
@@ -186,20 +185,14 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         StopWatch timer = new StopWatch();
         timer.start();
 
-        HibernateTemplate tpl = new HibernateTemplate( this.getSessionFactory() );
-        tpl.setQueryCacheRegion( "diffExResult" );
-        tpl.setCacheQueries( true );
-
-        if ( limit != null ) {
-            tpl.setMaxResults( limit );
-        }
-
-        String[] paramNames = { "experimentsAnalyzed", "threshold" };
-        Object[] objectValues = { experiments, qvalueThreshold };
-
-        List<?> qResult = tpl
-                .findByNamedParam( DifferentialExpressionResultDaoImpl.fetchResultsByExperimentsQuery, paramNames,
-                        objectValues );
+        List<?> qResult = getSessionFactory().getCurrentSession()
+                .createQuery( DifferentialExpressionResultDaoImpl.fetchResultsByExperimentsQuery )
+                .setParameterList( "experimentsAnalyzed", experiments )
+                .setParameter( "threshold", qvalueThreshold )
+                .setMaxResults( limit != null ? limit : -1 )
+                .setCacheable( true )
+                .setCacheRegion( "diffExResult" )
+                .list();
 
         for ( Object o : qResult ) {
 
@@ -229,10 +222,10 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         if ( gene == null )
             return results;
 
-        HibernateTemplate tpl = new HibernateTemplate( this.getSessionFactory() );
-        tpl.setCacheQueries( true );
-
-        List<?> qResult = tpl.findByNamedParam( DifferentialExpressionResultDaoImpl.fetchResultsByGene, "gene", gene );
+        List<?> qResult = getSessionFactory().getCurrentSession().createQuery( DifferentialExpressionResultDaoImpl.fetchResultsByGene )
+                .setParameter( "gene", gene )
+                .setCacheable( true )
+                .list();
 
         for ( Object o : qResult ) {
 
@@ -267,12 +260,11 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         StopWatch timer = new StopWatch();
         timer.start();
 
-        String[] paramNames = { "gene", "experimentsAnalyzed" };
-        Object[] objectValues = { gene, experimentsAnalyzed };
-
-        List<?> qResult = this.getHibernateTemplate()
-                .findByNamedParam( DifferentialExpressionResultDaoImpl.fetchResultsByGeneAndExperimentsQuery,
-                        paramNames, objectValues );
+        List<?> qResult = this.getSessionFactory().getCurrentSession()
+                .createQuery( DifferentialExpressionResultDaoImpl.fetchResultsByGeneAndExperimentsQuery )
+                .setParameter( "gene", gene )
+                .setParameterList( "experimentsAnalyzed", experimentsAnalyzed )
+                .list();
 
         for ( Object o : qResult ) {
 
@@ -540,29 +532,21 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         String qs = DifferentialExpressionResultDaoImpl.fetchResultsBySingleResultSetQuery
                 + " and r.correctedPvalue <= :threshold order by r.correctedPvalue";
 
-        HibernateTemplate tpl = new HibernateTemplate( this.getSessionFactory() );
-
-        if ( limit != null ) {
-            tpl.setMaxResults( limit );
-        }
-
-        String[] paramNames = { "resultsSets", "threshold" };
-        Object[] objectValues = { resultsSets, threshold };
-
-        List<?> qResult = tpl.findByNamedParam( qs, paramNames, objectValues );
+        List<?> qResult = getSessionFactory().getCurrentSession().createQuery( qs )
+                .setParameterList( "resultsSets", resultsSets )
+                .setParameter( "threshold", threshold )
+                .setMaxResults( limit != null ? limit : -1 )
+                .list();
 
         // If too few probes meet threshold, redo and just get top results.
         if ( qResult.size() < minNumberOfResults ) {
             AbstractDao.log.info( "No results met threshold, repeating to just get the top hits" );
             qs = DifferentialExpressionResultDaoImpl.fetchResultsBySingleResultSetQuery + " order by r.correctedPvalue";
-
-            tpl = new HibernateTemplate( this.getSessionFactory() );
-            tpl.setMaxResults( minNumberOfResults );
-
-            String[] paramName = { "resultsSets" };
-            Object[] objectValue = { resultsSets };
-
-            qResult = tpl.findByNamedParam( qs, paramName, objectValue );
+            qResult = getSessionFactory().getCurrentSession().createQuery( qs )
+                    .setParameterList( "resultsSets", resultsSets )
+                    .setParameter( "threshold", threshold )
+                    .setMaxResults( minNumberOfResults )
+                    .list();
         }
 
         for ( Object o : qResult ) {
@@ -603,16 +587,11 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         String qs = DifferentialExpressionResultDaoImpl.fetchResultsByResultSetQuery
                 + " and r.correctedPvalue < :threshold order by r.correctedPvalue";
 
-        HibernateTemplate tpl = new HibernateTemplate( this.getSessionFactory() );
-
-        if ( limit != null ) {
-            tpl.setMaxResults( limit );
-        }
-
-        String[] paramNames = { "resultsAnalyzed", "threshold" };
-        Object[] objectValues = { resultsAnalyzed, threshold };
-
-        List<?> qResult = tpl.findByNamedParam( qs, paramNames, objectValues );
+        List<?> qResult = getSessionFactory().getCurrentSession().createQuery( qs )
+                .setParameterList( "resultsAnalyzed", resultsAnalyzed )
+                .setParameter( "threshold", threshold )
+                .setMaxResults( limit != null ? limit : -1 )
+                .list();
 
         for ( Object o : qResult ) {
 
@@ -636,10 +615,10 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
 
     @Override
     public DifferentialExpressionAnalysis getAnalysis( ExpressionAnalysisResultSet rs ) {
-        return ( DifferentialExpressionAnalysis ) this.getHibernateTemplate()
-                .findByNamedParam( "select a from DifferentialExpressionAnalysis a join a.resultSets r where r=:r", "r",
-                        rs )
-                .iterator().next();
+        return ( DifferentialExpressionAnalysis ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct a from DifferentialExpressionAnalysis a join a.resultSets r where r=:r" )
+                .setParameter( "r", rs )
+                .uniqueResult();
     }
 
     @Override
@@ -667,10 +646,10 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
         final String queryString = "select rs.experimentalFactors, r from ExpressionAnalysisResultSet rs"
                 + " inner join rs.results r where r in (:differentialExpressionAnalysisResults)";
 
-        String[] paramNames = { "differentialExpressionAnalysisResults" };
-        Object[] objectValues = { differentialExpressionAnalysisResults };
-
-        List<?> qr = this.getHibernateTemplate().findByNamedParam( queryString, paramNames, objectValues );
+        List<?> qr = this.getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameterList( "differentialExpressionAnalysisResults", differentialExpressionAnalysisResults )
+                .list();
 
         if ( qr == null || qr.isEmpty() )
             return factorsByResult;
@@ -927,9 +906,10 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
     @Override
     public Histogram loadPvalueDistribution( Long resultSetId ) {
 
-        List<?> pvds = this.getHibernateTemplate().findByNamedParam(
-                "select rs.pvalueDistribution from ExpressionAnalysisResultSet rs where rs.id=:rsid ", "rsid",
-                resultSetId );
+        List<?> pvds = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select rs.pvalueDistribution from ExpressionAnalysisResultSet rs where rs.id=:rsid " )
+                .setParameter( "rsid", resultSetId )
+                .list();
         if ( pvds.isEmpty() ) {
             return null;
         }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/Gene2GOAssociationDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/Gene2GOAssociationDaoImpl.java
@@ -148,15 +148,16 @@ public class Gene2GOAssociationDaoImpl extends AbstractDao<Gene2GOAssociation> i
         Session session = this.getSessionFactory().getCurrentSession();
 
         while ( true ) {
-            Query q = session.createQuery( "from Gene2GOAssociationImpl" );
+            Query q = session.createQuery( "from Gene2GOAssociation" );
             q.setMaxResults( 10000 );
-            List<?> list = q.list();
+            //noinspection unchecked
+            List<Gene2GOAssociation> list = q.list();
             if ( list.isEmpty() )
                 break;
 
             total += list.size();
 
-            this.getHibernateTemplate().deleteAll( list );
+            remove( list );
             AbstractDao.log.info( "Deleted " + total + " so far..." );
         }
 
@@ -168,7 +169,7 @@ public class Gene2GOAssociationDaoImpl extends AbstractDao<Gene2GOAssociation> i
         //language=HQL
         final String queryString = "select g.id, geneAss.ontologyEntry from Gene2GOAssociationImpl as geneAss join geneAss.gene g where g.id in (:genes)";
         Map<Gene, Collection<Characteristic>> results = new HashMap<>();
-        Query query = this.getHibernateTemplate().getSessionFactory().getCurrentSession().createQuery( queryString );
+        Query query = this.getSessionFactory().getCurrentSession().createQuery( queryString );
         query.setFetchSize( batch.size() );
         query.setParameterList( "genes", giMap.keySet() );
         List<?> o = query.list();

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionQueryQueueImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/coexpression/CoexpressionQueryQueueImpl.java
@@ -19,12 +19,11 @@
 
 package ubic.gemma.persistence.service.association.coexpression;
 
-import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import ubic.gemma.model.genome.Gene;
@@ -38,7 +37,7 @@ import java.util.concurrent.BlockingQueue;
  * @author Paul
  */
 // @Repository
-class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements CoexpressionQueryQueue {
+class CoexpressionQueryQueueImpl implements CoexpressionQueryQueue, InitializingBean {
 
     private static final int QUEUE_SIZE = 1000;
     private static final Logger log = LoggerFactory.getLogger( CoexpressionQueryQueueImpl.class );
@@ -50,11 +49,6 @@ class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements Coexpres
     private GeneDao geneDao;
     @Autowired
     private TaskExecutor taskExecutor;
-
-    @Autowired
-    public CoexpressionQueryQueueImpl( SessionFactory sessionFactory ) {
-        super.setSessionFactory( sessionFactory );
-    }
 
     @Override
     public synchronized void addToFullQueryQueue( Collection<Long> geneIds ) {
@@ -87,11 +81,10 @@ class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements Coexpres
     }
 
     @Override
-    protected void initDao() throws Exception {
-        super.initDao();
+    public void afterPropertiesSet() throws Exception {
         final SecurityContext context = SecurityContextHolder.getContext();
 
-        taskExecutor.execute(new Runnable() {
+        taskExecutor.execute( new Runnable() {
 
             private final int MAX_WARNINGS = 5;
 
@@ -131,7 +124,7 @@ class CoexpressionQueryQueueImpl extends HibernateDaoSupport implements Coexpres
                 }
             }
 
-        });
+        } );
     }
 
     private void queryForCache( QueuedGene gene ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/association/phenotype/PhenotypeAssociationDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/association/phenotype/PhenotypeAssociationDaoImpl.java
@@ -21,7 +21,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.orm.hibernate3.HibernateTemplate;
 import org.springframework.stereotype.Repository;
 import ubic.basecode.ontology.model.OntologyTerm;
 import ubic.gemma.model.association.GOEvidenceCode;
@@ -393,10 +392,11 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
     @Override
     public Collection<PhenotypeAssociation> findPhenotypesForBibliographicReference( String pubMedID ) {
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam(
-                "select phe from PhenotypeAssociation as phe join phe.phenotypeAssociationPublications as pub "
-                        + "join pub.citation as c join c.pubAccession as acc where acc.accession=:pubMedID", "pubMedID",
-                pubMedID );
+        return this.getSessionFactory().getCurrentSession()
+                .createQuery( "select phe from PhenotypeAssociation as phe join phe.phenotypeAssociationPublications as pub "
+                        + "join pub.citation as c join c.pubAccession as acc where acc.accession=:pubMedID" )
+                .setParameter( "pubMedID", pubMedID )
+                .list();
     }
 
     @Override
@@ -553,7 +553,9 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
     @Override
     public Collection<String> loadAllDescription() {
         //noinspection unchecked
-        return this.getHibernateTemplate().find( "select distinct p.description from PhenotypeAssociation as p " );
+        return this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct p.description from PhenotypeAssociation as p" )
+                .list();
     }
 
     /**
@@ -610,21 +612,23 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
     @Override
     public ExternalDatabaseStatisticsValueObject loadStatisticsOnAllEvidence( String downloadFile ) {
 
-        Long numEvidence = ( Long ) this.getHibernateTemplate()
-                .find( "select count (p) from PhenotypeAssociation as p" ).iterator().next();
+        Long numEvidence = ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select count (p) from PhenotypeAssociation as p" )
+                .uniqueResult();
 
-        Long numGenes = ( Long ) this.getHibernateTemplate()
-                .find( "select count (distinct g) from Gene as g inner join g.phenotypeAssociations as p" ).iterator()
-                .next();
+        Long numGenes = ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select count (distinct g) from Gene as g inner join g.phenotypeAssociations as p" )
+                .uniqueResult();
 
-        Long numPhenotypes = ( Long ) this.getHibernateTemplate()
-                .find( "select count (distinct c.valueUri) from PhenotypeAssociation as p inner join p.phenotypes as c" )
-                .iterator().next();
+        Long numPhenotypes = ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select count (distinct c.valueUri) from PhenotypeAssociation as p inner join p.phenotypes as c" )
+                .uniqueResult();
 
         //noinspection unchecked
-        Collection<String> publications = this.getHibernateTemplate()
-                .find( "select distinct phe.citation.pubAccession.accession from PhenotypeAssociation as p"
-                        + " join p.phenotypeAssociationPublications as phe" );
+        Collection<String> publications = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct phe.citation.pubAccession.accession from PhenotypeAssociation as p"
+                        + " join p.phenotypeAssociationPublications as phe" )
+                .list();
 
         Long numPublications = ( long ) publications.size();
 
@@ -638,9 +642,10 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
         HashMap<String, ExternalDatabaseStatisticsValueObject> externalDatabasesStatistics = new HashMap<>();
 
         //noinspection unchecked
-        List<Object[]> numEvidence = this.getHibernateTemplate()
-                .find( "select p.evidenceSource.externalDatabase, count (*), p.lastUpdated from PhenotypeAssociation "
-                        + "as p group by p.evidenceSource.externalDatabase order by p.lastUpdated desc" );
+        List<Object[]> numEvidence = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select p.evidenceSource.externalDatabase, count (*), p.lastUpdated from PhenotypeAssociation "
+                        + "as p group by p.evidenceSource.externalDatabase order by p.lastUpdated desc" )
+                .list();
 
         for ( Object[] o : numEvidence ) {
 
@@ -659,9 +664,10 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
         }
 
         //noinspection unchecked
-        List<Object[]> numGenes = this.getHibernateTemplate()
-                .find( "select p.evidenceSource.externalDatabase.name, count (distinct g) from Gene as g join g.phenotypeAssociations "
-                        + "as p group by p.evidenceSource.externalDatabase" );
+        List<Object[]> numGenes = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select p.evidenceSource.externalDatabase.name, count (distinct g) from Gene as g join g.phenotypeAssociations "
+                        + "as p group by p.evidenceSource.externalDatabase" )
+                .list();
 
         for ( Object[] o : numGenes ) {
             String externalDatabaseName = ( String ) o[0];
@@ -669,10 +675,11 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
         }
 
         //noinspection unchecked
-        List<Object[]> numPhenotypes = this.getHibernateTemplate()
-                .find( "select p.evidenceSource.externalDatabase.name, count (distinct c.valueUri) "
+        List<Object[]> numPhenotypes = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select p.evidenceSource.externalDatabase.name, count (distinct c.valueUri) "
                         + "from PhenotypeAssociation as p join p.phenotypes as c "
-                        + "group by p.evidenceSource.externalDatabase" );
+                        + "group by p.evidenceSource.externalDatabase" )
+                .list();
 
         for ( Object[] o : numPhenotypes ) {
             String externalDatabaseName = ( String ) o[0];
@@ -680,10 +687,11 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
         }
 
         //noinspection unchecked
-        List<Object[]> numPublications = this.getHibernateTemplate()
-                .find( "select p.evidenceSource.externalDatabase.name, count (distinct pub.citation.pubAccession.accession) "
+        List<Object[]> numPublications = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select p.evidenceSource.externalDatabase.name, count (distinct pub.citation.pubAccession.accession) "
                         + "from PhenotypeAssociation as p join p.phenotypeAssociationPublications as pub"
-                        + " group by p.evidenceSource.externalDatabase" );
+                        + " group by p.evidenceSource.externalDatabase" )
+                .list();
 
         for ( Object[] o : numPublications ) {
             String externalDatabaseName = ( String ) o[0];
@@ -700,23 +708,23 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
     @Override
     public ExternalDatabaseStatisticsValueObject loadStatisticsOnManualCuration( String downloadFile ) {
 
-        Long numEvidence = ( Long ) this.getHibernateTemplate()
-                .find( "select count (p) from PhenotypeAssociation as p where p.evidenceSource is null" ).iterator()
-                .next();
+        Long numEvidence = ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select count (p) from PhenotypeAssociation as p where p.evidenceSource is null" )
+                .uniqueResult();
 
-        Long numGenes = ( Long ) this.getHibernateTemplate()
-                .find( "select count (distinct g) from Gene as g inner join g.phenotypeAssociations as p where p.evidenceSource is null" )
-                .iterator().next();
+        Long numGenes = ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select count (distinct g) from Gene as g inner join g.phenotypeAssociations as p where p.evidenceSource is null" )
+                .uniqueResult();
 
-        Long numPhenotypes = ( Long ) this.getHibernateTemplate()
-                .find( "select count (distinct c.valueUri) from PhenotypeAssociation as p inner join p.phenotypes as c where p.evidenceSource is null" )
-                .iterator().next();
+        Long numPhenotypes = ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select count (distinct c.valueUri) from PhenotypeAssociation as p inner join p.phenotypes as c where p.evidenceSource is null" )
+                .uniqueResult();
 
-        HibernateTemplate tpl = new HibernateTemplate( this.getSessionFactory() );
-        tpl.setMaxResults( 1 );
-
-        List<?> result = tpl.find( "select p.lastUpdated from PhenotypeAssociation as p "
-                + "where p.evidenceSource is null order by p.lastUpdated desc" );
+        List<?> result = getSessionFactory().getCurrentSession()
+                .createQuery( "select p.lastUpdated from PhenotypeAssociation as p "
+                        + "where p.evidenceSource is null order by p.lastUpdated desc" )
+                .setMaxResults( 1 )
+                .list();
 
         Date lastUpdatedDate = null;
         if ( !result.isEmpty() ) {
@@ -725,9 +733,10 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
 
         // find all secondary pubmed for ExperimentalEvidence
         //noinspection unchecked
-        Collection<String> publications = this.getHibernateTemplate()
-                .find( "select distinct pub.citation.pubAccession.accession from PhenotypeAssociation as p "
-                        + "join p.phenotypeAssociationPublications as pub where p.evidenceSource is null" );
+        Collection<String> publications = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct pub.citation.pubAccession.accession from PhenotypeAssociation as p "
+                        + "join p.phenotypeAssociationPublications as pub where p.evidenceSource is null" )
+                .list();
 
         Long numPublications = ( long ) publications.size();
 
@@ -741,8 +750,10 @@ public class PhenotypeAssociationDaoImpl extends AbstractDao<PhenotypeAssociatio
      */
     @Override
     public void removePhenotypePublication( Long phenotypeAssociationPublicationId ) {
-        this.getHibernateTemplate().bulkUpdate( "delete from PhenotypeAssociationPublicationImpl p where p.id = ?",
-                phenotypeAssociationPublicationId );
+        this.getSessionFactory().getCurrentSession()
+                .createQuery( "delete from PhenotypeAssociationPublicationImpl p where p.id = ?" )
+                .setParameter( 0, phenotypeAssociationPublicationId )
+                .executeUpdate();
     }
 
     @SuppressWarnings("ConstantConditions") // Better readability

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/AuditTrailDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/AuditTrailDaoImpl.java
@@ -73,7 +73,7 @@ public class AuditTrailDaoImpl extends AbstractDao<AuditTrail> implements AuditT
              * Note: this step should be done by the AuditAdvice when the entity was first created, so this is just
              * defensive.
              */
-            logger.warn(
+            log.warn(
                     "AuditTrail was null. It should have been initialized by the AuditAdvice when the entity was first created." );
             trail = AuditTrail.Factory.newInstance();
             auditable.setAuditTrail( trail );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/CurationDetailsDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/CurationDetailsDao.java
@@ -13,7 +13,7 @@ import ubic.gemma.persistence.service.BaseDao;
  * Interface extracted from CurationDetailsDaoImpl to satisfy spring autowiring requirements.
  */
 @Transactional
-public interface CurationDetailsDao extends InitializingBean, BaseDao<CurationDetails> {
+public interface CurationDetailsDao extends BaseDao<CurationDetails> {
     @Override
     CurationDetails load( Long id );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/UserGroupDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/auditAndSecurity/UserGroupDaoImpl.java
@@ -71,14 +71,8 @@ public class UserGroupDaoImpl extends AbstractDao<UserGroup> implements UserGrou
 
     @Override
     public void removeAuthority( UserGroup group, String authority ) {
-        for ( Iterator<gemma.gsec.model.GroupAuthority> iterator = group.getAuthorities().iterator(); iterator
-                .hasNext(); ) {
-            gemma.gsec.model.GroupAuthority ga = iterator.next();
-            if ( ga.getAuthority().equals( authority ) ) {
-                iterator.remove();
-            }
-        }
-        this.getHibernateTemplate().update( group );
+        group.getAuthorities().removeIf( ga -> ga.getAuthority().equals( authority ) );
+        this.update( group );
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/common/measurement/UnitDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/common/measurement/UnitDaoImpl.java
@@ -26,8 +26,6 @@ import ubic.gemma.model.common.measurement.Unit;
 import ubic.gemma.persistence.service.AbstractDao;
 import ubic.gemma.persistence.util.BusinessKey;
 
-import java.util.List;
-
 /**
  * <p>
  * Base Spring DAO Class: is able to create, update, remove, load, and find objects of type
@@ -47,23 +45,8 @@ public class UnitDaoImpl extends AbstractDao<Unit> implements UnitDao {
 
     @Override
     public Unit find( Unit unit ) {
-        try {
-            BusinessKey.checkValidKey( unit );
-            Criteria queryObject = BusinessKey.createQueryObject( this.getSessionFactory().getCurrentSession(), unit );
-            List<?> results = queryObject.list();
-            Object result = null;
-            if ( results != null ) {
-                if ( results.size() > 1 ) {
-                    throw new org.springframework.dao.InvalidDataAccessResourceUsageException(
-                            results.size() + " " + Unit.class.getName() + "s were found when executing query" );
-
-                } else if ( results.size() == 1 ) {
-                    result = results.iterator().next();
-                }
-            }
-            return ( Unit ) result;
-        } catch ( org.hibernate.HibernateException ex ) {
-            throw getHibernateTemplate().convertHibernateAccessException( ex );
-        }
+        BusinessKey.checkValidKey( unit );
+        Criteria queryObject = BusinessKey.createQueryObject( this.getSessionFactory().getCurrentSession(), unit );
+        return ( Unit ) queryObject.uniqueResult();
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/arrayDesign/ArrayDesignDao.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * ArrayDesignDao interface
  */
 @Repository
-public interface ArrayDesignDao extends InitializingBean, CuratableDao<ArrayDesign, ArrayDesignValueObject>,
+public interface ArrayDesignDao extends CuratableDao<ArrayDesign, ArrayDesignValueObject>,
         FilteringVoEnabledDao<ArrayDesign, ArrayDesignValueObject> {
 
     String OBJECT_ALIAS = "ad";

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssay/BioAssayDaoImpl.java
@@ -66,26 +66,9 @@ public class BioAssayDaoImpl extends AbstractVoEnabledDao<BioAssay, BioAssayValu
 
     @Override
     public BioAssay find( BioAssay bioAssay ) {
-        try {
-            Criteria queryObject = BusinessKey
-                    .createQueryObject( this.getSessionFactory().getCurrentSession(), bioAssay );
-
-            List<?> results = queryObject.list();
-            Object result = null;
-            if ( results != null ) {
-                if ( results.size() > 1 ) {
-                    throw new org.springframework.dao.InvalidDataAccessResourceUsageException(
-                            "More than one instance of '" + BioAssay.class.getName()
-                                    + "' was found when executing query" );
-
-                } else if ( results.size() == 1 ) {
-                    result = results.iterator().next();
-                }
-            }
-            return ( BioAssay ) result;
-        } catch ( org.hibernate.HibernateException ex ) {
-            throw getHibernateTemplate().convertHibernateAccessException( ex );
-        }
+        return ( BioAssay ) BusinessKey
+                .createQueryObject( this.getSessionFactory().getCurrentSession(), bioAssay )
+                .uniqueResult();
     }
 
     @Override
@@ -145,14 +128,13 @@ public class BioAssayDaoImpl extends AbstractVoEnabledDao<BioAssay, BioAssayValu
     public Collection<BioAssay> thaw( Collection<BioAssay> bioAssays ) {
         if ( bioAssays.isEmpty() )
             return bioAssays;
-        List<?> thawedBioassays = this.getHibernateTemplate().findByNamedParam(
-                "select distinct b from BioAssay b left join fetch b.arrayDesignUsed"
-                        + " left join fetch b.sampleUsed bm"
-                        + " left join bm.factorValues left join bm.bioAssaysUsedIn where b.id in (:ids) ",
-                "ids",
-                EntityUtils.getIds( bioAssays ) );
         //noinspection unchecked
-        return ( Collection<BioAssay> ) thawedBioassays;
+        return this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct b from BioAssay b left join fetch b.arrayDesignUsed"
+                        + " left join fetch b.sampleUsed bm"
+                        + " left join bm.factorValues left join bm.bioAssaysUsedIn where b.id in (:ids) " )
+                .setParameterList( "ids", EntityUtils.getIds( bioAssays ) )
+                .list();
     }
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/BioAssayDimensionDaoImpl.java
@@ -25,6 +25,7 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimensionValueObject;
@@ -119,55 +120,47 @@ public class BioAssayDimensionDaoImpl extends AbstractVoEnabledDao<BioAssayDimen
     }
 
     @Override
+    @Transactional
     public BioAssayDimension thawLite( final BioAssayDimension bioAssayDimension ) {
         if ( bioAssayDimension == null )
             return null;
         if ( bioAssayDimension.getId() == null )
             return bioAssayDimension;
-
-        this.getHibernateTemplate().execute( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
-            @Override
-            public Object doInHibernate( org.hibernate.Session session ) throws org.hibernate.HibernateException {
-                session.buildLockRequest( LockOptions.NONE ).lock( bioAssayDimension );
-                Hibernate.initialize( bioAssayDimension );
-                Hibernate.initialize( bioAssayDimension.getBioAssays() );
-                return null;
-            }
-        } );
+        Session session = getSessionFactory().getCurrentSession();
+        session.buildLockRequest( LockOptions.NONE ).lock( bioAssayDimension );
+        Hibernate.initialize( bioAssayDimension );
+        Hibernate.initialize( bioAssayDimension.getBioAssays() );
         return bioAssayDimension;
     }
 
     @Override
+    @Transactional
     public BioAssayDimension thaw( final BioAssayDimension bioAssayDimension ) {
         if ( bioAssayDimension == null )
             return null;
         if ( bioAssayDimension.getId() == null )
             return bioAssayDimension;
 
-        this.getHibernateTemplate().execute( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
-            @Override
-            public Object doInHibernate( org.hibernate.Session session ) throws org.hibernate.HibernateException {
-                session.buildLockRequest( LockOptions.NONE ).lock( bioAssayDimension );
-                Hibernate.initialize( bioAssayDimension );
-                Hibernate.initialize( bioAssayDimension.getBioAssays() );
+        Session session = getSessionFactory().getCurrentSession();
+        session.buildLockRequest( LockOptions.NONE ).lock( bioAssayDimension );
+        Hibernate.initialize( bioAssayDimension );
+        Hibernate.initialize( bioAssayDimension.getBioAssays() );
 
-                for ( BioAssay ba : bioAssayDimension.getBioAssays() ) {
-                    if ( ba != null ) {
-                        session.buildLockRequest( LockOptions.NONE ).lock( ba );
-                        Hibernate.initialize( ba );
-                        Hibernate.initialize( ba.getSampleUsed() );
-                        Hibernate.initialize( ba.getArrayDesignUsed() );
-                        Hibernate.initialize( ba.getOriginalPlatform() );
-                        BioMaterial bm = ba.getSampleUsed();
-                        session.buildLockRequest( LockOptions.NONE ).lock( bm );
-                        Hibernate.initialize( bm );
-                        Hibernate.initialize( bm.getBioAssaysUsedIn() );
-                        Hibernate.initialize( bm.getFactorValues() );
-                    }
-                }
-                return null;
+        for ( BioAssay ba : bioAssayDimension.getBioAssays() ) {
+            if ( ba != null ) {
+                session.buildLockRequest( LockOptions.NONE ).lock( ba );
+                Hibernate.initialize( ba );
+                Hibernate.initialize( ba.getSampleUsed() );
+                Hibernate.initialize( ba.getArrayDesignUsed() );
+                Hibernate.initialize( ba.getOriginalPlatform() );
+                BioMaterial bm = ba.getSampleUsed();
+                session.buildLockRequest( LockOptions.NONE ).lock( bm );
+                Hibernate.initialize( bm );
+                Hibernate.initialize( bm.getBioAssaysUsedIn() );
+                Hibernate.initialize( bm.getFactorValues() );
             }
-        } );
+        }
+
         return bioAssayDimension;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/DesignElementDataVectorDaoImpl.java
@@ -183,7 +183,7 @@ public abstract class DesignElementDataVectorDaoImpl<T extends DesignElementData
 
     @Override
     public void thaw( T designElementDataVector ) {
-        Session session = this.getHibernateTemplate().getSessionFactory().getCurrentSession();
+        Session session = this.getSessionFactory().getCurrentSession();
         BioSequence seq = designElementDataVector.getDesignElement().getBiologicalCharacteristic();
         if ( seq != null ) {
             session.buildLockRequest( LockOptions.NONE ).lock( seq );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/bioAssayData/ProcessedExpressionDataVectorDaoImpl.java
@@ -555,14 +555,20 @@ public class ProcessedExpressionDataVectorDaoImpl extends DesignElementDataVecto
     @Override
     public void removeDataForCompositeSequence( final CompositeSequence compositeSequence ) {
         final String dedvRemovalQuery = "delete ProcessedExpressionDataVector dedv where dedv.designElement = ?";
-        int deleted = this.getHibernateTemplate().bulkUpdate( dedvRemovalQuery, compositeSequence );
+        int deleted = this.getSessionFactory().getCurrentSession()
+                .createQuery( dedvRemovalQuery )
+                .setParameter( 0, compositeSequence )
+                .executeUpdate();
         AbstractDao.log.info( "Deleted: " + deleted );
     }
 
     @Override
     public void removeDataForQuantitationType( final QuantitationType quantitationType ) {
         final String dedvRemovalQuery = "delete from ProcessedExpressionDataVector as dedv where dedv.quantitationType = ?";
-        int deleted = this.getHibernateTemplate().bulkUpdate( dedvRemovalQuery, quantitationType );
+        int deleted = this.getSessionFactory().getCurrentSession()
+                .createQuery( dedvRemovalQuery )
+                .setParameter( 0, quantitationType )
+                .executeUpdate();
         AbstractDao.log.info( "Deleted " + deleted + " data vector elements" );
     }
     //

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExperimentalFactorDaoImpl.java
@@ -63,7 +63,11 @@ public class ExperimentalFactorDaoImpl extends AbstractVoEnabledDao<Experimental
 
         //language=HQL
         final String queryString = "select distinct ee from ExpressionExperiment as ee where ee.experimentalDesign = :ed";
-        List<ExpressionExperiment> results = this.getHibernateTemplate().findByNamedParam( queryString, "ed", ed );
+        //noinspection unchecked
+        List<ExpressionExperiment> results = getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameter( "ed", ed )
+                .list();
 
         if ( results.isEmpty() ) {
             log.warn( "No expression experiment for experimental design " + ed );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDao.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 @SuppressWarnings("unused") // Possible external use
 public interface ExpressionExperimentDao
-        extends InitializingBean, CuratableDao<ExpressionExperiment, ExpressionExperimentValueObject>,
+        extends CuratableDao<ExpressionExperiment, ExpressionExperimentValueObject>,
         FilteringVoEnabledDao<ExpressionExperiment, ExpressionExperimentValueObject> {
 
     String OBJECT_ALIAS = "ee";

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDaoImpl.java
@@ -264,24 +264,20 @@ public class ExpressionExperimentDaoImpl
 
         Collection<Long> eeIds;
 
-        try {
-            Session session = this.getSessionFactory().getCurrentSession();
-            org.hibernate.SQLQuery queryObject = session.createSQLQuery( queryString );
-            queryObject.setLong( "geneID", gene.getId() );
-            queryObject.setDouble( "rank", rank );
-            queryObject.addScalar( "eeID", new LongType() );
-            ScrollableResults results = queryObject.scroll();
+        Session session = this.getSessionFactory().getCurrentSession();
+        org.hibernate.SQLQuery queryObject = session.createSQLQuery( queryString );
+        queryObject.setLong( "geneID", gene.getId() );
+        queryObject.setDouble( "rank", rank );
+        queryObject.addScalar( "eeID", new LongType() );
+        ScrollableResults results = queryObject.scroll();
 
-            eeIds = new HashSet<>();
+        eeIds = new HashSet<>();
 
-            // Post Processing
-            while ( results.next() )
-                eeIds.add( results.getLong( 0 ) );
+        // Post Processing
+        while ( results.next() )
+            eeIds.add( results.getLong( 0 ) );
 
-            session.clear();
-        } catch ( org.hibernate.HibernateException ex ) {
-            throw super.getHibernateTemplate().convertHibernateAccessException( ex );
-        }
+        session.clear();
 
         return this.load( eeIds );
     }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/FactorValueDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/FactorValueDaoImpl.java
@@ -80,9 +80,10 @@ public class FactorValueDaoImpl extends AbstractQueryFilteringVoEnabledDao<Facto
             }
         }
 
-        List<?> efs = this.getHibernateTemplate()
-                .findByNamedParam( "select ef from ExperimentalFactor ef join ef.factorValues fv where fv = :fv", "fv",
-                        factorValue );
+        List<?> efs = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select ef from ExperimentalFactor ef join ef.factorValues fv where fv = :fv" )
+                .setParameter( "fv", factorValue )
+                .list();
 
         ExperimentalFactor ef = ( ExperimentalFactor ) efs.iterator().next();
         ef.getFactorValues().remove( factorValue );
@@ -108,30 +109,13 @@ public class FactorValueDaoImpl extends AbstractQueryFilteringVoEnabledDao<Facto
 
     @Override
     public FactorValue find( FactorValue factorValue ) {
-        try {
-            Criteria queryObject = this.getSessionFactory().getCurrentSession().createCriteria( FactorValue.class );
+        Criteria queryObject = this.getSessionFactory().getCurrentSession().createCriteria( FactorValue.class );
 
-            BusinessKey.checkKey( factorValue );
+        BusinessKey.checkKey( factorValue );
 
-            BusinessKey.createQueryObject( queryObject, factorValue );
+        BusinessKey.createQueryObject( queryObject, factorValue );
 
-            java.util.List<?> results = queryObject.list();
-            Object result = null;
-            if ( results != null ) {
-                if ( results.size() > 1 ) {
-                    this.debug( results );
-                    throw new org.springframework.dao.InvalidDataAccessResourceUsageException(
-                            results.size() + " instances of '" + FactorValue.class.getName()
-                                    + "' was found when executing query for " + factorValue );
-
-                } else if ( results.size() == 1 ) {
-                    result = results.iterator().next();
-                }
-            }
-            return ( FactorValue ) result;
-        } catch ( org.hibernate.HibernateException ex ) {
-            throw getHibernateTemplate().convertHibernateAccessException( ex );
-        }
+        return ( FactorValue ) queryObject.uniqueResult();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/GeneDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/GeneDaoImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import ubic.basecode.util.BatchIterator;
@@ -47,7 +48,7 @@ import java.util.*;
  * @see Gene
  */
 @Repository
-public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneValueObject> implements GeneDao {
+public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneValueObject> implements GeneDao, InitializingBean {
 
     private static final int BATCH_SIZE = 100;
     private static final int MAX_RESULTS = 100;
@@ -75,8 +76,11 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
 
         if ( source == null ) {
             //noinspection unchecked
-            genes = this.getHibernateTemplate().findByNamedParam( accessionQuery, "accession", accession );
-            if ( genes.size() == 0 ) {
+            genes = this.getSessionFactory().getCurrentSession()
+                    .createQuery( accessionQuery )
+                    .setParameter( "accession", accession )
+                    .list();
+            if ( genes.isEmpty() ) {
                 try {
                     return this.findByNcbiId( Integer.parseInt( accession ) );
                 } catch ( NumberFormatException e ) {
@@ -92,9 +96,11 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                 }
             } else {
                 //noinspection unchecked
-                genes = this.getHibernateTemplate()
-                        .findByNamedParam( externalDbQuery, new String[] { "accession", "source" },
-                                new Object[] { accession, source } );
+                genes = this.getSessionFactory().getCurrentSession()
+                        .createQuery( externalDbQuery )
+                        .setParameter( "accession", accession )
+                        .setParameter( "source", source )
+                        .list();
             }
         }
         if ( genes.size() > 0 ) {
@@ -174,9 +180,11 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
 
         for ( Collection<String> batch : new BatchIterator<>( query, GeneDaoImpl.BATCH_SIZE ) ) {
             //noinspection unchecked
-            List<Gene> results = this.getHibernateTemplate()
-                    .findByNamedParam( queryString, new String[] { "symbols", "taxonId" },
-                            new Object[] { batch, taxonId } );
+            List<Gene> results = this.getSessionFactory().getCurrentSession()
+                    .createQuery( queryString )
+                    .setParameterList( "symbols", batch )
+                    .setParameter( "taxonId", taxonId )
+                    .list();
             for ( Gene g : results ) {
                 result.put( g.getOfficialSymbol().toLowerCase(), g );
             }
@@ -192,7 +200,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
 
         for ( Collection<Integer> batch : new BatchIterator<>( ncbiIds, GeneDaoImpl.BATCH_SIZE ) ) {
             //noinspection unchecked
-            List<Gene> results = this.getHibernateTemplate().findByNamedParam( queryString, "ncbi", batch );
+            List<Gene> results = this.getSessionFactory().getCurrentSession()
+                    .createQuery( queryString )
+                    .setParameterList( "ncbi", batch )
+                    .list();
             for ( Gene g : results ) {
                 result.put( g.getNcbiGeneId(), g );
             }
@@ -220,8 +231,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                 "select count(distinct cs) from Gene as gene inner join gene.products gp,  BioSequence2GeneProduct"
                         + " as bs2gp, CompositeSequence as cs where gp=bs2gp.geneProduct "
                         + " and cs.biologicalCharacteristic=bs2gp.bioSequence " + " and gene.id = :id ";
-        List<?> r = this.getHibernateTemplate().findByNamedParam( queryString, "id", id );
-        return ( Long ) r.iterator().next();
+        return ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameter( "id", id )
+                .uniqueResult();
     }
 
     @Override
@@ -234,17 +247,12 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                         + " and cs.biologicalCharacteristic=bs2gp.bioSequence "
                         + " and gene = :gene and cs.arrayDesign = :arrayDesign ";
 
-        try {
-            org.hibernate.Query queryObject = this.getSessionFactory().getCurrentSession().createQuery( queryString );
-            queryObject.setParameter( "arrayDesign", arrayDesign );
-            queryObject.setParameter( "gene", gene );
-            //noinspection unchecked
-            compSeq = queryObject.list();
-
-        } catch ( org.hibernate.HibernateException ex ) {
-            throw getHibernateTemplate().convertHibernateAccessException( ex );
-        }
-        return compSeq;
+        //noinspection unchecked
+        return this.getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameter( "arrayDesign", arrayDesign )
+                .setParameter( "gene", gene )
+                .list();
     }
 
     /**
@@ -260,7 +268,9 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                         + " as bs2gp , CompositeSequence as cs where gp=bs2gp.geneProduct "
                         + " and cs.biologicalCharacteristic=bs2gp.bioSequence " + " and gene.id = :id ";
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam( queryString, "id", id );
+        return this.getSessionFactory().getCurrentSession().createQuery( queryString )
+                .setParameter( "id", id )
+                .list();
     }
 
     @Override
@@ -272,7 +282,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
         //language=HQL
         final String queryString = "select gene from Gene as gene where gene.taxon = :taxon ";
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam( queryString, "taxon", taxon );
+        return this.getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameter( "taxon", taxon )
+                .list();
     }
 
     @Override
@@ -285,7 +298,7 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
         final String queryString = "select gene from Gene as gene where gene.taxon = :taxon"
                 + " and (gene.description like '%micro RNA or sno RNA' OR gene.description = 'miRNA')";
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam( queryString, "taxon", taxon );
+        return this.getSessionFactory().getCurrentSession().createQuery( queryString ).setParameter( "taxon", taxon ).list();
     }
 
     @Override
@@ -295,9 +308,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                 "select count(distinct cs.arrayDesign) from Gene as gene inner join gene.products gp,  BioSequence2GeneProduct"
                         + " as bs2gp, CompositeSequence as cs where gp=bs2gp.geneProduct "
                         + " and cs.biologicalCharacteristic=bs2gp.bioSequence " + " and gene.id = :id ";
-        List r = this.getSessionFactory().getCurrentSession().createQuery( queryString ).setParameter( "id", id ).list();
-        return ( ( Long ) r.iterator().next() ).intValue();
-
+        return ( ( Long ) this.getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameter( "id", id )
+                .uniqueResult() ).intValue();
     }
 
     @Override
@@ -310,7 +324,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
         final String queryString = "select gene from Gene as gene fetch all properties where gene.taxon = :taxon";
 
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam( queryString, "taxon", taxon );
+        return getSessionFactory().getCurrentSession()
+                .createQuery( queryString )
+                .setParameter( "taxon", taxon )
+                .list();
     }
 
     @Override
@@ -351,17 +368,16 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
     public Gene thaw( final Gene gene ) {
         if ( gene.getId() == null )
             return gene;
-
-        List<?> res = this.getHibernateTemplate().findByNamedParam(
-                "select distinct g from Gene g " + " left join fetch g.aliases left join fetch g.accessions acc"
-                        + " left join fetch acc.externalDatabase left join fetch g.products gp "
-                        + " left join fetch gp.accessions gpacc left join fetch gpacc.externalDatabase left join"
-                        + " fetch gp.physicalLocation gppl left join fetch gppl.chromosome chr left join fetch chr.taxon "
-                        + " left join fetch g.taxon t left join fetch t.externalDatabase "
-                        + " left join fetch g.multifunctionality left join fetch g.phenotypeAssociations "
-                        + " where g.id=:gid", "gid", gene.getId() );
-
-        return ( Gene ) res.iterator().next();
+        return ( Gene ) this.getSessionFactory().getCurrentSession().createQuery(
+                        "select distinct g from Gene g " + " left join fetch g.aliases left join fetch g.accessions acc"
+                                + " left join fetch acc.externalDatabase left join fetch g.products gp "
+                                + " left join fetch gp.accessions gpacc left join fetch gpacc.externalDatabase left join"
+                                + " fetch gp.physicalLocation gppl left join fetch gppl.chromosome chr left join fetch chr.taxon "
+                                + " left join fetch g.taxon t left join fetch t.externalDatabase "
+                                + " left join fetch g.multifunctionality left join fetch g.phenotypeAssociations "
+                                + " where g.id=:gid" )
+                .setParameter( "gid", gene.getId() )
+                .uniqueResult();
     }
 
     /**
@@ -371,11 +387,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
     public Gene thawAliases( final Gene gene ) {
         if ( gene.getId() == null )
             return gene;
-
-        List<?> res = this.getHibernateTemplate().findByNamedParam( "select distinct g from Gene g "
-                + "left join fetch g.aliases left join fetch g.accessions acc where g.id=:gid", "gid", gene.getId() );
-
-        return ( Gene ) res.iterator().next();
+        return ( Gene ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct g from Gene g left join fetch g.aliases left join fetch g.accessions acc where g.id=:gid" )
+                .setParameter( "gid", gene.getId() )
+                .uniqueResult();
     }
 
     @Override
@@ -411,11 +426,10 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
         if ( gene.getId() == null )
             return gene;
 
-        List<?> res = this.getHibernateTemplate()
-                .findByNamedParam( "select distinct g from Gene g " + " left join fetch g.taxon" + " where g.id=:gid",
-                        "gid", gene.getId() );
-
-        return ( Gene ) res.iterator().next();
+        return ( Gene ) this.getSessionFactory().getCurrentSession()
+                .createQuery( "select distinct g from Gene g left join fetch g.taxon where g.id=:gid" )
+                .setParameter( "gid", gene.getId() )
+                .uniqueResult();
     }
 
     @Override
@@ -433,9 +447,12 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
         Collection<Gene> genes = new HashSet<>();
 
         BatchIterator<Long> it = BatchIterator.batches( ids, batchSize );
-        for ( ; it.hasNext(); ) {
+        while ( it.hasNext() ) {
             //noinspection unchecked
-            genes.addAll( this.getHibernateTemplate().findByNamedParam( queryString, "ids", it.next() ) );
+            genes.addAll( this.getSessionFactory().getCurrentSession()
+                    .createQuery( queryString )
+                    .setParameterList( "ids", it.next() )
+                    .list() );
         }
 
         if ( ids.size() > batchSize ) {
@@ -450,12 +467,15 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
         if ( gene == null ) {
             throw new IllegalArgumentException( "Gene.remove - 'gene' can not be null" );
         }
+
         // remove associations
-        List<?> associations = this.getHibernateTemplate().findByNamedParam(
-                "select ba from BioSequence2GeneProduct ba join ba.geneProduct gp join gp.gene g where g=:g ", "g",
-                gene );
-        if ( !associations.isEmpty() )
-            this.getHibernateTemplate().deleteAll( associations );
+        List<?> associations = this.getSessionFactory().getCurrentSession()
+                .createQuery( "select ba from BioSequence2GeneProduct ba join ba.geneProduct gp join gp.gene g where g=:g" )
+                .setParameter( "g", gene )
+                .list();
+        for ( Object association : associations ) {
+            getSessionFactory().getCurrentSession().delete( association );
+        }
 
         super.remove( gene );
     }
@@ -551,7 +571,7 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
     }
 
     @Override
-    protected void initDao() {
+    public void afterPropertiesSet() {
         CacheUtils.createOrLoadCache( cacheManager, GeneDaoImpl.G2CS_CACHE_NAME, 500000, false,
                 false, 0, 0 );
     }
@@ -603,17 +623,18 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
 
     private Collection<Gene> doLoadThawedLite( Collection<Long> ids ) {
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam(
+        return this.getSessionFactory().getCurrentSession().createQuery(
                 "select g from Gene g left join fetch g.aliases left join fetch g.accessions acc "
                         + "join fetch g.taxon t left join fetch g.products gp left join fetch g.multifunctionality "
-                        + "where g.id in (:gIds)", "gIds", ids );
+                        + "where g.id in (:gIds)" ).setParameterList( "gIds", ids ).list();
     }
 
     private Collection<Gene> doLoadThawedLiter( Collection<Long> ids ) {
         //noinspection unchecked
-        return this.getHibernateTemplate()
-                .findByNamedParam( "select g from Gene g join fetch g.taxon t " + "where g.id in (:gIds)", "gIds",
-                        ids );
+        return this.getSessionFactory().getCurrentSession()
+                .createQuery( "select g from Gene g join fetch g.taxon t where g.id in (:gIds)" )
+                .setParameterList( "gIds", ids )
+                .list();
     }
 
     /**
@@ -633,18 +654,22 @@ public class GeneDaoImpl extends AbstractQueryFilteringVoEnabledDao<Gene, GeneVa
                 + "and pl.chromosome = :chromosome and " + SequenceBinUtils.addBinToQuery( "pl", targetStart,
                 targetEnd );
 
-        String[] params;
-        Object[] vals;
         if ( strand != null ) {
-            query = query + " and pl.strand = :strand ";
-            params = new String[] { "chromosome", "start", "end", "strand" };
-            vals = new Object[] { chromosome, targetStart, targetEnd, strand };
+            //noinspection unchecked
+            return getSessionFactory().getCurrentSession().createQuery( query + " and pl.strand = :strand" )
+                    .setParameter( "chromosome", chromosome )
+                    .setParameter( "start", targetStart )
+                    .setParameter( "end", targetEnd )
+                    .setParameter( "strand", strand )
+                    .list();
         } else {
-            params = new String[] { "chromosome", "start", "end" };
-            vals = new Object[] { chromosome, targetStart, targetEnd };
+            //noinspection unchecked
+            return getSessionFactory().getCurrentSession().createQuery( query )
+                    .setParameter( "chromosome", chromosome )
+                    .setParameter( "start", targetStart )
+                    .setParameter( "end", targetEnd )
+                    .list();
         }
-        //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam( query, params, vals );
     }
 
     private void debug( List<Gene> results ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/biosequence/BioSequenceDaoImpl.java
@@ -141,16 +141,11 @@ public class BioSequenceDaoImpl extends AbstractVoEnabledDao<BioSequence, BioSeq
 
     @Override
     public Collection<Gene> getGenesByName( String search ) {
-        try {
-            //noinspection unchecked
-            return this.getSessionFactory().getCurrentSession().createQuery(
-                    "select distinct gene from Gene as gene inner join gene.products gp,  BioSequence2GeneProduct as bs2gp where gp=bs2gp.geneProduct "
-                            + " and bs2gp.bioSequence.name like :search " )
-                    .setString( "search", search ).list();
-
-        } catch ( org.hibernate.HibernateException ex ) {
-            throw getHibernateTemplate().convertHibernateAccessException( ex );
-        }
+        //noinspection unchecked
+        return this.getSessionFactory().getCurrentSession().createQuery(
+                        "select distinct gene from Gene as gene inner join gene.products gp,  BioSequence2GeneProduct as bs2gp where gp=bs2gp.geneProduct "
+                                + " and bs2gp.bioSequence.name like :search " )
+                .setString( "search", search ).list();
     }
 
     @Override
@@ -183,15 +178,14 @@ public class BioSequenceDaoImpl extends AbstractVoEnabledDao<BioSequence, BioSeq
         if ( bioSequence.getId() == null )
             return bioSequence;
 
-        List<?> res = this.getHibernateTemplate().findByNamedParam( "select b from BioSequence b "
-                + " left join fetch b.taxon tax left join fetch tax.externalDatabase "
-                + " left join fetch b.sequenceDatabaseEntry s left join fetch s.externalDatabase"
-                + " left join fetch b.bioSequence2GeneProduct bs2gp "
-                + " left join fetch bs2gp.geneProduct gp left join fetch gp.gene g"
-                + " left join fetch g.aliases left join fetch g.accessions  where b.id=:bid", "bid",
-                bioSequence.getId() );
-
-        return ( BioSequence ) res.iterator().next();
+        return ( BioSequence ) getSessionFactory().getCurrentSession().createQuery( "select b from BioSequence b "
+                        + " left join fetch b.taxon tax left join fetch tax.externalDatabase "
+                        + " left join fetch b.sequenceDatabaseEntry s left join fetch s.externalDatabase"
+                        + " left join fetch b.bioSequence2GeneProduct bs2gp "
+                        + " left join fetch bs2gp.geneProduct gp left join fetch gp.gene g"
+                        + " left join fetch g.aliases left join fetch g.accessions  where b.id=:bid" )
+                .setParameter( "bid", bioSequence.getId() )
+                .uniqueResult();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatAssociationDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatAssociationDaoImpl.java
@@ -23,10 +23,11 @@ import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.LockOptions;
 import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
 import org.hibernate.criterion.Restrictions;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.orm.hibernate3.HibernateTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.gene.GeneProduct;
@@ -95,40 +96,28 @@ public class BlatAssociationDaoImpl extends AbstractDao<BlatAssociation> impleme
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void thaw( final Collection<BlatAssociation> blatAssociations ) {
         if ( blatAssociations == null )
             return;
-        HibernateTemplate templ = this.getHibernateTemplate();
-        templ.executeWithNativeSession( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
-            @Override
-            public Object doInHibernate( org.hibernate.Session session ) throws org.hibernate.HibernateException {
-                for ( Object object : blatAssociations ) {
-                    BlatAssociation blatAssociation = ( BlatAssociation ) object;
-                    if ( ( blatAssociation ).getId() == null )
-                        continue;
-                    BlatAssociationDaoImpl.this.thawBlatAssociation( session, blatAssociation );
-                    session.evict( blatAssociation );
-                }
-                return null;
-            }
-
-        } );
+        for ( BlatAssociation blatAssociation : blatAssociations ) {
+            this.thaw( blatAssociation );
+        }
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void thaw( final BlatAssociation blatAssociation ) {
         if ( blatAssociation == null )
             return;
         if ( blatAssociation.getId() == null )
             return;
-        HibernateTemplate templ = this.getHibernateTemplate();
-        templ.executeWithNativeSession( new org.springframework.orm.hibernate3.HibernateCallback<Object>() {
-            @Override
-            public Object doInHibernate( org.hibernate.Session session ) throws org.hibernate.HibernateException {
-                BlatAssociationDaoImpl.this.thawBlatAssociation( session, blatAssociation );
-                return null;
-            }
-        } );
+        Session session = getSessionFactory().getCurrentSession();
+        session.buildLockRequest( LockOptions.NONE ).lock( blatAssociation );
+        Hibernate.initialize( blatAssociation.getBioSequence() );
+        Hibernate.initialize( blatAssociation.getGeneProduct() );
+        Hibernate.initialize( blatAssociation.getBlatResult() );
+        Hibernate.initialize( blatAssociation.getBlatResult().getTargetChromosome() );
     }
 
     @Override
@@ -139,14 +128,6 @@ public class BlatAssociationDaoImpl extends AbstractDao<BlatAssociation> impleme
                 this.getSessionFactory().getCurrentSession()
                         .createQuery( "select b from BlatAssociation b join b.geneProduct gp where gp in (:gps)" )
                         .setParameterList( "gps", gps ).list();
-    }
-
-    private void thawBlatAssociation( org.hibernate.Session session, BlatAssociation blatAssociation ) {
-        session.buildLockRequest( LockOptions.NONE ).lock( blatAssociation );
-        Hibernate.initialize( blatAssociation.getBioSequence() );
-        Hibernate.initialize( blatAssociation.getGeneProduct() );
-        Hibernate.initialize( blatAssociation.getBlatResult() );
-        Hibernate.initialize( blatAssociation.getBlatResult().getTargetChromosome() );
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/genome/sequenceAnalysis/BlatResultDaoImpl.java
@@ -69,13 +69,14 @@ public class BlatResultDaoImpl extends AbstractVoEnabledDao<BlatResult, BlatResu
     public BlatResult thaw( BlatResult blatResult ) {
         if ( blatResult.getId() == null )
             return blatResult;
-        return ( BlatResult ) this.getHibernateTemplate().findByNamedParam(
-                "select b from BlatResult b left join fetch b.querySequence qs left join fetch b.targetSequence ts  "
-                        + " left join fetch b.searchedDatabase left join fetch b.targetChromosome tc left join fetch tc.taxon left join fetch tc.sequence"
-                        + " left join fetch qs.taxon t "
-                        + " left join fetch t.externalDatabase left join fetch qs.sequenceDatabaseEntry s "
-                        + " left join fetch s.externalDatabase" + " where b.id = :id", "id", blatResult.getId() )
-                .iterator().next();
+        return ( BlatResult ) this.getSessionFactory().getCurrentSession().createQuery(
+                        "select b from BlatResult b left join fetch b.querySequence qs left join fetch b.targetSequence ts  "
+                                + " left join fetch b.searchedDatabase left join fetch b.targetChromosome tc left join fetch tc.taxon left join fetch tc.sequence"
+                                + " left join fetch qs.taxon t "
+                                + " left join fetch t.externalDatabase left join fetch qs.sequenceDatabaseEntry s "
+                                + " left join fetch s.externalDatabase" + " where b.id = :id" )
+                .setParameter( "id", blatResult.getId() )
+                .uniqueResult();
     }
 
     @Override
@@ -83,13 +84,14 @@ public class BlatResultDaoImpl extends AbstractVoEnabledDao<BlatResult, BlatResu
         if ( blatResults.isEmpty() )
             return blatResults;
         //noinspection unchecked
-        return this.getHibernateTemplate().findByNamedParam(
-                "select distinct b from BlatResult b left join fetch b.querySequence qs left join fetch b.targetSequence ts  "
-                        + " left join fetch b.searchedDatabase left join fetch b.targetChromosome tc left join tc.taxon left join fetch tc.sequence"
-                        + " left join fetch qs.taxon t "
-                        + " left join fetch t.externalDatabase left join fetch qs.sequenceDatabaseEntry s "
-                        + " left join fetch s.externalDatabase" + " where b.id in ( :ids)", "ids",
-                EntityUtils.getIds( blatResults ) );
+        return this.getSessionFactory().getCurrentSession().createQuery(
+                        "select distinct b from BlatResult b left join fetch b.querySequence qs left join fetch b.targetSequence ts  "
+                                + " left join fetch b.searchedDatabase left join fetch b.targetChromosome tc left join tc.taxon left join fetch tc.sequence"
+                                + " left join fetch qs.taxon t "
+                                + " left join fetch t.externalDatabase left join fetch qs.sequenceDatabaseEntry s "
+                                + " left join fetch s.externalDatabase" + " where b.id in ( :ids)" )
+                .setParameter( "ids", EntityUtils.getIds( blatResults ) )
+                .list();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This is a prerequisite to #116 

All API usages from `org.springframework.orm.hibernate3.*` have been removed except for the context configuration and model definitions.

- [ ] verify if exception translation works, since we don't want to deal with Hibernate-specific exceptions in the code (needs some unit tests!)
- [ ] ensure that all DAO are annotated with `@Repository`
- [ ] replace Hibernate-specific exception handling in code with DataAccessException hierarchy

Reference: https://stackoverflow.com/questions/41801512/spring-how-exception-translation-works