### PR TITLE
Insert result and contrasts with JDBC

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/report/DatabaseViewGeneratorImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/report/DatabaseViewGeneratorImpl.java
@@ -358,9 +358,9 @@ public class DatabaseViewGeneratorImpl implements DatabaseViewGenerator {
         for ( ContrastResult cr : contrasts ) {
             FactorValue factorValue = cr.getFactorValue();
 
-            String direction = cr.getLogFoldChange() < 0 ? "-" : "+";
+            String direction = cr.getLogFoldChange() != null ? ( cr.getLogFoldChange() < 0 ? "-" : "+" ) : "";
 
-            String factorValueDescription = ExperimentalDesignUtils.prettyString( factorValue );
+            String factorValueDescription = factorValue != null ? ExperimentalDesignUtils.prettyString( factorValue ) : "";
 
             buf.append( String.format( "%d\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n", ee.getId(), ee.getShortName(),
                     g.getNcbiGeneId().toString(), g.getId(), factorName, factorURI, baselineDescription,

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ContrastResult.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ContrastResult.java
@@ -21,7 +21,9 @@ package ubic.gemma.model.analysis.expression.diff;
 import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.expression.experiment.FactorValue;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Represents a contrast between "conditions". In practice, this is the comparison between a factor level and the
@@ -33,25 +35,32 @@ public class ContrastResult implements Identifiable, Serializable {
      * The serial version UID of this class. Needed for serialization.
      */
     private static final long serialVersionUID = -4310735803120153778L;
+    @Nullable
     private Double pvalue;
+    @Nullable
     private Double tStat;
+    @Nullable
     private Double coefficient;
     /**
      * TODO: rename this to log2FoldChange to avoid confusion with the logarithm base used.
      */
+    @Nullable
     private Double logFoldChange;
     private Long id;
+    @Nullable
     private FactorValue factorValue;
+    @Nullable
     private FactorValue secondFactorValue;
 
     /**
      * @return The estimated value from the fit
      */
+    @Nullable
     public Double getCoefficient() {
         return this.coefficient;
     }
 
-    public void setCoefficient( Double coefficient ) {
+    public void setCoefficient( @Nullable Double coefficient ) {
         this.coefficient = coefficient;
     }
 
@@ -59,11 +68,12 @@ public class ContrastResult implements Identifiable, Serializable {
      * @return The factorValue for the group of samples that is being compared to baseline. The baseline itself is a property of
      * the ResultSet. For factors that have continuous values, this will be null.
      */
+    @Nullable
     public FactorValue getFactorValue() {
         return this.factorValue;
     }
 
-    public void setFactorValue( FactorValue factorValue ) {
+    public void setFactorValue( @Nullable FactorValue factorValue ) {
         this.factorValue = factorValue;
     }
 
@@ -81,38 +91,42 @@ public class ContrastResult implements Identifiable, Serializable {
      * @return The fold change relative to the baseline, based on the fitted values. log2-transformed. This will be the same as
      * the coefficient if the data were log transformed when analyzed. This might be null if it wasn't computed.
      */
+    @Nullable
     public Double getLogFoldChange() {
         return this.logFoldChange;
     }
 
-    public void setLogFoldChange( Double logFoldChange ) {
+    public void setLogFoldChange( @Nullable Double logFoldChange ) {
         this.logFoldChange = logFoldChange;
     }
 
+    @Nullable
     public Double getPvalue() {
         return this.pvalue;
     }
 
-    public void setPvalue( Double pvalue ) {
+    public void setPvalue( @Nullable Double pvalue ) {
         this.pvalue = pvalue;
     }
 
+    @Nullable
     public FactorValue getSecondFactorValue() {
         return this.secondFactorValue;
     }
 
-    public void setSecondFactorValue( FactorValue secondFactorValue ) {
+    public void setSecondFactorValue( @Nullable FactorValue secondFactorValue ) {
         this.secondFactorValue = secondFactorValue;
     }
 
     /**
      * @return Serves as the effect size as well as an indicator of the direction of change relative to the baseline
      */
+    @Nullable
     public Double getTstat() {
         return this.tStat;
     }
 
-    public void setTstat( Double tstat ) {
+    public void setTstat( @Nullable Double tstat ) {
         this.tStat = tstat;
     }
 
@@ -121,10 +135,7 @@ public class ContrastResult implements Identifiable, Serializable {
      */
     @Override
     public int hashCode() {
-        int hashCode = 0;
-        hashCode = 29 * hashCode + ( id == null ? 0 : id.hashCode() );
-
-        return hashCode;
+        return Objects.hash( id );
     }
 
     /**
@@ -145,7 +156,9 @@ public class ContrastResult implements Identifiable, Serializable {
 
     @Override
     public String toString() {
-        return "Contrast for " + this.getFactorValue() == null ? "[continuous]" : this.getFactorValue().toString();
+        return "Contrast for "
+                + ( factorValue != null ? factorValue : "[continuous]" )
+                + ( secondFactorValue != null ? ":" + secondFactorValue : "" );
     }
 
     public static final class Factory {
@@ -155,7 +168,7 @@ public class ContrastResult implements Identifiable, Serializable {
 
         @SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
         public static ContrastResult newInstance( Double pvalue, Double tstat, Double coefficient, Double logFoldChange,
-                FactorValue factorValue, FactorValue secondFactorValue ) {
+                @Nullable FactorValue factorValue, @Nullable FactorValue secondFactorValue ) {
             final ContrastResult entity = new ContrastResult();
             entity.setPvalue( pvalue );
             entity.setTstat( tstat );

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ContrastResultValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/ContrastResultValueObject.java
@@ -1,6 +1,8 @@
 package ubic.gemma.model.analysis.expression.diff;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import ubic.gemma.model.IdentifiableValueObject;
 import ubic.gemma.model.expression.experiment.FactorValueBasicValueObject;
 
@@ -33,7 +35,11 @@ public class ContrastResultValueObject extends IdentifiableValueObject<ContrastR
         this.tStat = contrastResult.getTstat();
         this.coefficient = contrastResult.getCoefficient();
         this.logFoldChange = contrastResult.getLogFoldChange();
-        this.factorValue = new FactorValueBasicValueObject( contrastResult.getFactorValue() );
+        if ( contrastResult.getFactorValue() != null ) {
+            this.factorValue = new FactorValueBasicValueObject( contrastResult.getFactorValue() );
+        } else {
+            this.factorValue = null;
+        }
         // not all contrast results have a second factor value
         if ( contrastResult.getSecondFactorValue() != null ) {
             this.secondFactorValue = new FactorValueBasicValueObject( contrastResult.getSecondFactorValue() );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
@@ -20,10 +20,12 @@ package ubic.gemma.persistence.service.analysis.expression.diff;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.time.StopWatch;
-import org.hibernate.Hibernate;
-import org.hibernate.SQLQuery;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.hibernate.*;
+import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.jdbc.Expectations;
+import org.hibernate.persister.entity.EntityPersister;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import ubic.gemma.model.analysis.expression.diff.*;
@@ -37,6 +39,9 @@ import ubic.gemma.persistence.util.CommonQueries;
 import ubic.gemma.persistence.util.EntityUtils;
 
 import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -48,9 +53,20 @@ import java.util.stream.Collectors;
 class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoBase<DifferentialExpressionAnalysis>
         implements DifferentialExpressionAnalysisDao {
 
+    /**
+     * Logger for manual SQL statements so they appear alongside Hibernate's.
+     */
+    private static final SqlStatementLogger statementLogger = new SqlStatementLogger();
+
+    private final EntityPersister resultPersister, contrastPersister;
+
     @Autowired
     public DifferentialExpressionAnalysisDaoImpl( SessionFactory sessionFactory ) {
         super( DifferentialExpressionAnalysis.class, sessionFactory );
+        resultPersister = ( ( SessionFactoryImpl ) sessionFactory )
+                .getEntityPersister( DifferentialExpressionAnalysisResult.class.getName() );
+        contrastPersister = ( ( SessionFactoryImpl ) sessionFactory )
+                .getEntityPersister( ContrastResult.class.getName() );
     }
 
     /**
@@ -60,23 +76,72 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
      * <p>
      * FIXME: remove this method when <a href="https://github.com/PavlidisLab/Gemma/issues/825">#825</a> is resolve and
      *        persist by cascade
+     * <p>
+     * To avoid updates of the DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK in the CONTRAST_RESULT table, we manually
+     * insert results and contrasts with the generated IDs.
      */
     @Override
     public DifferentialExpressionAnalysis create( DifferentialExpressionAnalysis entity ) {
-        entity = super.create( entity );
-        for ( ExpressionAnalysisResultSet rs : entity.getResultSets() ) {
-            for ( DifferentialExpressionAnalysisResult dear : rs.getResults() ) {
-                this.getSessionFactory().getCurrentSession().persist( dear );
-            }
-        }
-        for ( ExpressionAnalysisResultSet rs : entity.getResultSets() ) {
-            for ( DifferentialExpressionAnalysisResult dear : rs.getResults() ) {
-                for ( ContrastResult cr : dear.getContrasts() ) {
-                    this.getSessionFactory().getCurrentSession().persist( cr );
+        // create the analysis, result sets, pvalue distributions, etc.
+        DifferentialExpressionAnalysis finalEntity = super.create( entity );
+
+        getSessionFactory().getCurrentSession().doWork( work -> {
+            String insertResultSql = "insert into DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT (ID, PVALUE, CORRECTED_PVALUE, `RANK`, CORRECTED_P_VALUE_BIN, PROBE_FK, RESULT_SET_FK) values (?, ?, ?, ?, ?, ?, ?)";
+            PreparedStatement insertResultStmt = work.prepareStatement( insertResultSql );
+            String insertContrastSql = "insert into CONTRAST_RESULT (ID, PVALUE, TSTAT, FACTOR_VALUE_FK, DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK, COEFFICIENT, LOG_FOLD_CHANGE, SECOND_FACTOR_VALUE_FK) values (?, ?, ?, ?, ?, ?, ?, ?)";
+            PreparedStatement insertContrastStmt = work.prepareStatement( insertContrastSql );
+            int numResults = 0;
+            int numContrasts = 0;
+            for ( ExpressionAnalysisResultSet rs : finalEntity.getResultSets() ) {
+                for ( DifferentialExpressionAnalysisResult result : rs.getResults() ) {
+                    result.setId( ( Long ) resultPersister.getIdentifierGenerator().generate( ( SessionImpl ) getSessionFactory().getCurrentSession(), result ) );
+                    insertResultStmt.setLong( 1, result.getId() );
+                    insertResultStmt.setObject( 2, result.getPvalue(), Types.DOUBLE );
+                    insertResultStmt.setObject( 3, result.getCorrectedPvalue(), Types.DOUBLE );
+                    insertResultStmt.setObject( 4, result.getRank(), Types.DOUBLE );
+                    insertResultStmt.setObject( 5, result.getCorrectedPValueBin(), Types.INTEGER );
+                    insertResultStmt.setLong( 6, result.getProbe().getId() );
+                    insertResultStmt.setLong( 7, rs.getId() );
+                    insertResultStmt.addBatch();
+                    numResults++;
+                    for ( ContrastResult cr : result.getContrasts() ) {
+                        cr.setId( ( Long ) contrastPersister.getIdentifierGenerator().generate( ( SessionImpl ) getSessionFactory().getCurrentSession(), cr ) );
+                        insertContrastStmt.setLong( 1, cr.getId() );
+                        insertContrastStmt.setObject( 2, cr.getPvalue(), Types.DOUBLE );
+                        insertContrastStmt.setObject( 3, cr.getTstat(), Types.DOUBLE );
+                        if ( cr.getFactorValue() != null ) {
+                            insertContrastStmt.setLong( 4, cr.getFactorValue().getId() );
+                        } else {
+                            insertContrastStmt.setNull( 4, Types.BIGINT );
+                        }
+                        insertContrastStmt.setLong( 5, result.getId() );
+                        insertContrastStmt.setObject( 6, cr.getCoefficient(), Types.DOUBLE );
+                        insertContrastStmt.setObject( 7, cr.getLogFoldChange(), Types.DOUBLE );
+                        if ( cr.getSecondFactorValue() != null ) {
+                            insertContrastStmt.setLong( 8, cr.getSecondFactorValue().getId() );
+                        } else {
+                            insertContrastStmt.setNull( 8, Types.BIGINT );
+                        }
+                        insertContrastStmt.addBatch();
+                        numContrasts++;
+                    }
                 }
             }
+
+            statementLogger.logStatement( insertResultSql + String.format( " [repeated %d times]", numResults ) );
+            ensureExpectedRowsAreInserted( insertResultStmt, insertResultStmt.executeBatch() );
+            statementLogger.logStatement( insertContrastSql + String.format( " [repeated %d times]", numContrasts ) );
+            ensureExpectedRowsAreInserted( insertContrastStmt, insertContrastStmt.executeBatch() );
+        } );
+
+        return finalEntity;
+    }
+
+    private void ensureExpectedRowsAreInserted( PreparedStatement statement, int[] batchStatus ) throws HibernateException, SQLException {
+        int i = 0;
+        for ( int bs : batchStatus ) {
+            Expectations.BASIC.verifyOutcome( bs, statement, i++ );
         }
-        return entity;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
@@ -58,6 +58,10 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
      */
     private static final SqlStatementLogger statementLogger = new SqlStatementLogger();
 
+    private static final String
+            INSERT_RESULT_SQL = "insert into DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT (ID, PVALUE, CORRECTED_PVALUE, `RANK`, CORRECTED_P_VALUE_BIN, PROBE_FK, RESULT_SET_FK) values (?, ?, ?, ?, ?, ?, ?)",
+            INSERT_CONTRAST_SQL = "insert into CONTRAST_RESULT (ID, PVALUE, TSTAT, FACTOR_VALUE_FK, DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK, COEFFICIENT, LOG_FOLD_CHANGE, SECOND_FACTOR_VALUE_FK) values (?, ?, ?, ?, ?, ?, ?, ?)";
+
     private final EntityPersister resultPersister, contrastPersister;
 
     @Autowired
@@ -86,10 +90,8 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
         DifferentialExpressionAnalysis finalEntity = super.create( entity );
 
         getSessionFactory().getCurrentSession().doWork( work -> {
-            String insertResultSql = "insert into DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT (ID, PVALUE, CORRECTED_PVALUE, `RANK`, CORRECTED_P_VALUE_BIN, PROBE_FK, RESULT_SET_FK) values (?, ?, ?, ?, ?, ?, ?)";
-            PreparedStatement insertResultStmt = work.prepareStatement( insertResultSql );
-            String insertContrastSql = "insert into CONTRAST_RESULT (ID, PVALUE, TSTAT, FACTOR_VALUE_FK, DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK, COEFFICIENT, LOG_FOLD_CHANGE, SECOND_FACTOR_VALUE_FK) values (?, ?, ?, ?, ?, ?, ?, ?)";
-            PreparedStatement insertContrastStmt = work.prepareStatement( insertContrastSql );
+            PreparedStatement insertResultStmt = work.prepareStatement( INSERT_RESULT_SQL );
+            PreparedStatement insertContrastStmt = work.prepareStatement( INSERT_CONTRAST_SQL );
             int numResults = 0;
             int numContrasts = 0;
             for ( ExpressionAnalysisResultSet rs : finalEntity.getResultSets() ) {
@@ -128,9 +130,9 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
                 }
             }
 
-            statementLogger.logStatement( insertResultSql + String.format( " [repeated %d times]", numResults ) );
+            statementLogger.logStatement( INSERT_RESULT_SQL + String.format( " [repeated %d times]", numResults ) );
             ensureExpectedRowsAreInserted( insertResultStmt, insertResultStmt.executeBatch() );
-            statementLogger.logStatement( insertContrastSql + String.format( " [repeated %d times]", numContrasts ) );
+            statementLogger.logStatement( INSERT_CONTRAST_SQL + String.format( " [repeated %d times]", numContrasts ) );
             ensureExpectedRowsAreInserted( insertContrastStmt, insertContrastStmt.executeBatch() );
         } );
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionResultDaoImpl.java
@@ -753,10 +753,7 @@ public class DifferentialExpressionResultDaoImpl extends AbstractDao<Differentia
 
         Collection<ContrastResult> contrasts = result.getContrasts();
         for ( ContrastResult contrast : contrasts ) {
-            FactorValue f = contrast.getFactorValue();
-            Hibernate.initialize( f );
-            //noinspection ResultOfMethodCallIgnored
-            f.getIsBaseline();
+            Hibernate.initialize( contrast.getFactorValue() );
         }
     }
 

--- a/gemma-core/src/main/resources/sql/migrations/db.1.30.1.sql
+++ b/gemma-core/src/main/resources/sql/migrations/db.1.30.1.sql
@@ -1,0 +1,2 @@
+alter table CONTRAST_RESULT
+    modify column DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK bigint not null;

--- a/gemma-core/src/main/resources/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResult.hbm.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisResult.hbm.xml
@@ -25,7 +25,7 @@
         <!-- FIXME: use cascade="all" when https://github.com/PavlidisLab/Gemma/issues/825 is resolved -->
         <set name="contrasts" lazy="true" fetch="select" cascade="delete" mutable="false">
             <key foreign-key="CONTRAST_RESULT_DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FKC">
-                <column name="DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK" sql-type="BIGINT"/>
+                <column name="DIFFERENTIAL_EXPRESSION_ANALYSIS_RESULT_FK" sql-type="BIGINT" not-null="true"/>
             </key>
             <one-to-many class="ubic.gemma.model.analysis.expression.diff.ContrastResult"/>
         </set>

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/AncovaTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/AncovaTest.java
@@ -20,7 +20,6 @@
 package ubic.gemma.core.analysis.expression.diff;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.springframework.beans.factory.annotation.Autowired;
 import ubic.gemma.model.analysis.expression.diff.ContrastResult;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
@@ -364,7 +363,9 @@ public class AncovaTest extends BaseAnalyzerConfigurationTest {
                             assertEquals( 0.0048, pvalue, 0.0001 );
                             assertNotNull( stat );
                             assertEquals( -125.746, stat, 0.001 );
-                            assertEquals( 0.00506, contrasts.iterator().next().getPvalue(), 0.0001 ); // factor1a
+                            ContrastResult c = contrasts.iterator().next();
+                            assertNotNull( c.getPvalue() );
+                            assertEquals( 0.00506, c.getPvalue(), 0.0001 ); // factor1a
 
                             break;
                     }

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
@@ -30,7 +30,6 @@ import ubic.gemma.core.loader.expression.simple.ExperimentalDesignImporter;
 import ubic.gemma.core.loader.genome.gene.ExternalFileGeneLoaderService;
 import ubic.gemma.core.loader.util.AlreadyExistsInSystemException;
 import ubic.gemma.core.util.test.category.SlowTest;
-import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.common.description.ExternalDatabase;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
@@ -38,6 +37,7 @@ import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.model.expression.experiment.ExpressionExperimentDetailsValueObject;
+import ubic.gemma.model.expression.experiment.FactorValue;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.TableMaintenanceUtil;
@@ -566,8 +566,8 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
         StringBuilder buf = new StringBuilder( "\n" );
         for ( DifferentialExpressionAnalysisResult rr : r.getResultsUsed() ) {
             buf.append( String.format( "%s  %s fv=%d  p=%.4g t=%.2f id=%d", gene, rr.getProbe().getName(),
-                    rr.getContrasts().iterator().next().getFactorValue().getId(), rr.getPvalue(),
-                    rr.getContrasts().iterator().next().getCoefficient(), rr.getId() ) ).append( "\n" );
+                    rr.getContrasts().stream().findAny().map( ContrastResult::getFactorValue ).map( FactorValue::getId ).orElse( null ),
+                    rr.getPvalue(), rr.getContrasts().iterator().next().getCoefficient(), rr.getId() ) ).append( "\n" );
         }
         return buf.toString();
     }

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExTest.java
@@ -203,8 +203,11 @@ public class DiffExTest extends AbstractGeoServiceTest {
                 // also values changed very slightly with updated library size computation (post-filtering)
                 assertEquals( 1, r.getContrasts().size() );
                 ContrastResult contrast = r.getContrasts().iterator().next();
+                assertNotNull( contrast.getCoefficient() );
                 assertEquals( 2.272896, Math.abs( contrast.getCoefficient() ), 0.001 );
+                assertNotNull( contrast.getPvalue() );
                 assertEquals( 0.006149004, contrast.getPvalue(), 0.00001 );
+                assertNotNull( contrast.getTstat() );
                 assertEquals( 12.693680, Math.abs( contrast.getTstat() ), 0.001 );
                 assertEquals( 0.006149004, r.getPvalue(), 0.00001 );
                 break;

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoTest.java
@@ -13,7 +13,7 @@ import ubic.gemma.model.expression.designElement.CompositeSequence;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.util.TestComponent;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @ContextConfiguration
 public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
@@ -41,6 +41,7 @@ public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
         sessionFactory.getCurrentSession().persist( ad );
         for ( int j = 0; j < 3; j++ ) {
             ExpressionAnalysisResultSet resultSet = new ExpressionAnalysisResultSet();
+            resultSet.setAnalysis( analysis );
             PvalueDistribution pvalueDist = new PvalueDistribution();
             pvalueDist.setNumBins( 2 );
             pvalueDist.setBinCounts( new byte[2] );
@@ -61,13 +62,18 @@ public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
         analysis = differentialExpressionAnalysisDao.create( analysis );
         sessionFactory.getCurrentSession().flush();
         assertNotNull( analysis.getId() );
+        assertEquals( 3, analysis.getResultSets().size() );
         for ( ExpressionAnalysisResultSet resultSet : analysis.getResultSets() ) {
             assertNotNull( resultSet.getId() );
             assertNotNull( resultSet.getPvalueDistribution().getId() );
+            assertEquals( 100, resultSet.getResults().size() );
             for ( DifferentialExpressionAnalysisResult result : resultSet.getResults() ) {
                 assertNotNull( result.getId() );
+                assertFalse( sessionFactory.getCurrentSession().contains( result ) );
+                assertEquals( 2, result.getContrasts().size() );
                 for ( ContrastResult contrast : result.getContrasts() ) {
                     assertNotNull( contrast.getId() );
+                    assertFalse( sessionFactory.getCurrentSession().contains( contrast ) );
                 }
             }
         }

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoTest.java
@@ -10,8 +10,12 @@ import ubic.gemma.core.util.test.BaseDatabaseTest;
 import ubic.gemma.model.analysis.expression.diff.*;
 import ubic.gemma.model.expression.arrayDesign.ArrayDesign;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.experiment.FactorValue;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.util.TestComponent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -38,6 +42,13 @@ public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
         sessionFactory.getCurrentSession().persist( taxon );
         ArrayDesign ad = new ArrayDesign();
         ad.setPrimaryTaxon( taxon );
+        List<CompositeSequence> probes = new ArrayList<>( 100 );
+        for ( int i = 0; i < 100; i++ ) {
+            CompositeSequence cs = CompositeSequence.Factory.newInstance( "cs" + i );
+            cs.setArrayDesign( ad );
+            ad.getCompositeSequences().add( cs );
+            probes.add( cs );
+        }
         sessionFactory.getCurrentSession().persist( ad );
         for ( int j = 0; j < 3; j++ ) {
             ExpressionAnalysisResultSet resultSet = new ExpressionAnalysisResultSet();
@@ -47,10 +58,7 @@ public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
             pvalueDist.setBinCounts( new byte[2] );
             for ( int i = 0; i < 100; i++ ) {
                 DifferentialExpressionAnalysisResult der = new DifferentialExpressionAnalysisResult();
-                CompositeSequence cs = new CompositeSequence();
-                cs.setArrayDesign( ad );
-                sessionFactory.getCurrentSession().persist( cs );
-                der.setProbe( cs );
+                der.setProbe( probes.get( i ) );
                 der.setResultSet( resultSet );
                 der.getContrasts().add( ContrastResult.Factory.newInstance() );
                 der.getContrasts().add( ContrastResult.Factory.newInstance() );
@@ -60,7 +68,6 @@ public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
             analysis.getResultSets().add( resultSet );
         }
         analysis = differentialExpressionAnalysisDao.create( analysis );
-        sessionFactory.getCurrentSession().flush();
         assertNotNull( analysis.getId() );
         assertEquals( 3, analysis.getResultSets().size() );
         for ( ExpressionAnalysisResultSet resultSet : analysis.getResultSets() ) {
@@ -77,5 +84,120 @@ public class DifferentialExpressionAnalysisDaoTest extends BaseDatabaseTest {
                 }
             }
         }
+        analysis = reload( analysis );
+        assertNotNull( analysis.getId() );
+        assertEquals( 3, analysis.getResultSets().size() );
+        for ( ExpressionAnalysisResultSet resultSet : analysis.getResultSets() ) {
+            assertNotNull( resultSet.getId() );
+            assertNotNull( resultSet.getPvalueDistribution().getId() );
+            assertEquals( 100, resultSet.getResults().size() );
+            for ( DifferentialExpressionAnalysisResult result : resultSet.getResults() ) {
+                assertNotNull( result.getId() );
+                assertTrue( sessionFactory.getCurrentSession().contains( result ) );
+                assertEquals( 2, result.getContrasts().size() );
+                for ( ContrastResult contrast : result.getContrasts() ) {
+                    assertNotNull( contrast.getId() );
+                    assertTrue( sessionFactory.getCurrentSession().contains( contrast ) );
+                }
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateInvalidAnalysis() {
+        DifferentialExpressionAnalysis analysis = new DifferentialExpressionAnalysis();
+        Taxon taxon = new Taxon();
+        sessionFactory.getCurrentSession().persist( taxon );
+        ArrayDesign ad = new ArrayDesign();
+        ad.setPrimaryTaxon( taxon );
+        List<CompositeSequence> probes = new ArrayList<>( 100 );
+        for ( int i = 0; i < 100; i++ ) {
+            CompositeSequence cs = CompositeSequence.Factory.newInstance( "cs" + i );
+            cs.setArrayDesign( ad );
+            ad.getCompositeSequences().add( cs );
+            probes.add( cs );
+        }
+        sessionFactory.getCurrentSession().persist( ad );
+        for ( int j = 0; j < 3; j++ ) {
+            ExpressionAnalysisResultSet resultSet = new ExpressionAnalysisResultSet();
+            resultSet.setAnalysis( analysis );
+            PvalueDistribution pvalueDist = new PvalueDistribution();
+            pvalueDist.setNumBins( 2 );
+            pvalueDist.setBinCounts( new byte[2] );
+            for ( int i = 0; i < 100; i++ ) {
+                DifferentialExpressionAnalysisResult der = new DifferentialExpressionAnalysisResult();
+                der.setProbe( probes.get( i ) );
+                der.setResultSet( resultSet );
+                // this is invalid because FVs are not shared
+                der.getContrasts().add( ContrastResult.Factory.newInstance( null, null, null, null, new FactorValue(), new FactorValue() ) );
+                der.getContrasts().add( ContrastResult.Factory.newInstance( null, null, null, null, new FactorValue(), new FactorValue() ) );
+                resultSet.getResults().add( der );
+            }
+            resultSet.setPvalueDistribution( pvalueDist );
+            analysis.getResultSets().add( resultSet );
+        }
+        //noinspection ResultOfMethodCallIgnored
+        differentialExpressionAnalysisDao.create( analysis );
+    }
+
+    @Test
+    public void testCreateAnalysisWithoutResults() {
+        DifferentialExpressionAnalysis analysis = new DifferentialExpressionAnalysis();
+        Taxon taxon = new Taxon();
+        sessionFactory.getCurrentSession().persist( taxon );
+        ArrayDesign ad = new ArrayDesign();
+        ad.setPrimaryTaxon( taxon );
+        sessionFactory.getCurrentSession().persist( ad );
+        for ( int j = 0; j < 3; j++ ) {
+            ExpressionAnalysisResultSet resultSet = new ExpressionAnalysisResultSet();
+            resultSet.setAnalysis( analysis );
+            PvalueDistribution pvalueDist = new PvalueDistribution();
+            pvalueDist.setNumBins( 2 );
+            pvalueDist.setBinCounts( new byte[2] );
+            resultSet.setPvalueDistribution( pvalueDist );
+            analysis.getResultSets().add( resultSet );
+        }
+        //noinspection ResultOfMethodCallIgnored
+        differentialExpressionAnalysisDao.create( analysis );
+    }
+
+    @Test
+    public void testCreateAnalysisWithoutContrasts() {
+        DifferentialExpressionAnalysis analysis = new DifferentialExpressionAnalysis();
+        Taxon taxon = new Taxon();
+        sessionFactory.getCurrentSession().persist( taxon );
+        ArrayDesign ad = new ArrayDesign();
+        ad.setPrimaryTaxon( taxon );
+        List<CompositeSequence> probes = new ArrayList<>( 100 );
+        for ( int i = 0; i < 100; i++ ) {
+            CompositeSequence cs = CompositeSequence.Factory.newInstance( "cs" + i );
+            cs.setArrayDesign( ad );
+            ad.getCompositeSequences().add( cs );
+            probes.add( cs );
+        }
+        sessionFactory.getCurrentSession().persist( ad );
+        for ( int j = 0; j < 3; j++ ) {
+            ExpressionAnalysisResultSet resultSet = new ExpressionAnalysisResultSet();
+            resultSet.setAnalysis( analysis );
+            PvalueDistribution pvalueDist = new PvalueDistribution();
+            pvalueDist.setNumBins( 2 );
+            pvalueDist.setBinCounts( new byte[2] );
+            resultSet.setPvalueDistribution( pvalueDist );
+            for ( int i = 0; i < 100; i++ ) {
+                DifferentialExpressionAnalysisResult der = new DifferentialExpressionAnalysisResult();
+                der.setProbe( probes.get( i ) );
+                der.setResultSet( resultSet );
+                resultSet.getResults().add( der );
+            }
+            analysis.getResultSets().add( resultSet );
+        }
+        //noinspection ResultOfMethodCallIgnored
+        differentialExpressionAnalysisDao.create( analysis );
+    }
+
+    private DifferentialExpressionAnalysis reload( DifferentialExpressionAnalysis analysis ) {
+        sessionFactory.getCurrentSession().flush();
+        sessionFactory.getCurrentSession().clear();
+        return differentialExpressionAnalysisDao.load( analysis.getId() );
     }
 }


### PR DESCRIPTION
This approach prevents Hibernate from performing a round of updates to set the result FKs on the contrasts.

Fix #826 