### PR TITLE
add basic support for tracking gene type (not exposed anywhere)

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneConverter.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/NcbiGeneConverter.java
@@ -109,6 +109,7 @@ public class NcbiGeneConverter implements Converter<Object, Object> {
         gene.setOfficialSymbol( info.getDefaultSymbol() );
         gene.setOfficialName( info.getDescription() );
         gene.setEnsemblId( info.getEnsemblId() );
+        gene.setType(info.getGeneType().toString());
 
         /*
          * NOTE we allow multiple discontinued or previous ids, separated by commas. This is a hack to account for cases

--- a/gemma-core/src/main/java/ubic/gemma/model/genome/Gene.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/genome/Gene.java
@@ -18,6 +18,7 @@
  */
 package ubic.gemma.model.genome;
 
+import ubic.gemma.core.loader.genome.gene.ncbi.model.NCBIGeneInfo;
 import ubic.gemma.model.association.phenotype.PhenotypeAssociation;
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.genome.gene.GeneAlias;
@@ -47,11 +48,20 @@ public class Gene extends ChromosomeFeature {
     private Set<DatabaseEntry> accessions = new HashSet<>();
     private Multifunctionality multifunctionality;
     private Set<PhenotypeAssociation> phenotypeAssociations = new HashSet<>();
+    private NCBIGeneInfo.GeneType type;
 
     /**
      * No-arg constructor added to satisfy javabean contract
      */
     public Gene() {
+    }
+
+    public String getType() {
+        return type.toString();
+    }
+
+    public void setType( String type ) {
+        this.type = NCBIGeneInfo.typeStringToGeneType( type );
     }
 
     @Override

--- a/gemma-core/src/main/resources/ubic/gemma/model/genome/ChromosomeFeature.hbm.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/model/genome/ChromosomeFeature.hbm.xml
@@ -64,6 +64,10 @@
                 <column name="ENSEMBL_ID" not-null="false" unique="false"
                         sql-type="VARCHAR(255)"/>
             </property>
+            <property name="type" type="java.lang.String">
+                <column name="TYPE" not-null="false" unique="false"
+                        sql-type="VARCHAR(255)"/>
+            </property>
             <set name="products" lazy="true" fetch="select" inverse="true" cascade="all">
                 <cache usage="read-write"/>
                 <key foreign-key="GENE_PRODUCT_GENE_FKC">

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/genome/gene/ncbi/NCBIGeneParserTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/genome/gene/ncbi/NCBIGeneParserTest.java
@@ -20,6 +20,7 @@ package ubic.gemma.core.loader.genome.gene.ncbi;
 
 import junit.framework.TestCase;
 import org.springframework.core.io.ClassPathResource;
+import ubic.gemma.core.loader.genome.gene.ncbi.model.NCBIGeneInfo;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -45,6 +46,8 @@ public class NCBIGeneParserTest extends TestCase {
         ncbiGeneInfoParser.setFilter( false );
         ncbiGeneInfoParser.parse( is );
         TestCase.assertEquals( 99, ncbiGeneInfoParser.getResults().size() );
+        NCBIGeneInfo n = ncbiGeneInfoParser.getResults().iterator().next();
+        assertNotNull( n.getGeneType() );
     }
 
 }


### PR DESCRIPTION
As per #64

This should be added as a field to the API and probably displayed on the UI.

Consider making more human-readable but not important.