### PR TITLE
Store additional metadata for ExpressionExperiment and BioAssay in the database

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
+++ b/gemma-cli/src/main/java/ubic/gemma/core/apps/RNASeqDataAddCli.java
@@ -29,8 +29,10 @@ import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Designed to add count and/or RPKM data to a data set that has only meta-data.
@@ -50,6 +52,7 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
     private Integer readLength = null;
     private String rpkmFile = null;
     private boolean justbackfillLog2cpm = false;
+    private File[] additionalMetadata;
 
     @Override
     public CommandGroup getCommandGroup() {
@@ -70,6 +73,10 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
 
         options.addOption( "log2cpm", "Just compute log2cpm from the existing stored count data (backfill); batchmode OK, no other options needed" );
 
+        options.addOption( Option.builder( "am" )
+                .longOpt( "additional-metadata" )
+                .type( File.class )
+                .build() );
     }
 
     @Override
@@ -191,6 +198,8 @@ public class RNASeqDataAddCli extends ExpressionExperimentManipulatingCLI {
 
             serv.addCountData( ee, targetArrayDesign, countMatrix, rpkmMatrix, readLength, isPairedReads,
                     allowMissingSamples );
+
+            serv.addAdditionalMetadata( ee, additionalMetadata, Collections.emptyMap() );
 
         } catch ( IOException e ) {
             throw new Exception( "Failed while processing " + ee, e );

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/DataUpdater.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/DataUpdater.java
@@ -4,9 +4,12 @@ import ubic.basecode.dataStructure.matrix.DoubleMatrix;
 import ubic.gemma.core.datastructure.matrix.ExpressionDataDoubleMatrix;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
+import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 public interface DataUpdater {
     void addAffyDataFromAPTOutput( ExpressionExperiment ee, String pathToAptOutputFile ) throws IOException;
@@ -26,4 +29,6 @@ public interface DataUpdater {
 
     ExpressionExperiment replaceData( ExpressionExperiment ee, ArrayDesign targetPlatform,
             ExpressionDataDoubleMatrix data );
+
+    void addAdditionalMetadata( ExpressionExperiment ee, File[] additionalMetadata, Map<BioAssay, File[]> additionalMetadataPerBioAssay );
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/AdditionalMetadata.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/AdditionalMetadata.java
@@ -1,0 +1,26 @@
+package ubic.gemma.model.expression;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import ubic.gemma.model.common.Describable;
+import ubic.gemma.model.expression.bioAssay.BioAssay;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.model.expression.experiment.MetadataType;
+
+import java.sql.Blob;
+
+/**
+ * Metadata associated to an {@link ExpressionExperiment} or {@link BioAssay}.
+ * @author poirigui
+ */
+@Data
+@EqualsAndHashCode(of = { "id" })
+public class AdditionalMetadata implements Describable {
+
+    private Long id;
+    private String name;
+    private String description;
+    private MetadataType type;
+    private Blob contents;
+    private String mediaType;
+}

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/bioAssay/BioAssay.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/bioAssay/BioAssay.java
@@ -23,10 +23,13 @@ import ubic.gemma.model.common.AbstractDescribable;
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.biomaterial.BioMaterial;
+import ubic.gemma.model.expression.AdditionalMetadata;
 
 import javax.persistence.Transient;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents the bringing together of a biomaterial with an assay of some sort (typically an expression assay). We
@@ -59,6 +62,8 @@ public class BioAssay extends AbstractDescribable implements gemma.gsec.model.Se
      * this string will contain multiple newline-delimited headers.
      */
     private String fastqHeaders;
+
+    private Set<AdditionalMetadata> additionalMetadata = new HashSet<>();
 
     @Override
     public int hashCode() {
@@ -213,6 +218,14 @@ public class BioAssay extends AbstractDescribable implements gemma.gsec.model.Se
 
     public void setFastqHeaders( String fastqHeaders ) {
         this.fastqHeaders = fastqHeaders;
+    }
+
+    public Set<AdditionalMetadata> getAdditionalMetadata() {
+        return additionalMetadata;
+    }
+
+    public void setAdditionalMetadata( Set<AdditionalMetadata> additionalMetadata ) {
+        this.additionalMetadata = additionalMetadata;
     }
 
     public static final class Factory {

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperiment.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExpressionExperiment.java
@@ -14,7 +14,6 @@
  */
 package ubic.gemma.model.expression.experiment;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,6 +25,7 @@ import ubic.gemma.model.common.auditAndSecurity.curation.Curatable;
 import ubic.gemma.model.common.auditAndSecurity.curation.CurationDetails;
 import ubic.gemma.model.common.description.Characteristic;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
+import ubic.gemma.model.expression.AdditionalMetadata;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.bioAssayData.MeanVarianceRelation;
 import ubic.gemma.model.expression.bioAssayData.ProcessedExpressionDataVector;
@@ -80,6 +80,11 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
     private String source;
 
     private Set<Characteristic> allCharacteristics;
+
+    /**
+     * A collection of additional metadata blobs.
+     */
+    private Set<AdditionalMetadata> additionalMetadata = new HashSet<>();
 
     @Override
     public ExpressionExperimentValueObject createValueObject() {
@@ -278,6 +283,14 @@ public class ExpressionExperiment extends BioAssaySet implements SecuredNotChild
 
     public void setTaxon( Taxon taxon ) {
         this.taxon = taxon;
+    }
+
+    public Set<AdditionalMetadata> getAdditionalMetadata() {
+        return additionalMetadata;
+    }
+
+    public void setAdditionalMetadata( Set<AdditionalMetadata> additionalMetadata ) {
+        this.additionalMetadata = additionalMetadata;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/MetadataType.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/MetadataType.java
@@ -1,0 +1,24 @@
+package ubic.gemma.model.expression.experiment;
+
+import ubic.gemma.model.expression.bioAssay.BioAssay;
+
+public enum MetadataType {
+    /**
+     * A sequencing QC report.
+     * <p>
+     * Example: a FastQC report attached to a specific {@link BioAssay}.
+     */
+    SEQUENCING_QC_REPORT,
+    /**
+     * A sequencing alignment report.
+     * <p>
+     * Example: STAR's Log.final.out file on a {@link BioAssay}
+     */
+    SEQUENCING_ALIGNMENT_REPORT,
+    /**
+     * An overall sequencing report.
+     * <p>
+     * Example: a MultiQC report on a {@link ExpressionExperiment}
+     */
+    SEQUENCING_OVERALL_REPORT,
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDao.java
@@ -7,6 +7,7 @@ import ubic.gemma.model.common.description.AnnotationValueObject;
 import ubic.gemma.model.common.description.Characteristic;
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
+import ubic.gemma.model.expression.AdditionalMetadata;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
@@ -18,11 +19,13 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.BrowsingDao;
 import ubic.gemma.persistence.service.FilteringVoEnabledDao;
 import ubic.gemma.persistence.service.common.auditAndSecurity.curation.CuratableDao;
+import ubic.gemma.persistence.service.expression.bioAssay.BioAssayDao;
 import ubic.gemma.persistence.util.Filters;
 import ubic.gemma.persistence.util.Slice;
 import ubic.gemma.persistence.util.Sort;
 
 import javax.annotation.Nullable;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -232,4 +235,17 @@ public interface ExpressionExperimentDao
     long countTroubledPlatforms( ExpressionExperiment ee );
 
     MeanVarianceRelation updateMeanVarianceRelation( ExpressionExperiment ee, MeanVarianceRelation mvr );
+
+    /**
+     * Add metadata on a given dataset.
+     */
+    AdditionalMetadata addAdditionalMetadata( ExpressionExperiment ee, MetadataType type, InputStream additionalMetadata, long length, String mediaType );
+
+    /**
+     * Add metadata on a specific bioassay.
+     * <p>
+     * FIXME: this should probably be relocated in {@link BioAssayDao}.
+     * @throws IllegalArgumentException if the bioassay does not belong to the expression experiment
+     */
+    AdditionalMetadata addAdditionalMetadata( ExpressionExperiment ee, BioAssay sample, MetadataType metadataType, InputStream stream, long length, String mediaType ) throws IllegalArgumentException;
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentService.java
@@ -31,6 +31,7 @@ import ubic.gemma.model.common.description.Characteristic;
 import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
 import ubic.gemma.model.common.quantitationtype.QuantitationTypeValueObject;
+import ubic.gemma.model.expression.AdditionalMetadata;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.bioAssayData.BioAssayDimension;
@@ -48,6 +49,7 @@ import ubic.gemma.persistence.util.Sort;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.*;
 
 /**
@@ -627,4 +629,10 @@ public interface ExpressionExperimentService
 
     @Secured({ "GROUP_USER" })
     MeanVarianceRelation updateMeanVarianceRelation( ExpressionExperiment ee, MeanVarianceRelation mvr );
+
+    @Secured({ "GROUP_USER" })
+    AdditionalMetadata addAdditionalMetadata( ExpressionExperiment ee, MetadataType type, File additionalMetadata, String mediaType );
+
+    @Secured({ "GROUP_USER" })
+    AdditionalMetadata addAdditionalMetadata( ExpressionExperiment ee, BioAssay sample, MetadataType metadataType, File additionalMetadata, String textPlainValue );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
@@ -53,6 +53,7 @@ import ubic.gemma.model.common.description.DatabaseEntry;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
 import ubic.gemma.model.common.quantitationtype.QuantitationTypeValueObject;
 import ubic.gemma.model.common.search.SearchSettings;
+import ubic.gemma.model.expression.AdditionalMetadata;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.arrayDesign.TechnologyType;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
@@ -78,6 +79,7 @@ import ubic.gemma.persistence.util.Slice;
 import ubic.gemma.persistence.util.Sort;
 
 import javax.annotation.Nullable;
+import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -591,6 +593,26 @@ public class ExpressionExperimentServiceImpl
             impliedTermsUrisBySubClause.clear();
         }
         return f2;
+    }
+
+    @Override
+    @Transactional
+    public AdditionalMetadata addAdditionalMetadata( ExpressionExperiment ee, MetadataType type, File additionalMetadata, String mediaType ) {
+        try ( InputStream stream = new FileInputStream( additionalMetadata ) ) {
+            return expressionExperimentDao.addAdditionalMetadata( ee, type, stream, additionalMetadata.length(), mediaType );
+        } catch ( IOException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    @Transactional
+    public AdditionalMetadata addAdditionalMetadata( ExpressionExperiment ee, BioAssay sample, MetadataType metadataType, File additionalMetadata, String mediaType ) {
+        try ( InputStream stream = new FileInputStream( additionalMetadata ) ) {
+            return expressionExperimentDao.addAdditionalMetadata( ee, sample, metadataType, stream, additionalMetadata.length(), mediaType );
+        } catch ( IOException e ) {
+            throw new RuntimeException( e );
+        }
     }
 
     @Override

--- a/gemma-core/src/main/resources/hibernate.cfg.xml
+++ b/gemma-core/src/main/resources/hibernate.cfg.xml
@@ -58,6 +58,7 @@
         <mapping resource="ubic/gemma/model/common/measurement/Unit.hbm.xml"/>
         <mapping resource="ubic/gemma/model/common/protocol/Protocol.hbm.xml"/>
         <mapping resource="ubic/gemma/model/common/quantitationtype/QuantitationType.hbm.xml"/>
+        <mapping resource="ubic/gemma/model/expression/AdditionalMetadata.hbm.xml"/>
         <mapping resource="ubic/gemma/model/expression/arrayDesign/AlternateName.hbm.xml"/>
         <mapping resource="ubic/gemma/model/expression/arrayDesign/ArrayDesign.hbm.xml"/>
         <mapping resource="ubic/gemma/model/expression/bioAssay/BioAssay.hbm.xml"/>

--- a/gemma-core/src/main/resources/ubic/gemma/model/analysis/Investigation.hbm.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/model/analysis/Investigation.hbm.xml
@@ -155,6 +155,13 @@
 					</many-to-many>
 				</set>
 
+				<set name="additionalMetadata" cascade="all-delete-orphan">
+					<key foreign-key="EXPRESSION_EXPERIMENT_FKC">
+						<column name="EXPRESSION_EXPERIMENT_FK" sql-type="BIGINT"/>
+					</key>
+					<one-to-many class="ubic.gemma.model.expression.AdditionalMetadata"/>
+				</set>
+
 			</subclass>
 			<subclass name="ubic.gemma.model.expression.experiment.ExpressionExperimentSubSet"
 					  discriminator-value="ExpressionExperimentSubSet" abstract="false">

--- a/gemma-core/src/main/resources/ubic/gemma/model/expression/AdditionalMetadata.hbm.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/model/expression/AdditionalMetadata.hbm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+    "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+    <class name="ubic.gemma.model.expression.AdditionalMetadata"
+           table="ADDITIONAL_METADATA">
+        <id name="id" type="java.lang.Long">
+            <column name="ID" sql-type="BIGINT"/>
+            <generator class="native"/>
+        </id>
+        <property name="name" type="java.lang.String">
+            <column name="NAME" sql-type="VARCHAR(255)"/>
+        </property>
+        <property name="description" type="org.hibernate.type.MaterializedClobType">
+            <column name="DESCRIPTION" sql-type="TEXT"/>
+        </property>
+        <property name="type" not-null="true">
+            <column name="METADATA_TYPE" sql-type="VARCHAR(255)"/>
+            <type name="org.hibernate.type.EnumType">
+                <param name="enumClass">ubic.gemma.model.expression.experiment.MetadataType</param>
+                <param name="useNamed">true</param>
+            </type>
+        </property>
+        <property name="contents" not-null="true" type="java.sql.Blob">
+            <column name="CONTENTS" sql-type="MEDIUMBLOB"/>
+        </property>
+        <property name="mediaType" not-null="true" type="java.lang.String">
+            <column name="MEDIA_TYPE" sql-type="VARCHAR(255)"/>
+        </property>
+    </class>
+</hibernate-mapping>

--- a/gemma-core/src/main/resources/ubic/gemma/model/expression/bioAssay/BioAssay.hbm.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/model/expression/bioAssay/BioAssay.hbm.xml
@@ -52,5 +52,11 @@
       <many-to-one name="sampleUsed" class="ubic.gemma.model.expression.biomaterial.BioMaterial"  lazy="false" fetch="join">
          <column name="SAMPLE_USED_FK" not-null="false" sql-type="BIGINT"/>
       </many-to-one>
+      <set name="additionalMetadata" cascade="all-delete-orphan">
+         <key foreign-key="BIO_ASSAY_FKC">
+            <column name="BIO_ASSAY_FK" sql-type="BIGINT"/>
+         </key>
+         <one-to-many class="ubic.gemma.model.expression.AdditionalMetadata"/>
+      </set>
    </class>
 </hibernate-mapping>

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/preprocess/MeanVarianceServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/preprocess/MeanVarianceServiceTest.java
@@ -33,7 +33,6 @@ import ubic.gemma.core.loader.util.AlreadyExistsInSystemException;
 import ubic.gemma.core.security.authorization.acl.AclTestUtils;
 import ubic.gemma.core.util.test.category.GeoTest;
 import ubic.gemma.core.util.test.category.SlowTest;
-import ubic.gemma.model.common.auditAndSecurity.AuditAction;
 import ubic.gemma.model.common.quantitationtype.*;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.arrayDesign.TechnologyType;


### PR DESCRIPTION
We currently store EE metadata under `metadata/{shortName}` and detect a certain number of file formats organized in subdirectories.

This has however limitations because we cannot associate EEs with arbitrary metadata files, and we need to adjust the code if new format are to be supported. We also have no solution right now for attaching metadata to individual samples like FastQC reports.

This proposal here is storing blobs in the database with more flexible metadata and allows us to attach them at both the dataset and individual sample levels.

 - [ ] update `ExpressionExperimentDataFetchController` to also list metadata found in the database
 - [ ] fully implement CLI arguments for importing metadata