### PR TITLE
Add support for subqueries for the Criteria-based filtering service

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/ExpressionAnalysisResultSetDaoImpl.java
@@ -26,11 +26,9 @@ import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.PlatformTransactionManager;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.common.description.Characteristic;
 import ubic.gemma.model.common.description.DatabaseEntry;
-import ubic.gemma.model.common.measurement.Measurement;
 import ubic.gemma.model.common.protocol.Protocol;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
@@ -41,7 +39,10 @@ import ubic.gemma.persistence.service.AbstractDao;
 import ubic.gemma.persistence.util.*;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -221,13 +222,13 @@ public class ExpressionAnalysisResultSetDaoImpl extends AbstractCriteriaFilterin
         configurer.unregisterEntity( "analysis.protocol.", Protocol.class );
 
         // use the characteristics instead
-        configurer.registerAlias( "analysis.subsetFactorValue.characteristics.", "sfvc", Characteristic.class, null, 1 );
+        configurer.registerAlias( "analysis.subsetFactorValue.characteristics.", "sfvc", Characteristic.class, null, 1, true );
         configurer.unregisterProperty( "analysis.subsetFactorValue.characteristics.originalValue" );
         configurer.unregisterProperty( "analysis.subsetFactorValue.value" );
 
         // baseline is always baseline
         configurer.unregisterProperty( "baselineGroup.isBaseline" );
-        configurer.registerAlias( "baselineGroup.characteristics.", "bc", Characteristic.class, null, 1 );
+        configurer.registerAlias( "baselineGroup.characteristics.", "bc", Characteristic.class, null, 1, true );
         configurer.unregisterProperty( "baselineGroup.characteristics.originalValue" );
         configurer.unregisterProperty( "baselineGroup.value" );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/FilterCriteriaUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/FilterCriteriaUtils.java
@@ -6,7 +6,8 @@ import org.hibernate.criterion.*;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Utilities for integrating {@link Filter} with Hibernate {@link Criteria} API.
@@ -75,7 +76,8 @@ public class FilterCriteriaUtils {
                     return Restrictions.ne( property, filter.getRequiredValue() );
                 }
             case like:
-                return Restrictions.like( property, escapeLike( ( String ) Objects.requireNonNull( filter.getRequiredValue(), "Required value cannot be null for the like operator." ) ), MatchMode.START );
+                return Restrictions.like( property, escapeLike( ( String ) requireNonNull( filter.getRequiredValue(),
+                        "Required value cannot be null for the like operator." ) ), MatchMode.START );
             case lessThan:
                 return Restrictions.lt( property, filter.getRequiredValue() );
             case greaterThan:
@@ -85,8 +87,18 @@ public class FilterCriteriaUtils {
             case greaterOrEq:
                 return Restrictions.ge( property, filter.getRequiredValue() );
             case in:
-                return Restrictions.in( property, ( Collection<?> ) Objects.requireNonNull( filter.getRequiredValue(),
+                return Restrictions.in( property, ( Collection<?> ) requireNonNull( filter.getRequiredValue(),
                         "Required value cannot be null for a collection." ) );
+            case inSubquery:
+                Subquery subquery = ( Subquery ) requireNonNull( filter.getRequiredValue(),
+                        "Required value cannot be null for a subquery." );
+                DetachedCriteria dc = DetachedCriteria.forEntityName( subquery.getEntityName() )
+                        .setProjection( Projections.id() );
+                for ( Subquery.Alias a : subquery.getAliases() ) {
+                    dc.createAlias( a.getPropertyName(), a.getAlias() );
+                }
+                dc.add( formRestrictionClause( subquery.getFilter() ) );
+                return Subqueries.propertyIn( "id", dc );
             default:
                 throw new IllegalStateException( "Unexpected operator for filter: " + filter.getOperator() );
         }


### PR DESCRIPTION
This is the implementation of #714 for the Criteria-based API.

There's a bug I just can't figure out: no jointures are created in the subquery despites being declared with `createAlias`.

It's not super urgent for the 1.30 since the affected filters only involve HQL-based services.