### PR TITLE
Better exceptions in Gemma Web

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseReadOnlyService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/BaseReadOnlyService.java
@@ -6,6 +6,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.function.Function;
 
 /**
  * Interface for read-only services.
@@ -25,9 +26,15 @@ public interface BaseReadOnlyService<O extends Identifiable> {
     @CheckReturnValue
     O find( O entity );
 
+    /**
+     * Does a search for the entity in the persistent storage, raising a {@link NullPointerException} if not found.
+     * @param entity the entity to be searched for
+     * @return the version of entity retrieved from persistent storage
+     * @throws NullPointerException if the entity is not found
+     */
     @Nonnull
     @CheckReturnValue
-    O findOrFail( O entity );
+    O findOrFail( O entity ) throws NullPointerException;
 
     /**
      * Loads objects with given ids.
@@ -54,6 +61,9 @@ public interface BaseReadOnlyService<O extends Identifiable> {
      */
     @Nonnull
     O loadOrFail( Long id ) throws NullPointerException;
+
+    @Nonnull
+    <T extends Exception> O loadOrFail( Long id, Class<T> exceptionClass ) throws T;
 
     /**
      * Loads all the entities of specific type.

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisServiceImpl.java
@@ -250,9 +250,7 @@ public class DifferentialExpressionAnalysisServiceImpl extends AbstractService<D
     public void removeForExperiment( BioAssaySet ee ) {
         Collection<DifferentialExpressionAnalysis> diffAnalyses = this.differentialExpressionAnalysisDao
                 .findByExperiment( ee );
-        for ( DifferentialExpressionAnalysis de : diffAnalyses ) {
-            this.remove( de );
-        }
+        this.remove( diffAnalyses );
     }
 
     @Override

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/AbstractServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/AbstractServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 @ContextConfiguration
 public class AbstractServiceTest extends BaseDatabaseTest {
@@ -42,6 +43,37 @@ public class AbstractServiceTest extends BaseDatabaseTest {
     private MyService myService;
 
     private int i = 0;
+
+    public static class ExceptionWithoutMessage extends Exception {
+
+        public ExceptionWithoutMessage() {
+        }
+    }
+
+    public static class ExceptionWithMessage extends Exception {
+
+        public ExceptionWithMessage( String message ) {
+            super( message );
+        }
+    }
+
+    @Test
+    public void testLoadOrFail() {
+        try {
+            myService.loadOrFail( 12L, ExceptionWithoutMessage.class );
+            failBecauseExceptionWasNotThrown( ExceptionWithoutMessage.class );
+        } catch ( ExceptionWithoutMessage e ) {
+            assertThat( e ).hasMessage( null );
+        }
+        try {
+            myService.loadOrFail( 12L, ExceptionWithMessage.class );
+            failBecauseExceptionWasNotThrown( ExceptionWithMessage.class );
+        } catch ( ExceptionWithMessage e ) {
+            assertThat( e )
+                    .hasMessageContaining( "ExternalDatabase" )
+                    .hasMessageContaining( "12" );
+        }
+    }
 
     @Test
     public void testEnsureInSession() {

--- a/gemma-rest/src/main/java/ubic/gemma/rest/DatasetsWebService.java
+++ b/gemma-rest/src/main/java/ubic/gemma/rest/DatasetsWebService.java
@@ -61,7 +61,6 @@ import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.model.genome.TaxonValueObject;
 import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisService;
 import ubic.gemma.persistence.service.common.auditAndSecurity.AuditEventService;
-import ubic.gemma.persistence.service.common.quantitationtype.QuantitationTypeService;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 import ubic.gemma.persistence.service.expression.bioAssayData.ProcessedExpressionDataVectorService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
@@ -116,8 +115,6 @@ public class DatasetsWebService {
     private DifferentialExpressionAnalysisService differentialExpressionAnalysisService;
     @Autowired
     private AuditEventService auditEventService;
-    @Autowired
-    private QuantitationTypeService quantitationTypeService;
     @Autowired
     private DatasetArgService datasetArgService;
     @Autowired
@@ -1011,7 +1008,7 @@ public class DatasetsWebService {
     private List<DifferentialExpressionAnalysisValueObject> getDiffExVos( Long eeId, int offset, int limit ) {
         Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> map = differentialExpressionAnalysisService
                 .getAnalysesByExperiment( Collections.singleton( eeId ), offset, limit );
-        if ( map == null || map.size() < 1 ) {
+        if ( map == null || map.isEmpty() ) {
             return Collections.emptyList();
         }
         return map.get( map.keySet().iterator().next() );

--- a/gemma-rest/src/main/java/ubic/gemma/rest/TaxaWebService.java
+++ b/gemma-rest/src/main/java/ubic/gemma/rest/TaxaWebService.java
@@ -218,7 +218,7 @@ public class TaxaWebService {
     }
 
     /**
-     * Retrieves datasets for the given taxon. Filtering allowed exactly like in {@link DatasetsWebService#getDatasets(String, Double, FilterArg, OffsetArg, LimitArg, SortArg)}.
+     * Retrieves datasets for the given taxon. Filtering allowed exactly like in {@link DatasetsWebService#getDatasets(String, FilterArg, OffsetArg, LimitArg, SortArg)}.
      *
      * @param taxonArg can either be Taxon ID, Taxon NCBI ID, or one of its string identifiers:
      *                 scientific name, common name. It is recommended to use the ID for efficiency.

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/ExpressionExperimentReportGenerationController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/ExpressionExperimentReportGenerationController.java
@@ -24,6 +24,7 @@ import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.maintenance.ExpressionExperimentReportTaskCommand;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 /**
  * @author klc
@@ -39,7 +40,7 @@ public class ExpressionExperimentReportGenerationController {
     public String run( Long id ) {
         ExpressionExperiment ee = expressionExperimentService.load( id );
         if ( ee == null ) {
-            throw new IllegalArgumentException( "Could not access experiment with id=" + id );
+            throw new EntityNotFoundException( "Could not access experiment with id=" + id );
         }
 
         ExpressionExperimentReportTaskCommand cmd = new ExpressionExperimentReportTaskCommand( ee );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/expression/coexpression/links/LinkAnalysisController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/expression/coexpression/links/LinkAnalysisController.java
@@ -27,6 +27,7 @@ import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.analysis.coexp.LinkAnalysisTaskCommand;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 /**
  * A controller to pre-process expression data vectors.
@@ -49,7 +50,7 @@ public class LinkAnalysisController {
         ExpressionExperiment ee = expressionExperimentService.load( id );
 
         if ( ee == null ) {
-            throw new IllegalArgumentException( "Cannot access experiment with id=" + id );
+            throw new EntityNotFoundException( "Cannot access experiment with id=" + id );
         }
 
         experimentReportService.evictFromCache( id );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/BatchInfoFetchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/BatchInfoFetchController.java
@@ -26,6 +26,7 @@ import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.analysis.expression.BatchInfoFetchTaskCommand;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 /**
  * For populating "batch" information about experiments.
@@ -48,7 +49,7 @@ public class BatchInfoFetchController {
 
         ExpressionExperiment ee = expressionExperimentService.load( id );
         if ( ee == null )
-            throw new IllegalArgumentException( "Could not load experiment with id=" + id );
+            throw new EntityNotFoundException( "Could not load experiment with id=" + id );
         ee = expressionExperimentService.thawLite( ee );
 
         /*

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/PreprocessController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/PreprocessController.java
@@ -25,6 +25,7 @@ import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.analysis.expression.PreprocessTaskCommand;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 /**
  * A controller to pre-process expression data (including updating diagnostics)
@@ -47,7 +48,7 @@ public class PreprocessController {
      * Update the processed data vectors as well as diagnostics
      *
      * @param  id of the experiment
-     * @return    status
+     * @return status
      */
     public String run( Long id ) {
         if ( id == null )
@@ -55,7 +56,7 @@ public class PreprocessController {
 
         ExpressionExperiment ee = expressionExperimentService.load( id );
         if ( ee == null )
-            throw new IllegalArgumentException( "Could not load experiment with id=" + id );
+            throw new EntityNotFoundException( "Could not load experiment with id=" + id );
 
         ee = expressionExperimentService.thawLite( ee );
 
@@ -68,7 +69,7 @@ public class PreprocessController {
      * Only update the daignostics
      *
      * @param  id of experiment
-     * @return    status
+     * @return status
      */
     public String diagnostics( Long id ) {
         if ( id == null )
@@ -76,7 +77,7 @@ public class PreprocessController {
 
         ExpressionExperiment ee = expressionExperimentService.load( id );
         if ( ee == null )
-            throw new IllegalArgumentException( "Could not load experiment with id=" + id );
+            throw new EntityNotFoundException( "Could not load experiment with id=" + id );
 
         ee = expressionExperimentService.thawLite( ee );
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/SvdController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/SvdController.java
@@ -26,6 +26,7 @@ import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.analysis.expression.SvdTaskCommand;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 /**
  * Run SVD on a data set.
@@ -50,7 +51,7 @@ public class SvdController {
             throw new IllegalArgumentException( "ID cannot be null" );
         ExpressionExperiment ee = expressionExperimentService.load( id );
         if ( ee == null )
-            throw new IllegalArgumentException( "Could not load experiment with id=" + id );
+            throw new EntityNotFoundException( "Could not load experiment with id=" + id );
 
         ee = expressionExperimentService.thawLite( ee );
         experimentReportService.evictFromCache( id );

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/TwoChannelMissingValueController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/analysis/preprocess/TwoChannelMissingValueController.java
@@ -25,6 +25,7 @@ import ubic.gemma.core.job.executor.webapp.TaskRunningService;
 import ubic.gemma.core.tasks.analysis.expression.TwoChannelMissingValueTaskCommand;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 /**
  * Run misssing value computation via web request.
@@ -48,7 +49,7 @@ public class TwoChannelMissingValueController {
         ExpressionExperiment ee = expressionExperimentService.load( id );
 
         if ( ee == null ) {
-            throw new IllegalArgumentException( "Cannot access experiment with id=" + id );
+            throw new EntityNotFoundException( "Cannot access experiment with id=" + id );
         }
         ee = expressionExperimentService.thawLite( ee );
 

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/common/auditAndSecurity/SecurityControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/common/auditAndSecurity/SecurityControllerImpl.java
@@ -88,7 +88,7 @@ public class SecurityControllerImpl implements SecurityController {
         User userTakingAction = userManager.getCurrentUser();
 
         if ( userTakingAction == null ) {
-            throw new IllegalStateException( "Cannot add user to group when user is not logged in" );
+            throw new AccessDeniedException( "Cannot add user to group when user is not logged in" );
         }
 
         User u;

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/common/auditAndSecurity/UserFormMultiActionController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/common/auditAndSecurity/UserFormMultiActionController.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.encoding.PasswordEncoder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -85,7 +86,7 @@ public class UserFormMultiActionController extends BaseController {
             String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
             if ( !username.equals( originalUserName ) ) {
-                throw new RuntimeException( "You must be logged in to edit your profile." );
+                throw new AccessDeniedException( "You must be logged in to edit your profile." );
             }
 
             UserDetailsImpl user = ( UserDetailsImpl ) userManager.loadUserByUsername( username );
@@ -106,7 +107,7 @@ public class UserFormMultiActionController extends BaseController {
 
             if ( password.length() > 0 ) {
                 if ( !StringUtils.equals( password, passwordConfirm ) ) {
-                    throw new RuntimeException( "Passwords do not match." );
+                    throw new IllegalArgumentException( "Passwords do not match." );
                 }
                 String encryptedPassword = passwordEncoder.encodePassword( password, user.getUsername() );
                 userManager.changePassword( oldPassword, encryptedPassword );
@@ -177,7 +178,7 @@ public class UserFormMultiActionController extends BaseController {
         if ( StringUtils.isEmpty( email ) || StringUtils.isEmpty( username ) ) {
             String txt = "Email or username not specified.  These are required fields.";
             log.warn( txt );
-            throw new RuntimeException( txt );
+            throw new IllegalArgumentException( txt );
         }
 
         /* look up the user's information and reset password. */

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/common/auditAndSecurity/UserListControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/common/auditAndSecurity/UserListControllerImpl.java
@@ -25,7 +25,6 @@ import org.hibernate.LazyInitializationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.security.authentication.encoding.PasswordEncoder;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,14 +32,12 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import ubic.gemma.core.security.authentication.UserManager;
 import ubic.gemma.model.common.auditAndSecurity.User;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * For display and editing of users. Note: do not use parametrized collections as parameters for ajax methods in this
@@ -107,7 +104,7 @@ public class UserListControllerImpl implements UserListController {
         User u = userManager.findByUserName( userName );
 
         if ( u == null ) {
-            throw new IllegalArgumentException( String.format( "No user with username %s.", userName ) );
+            throw new EntityNotFoundException( String.format( "No user with username %s.", userName ) );
         }
 
         UserDetailsImpl userDetails;

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/common/description/bibref/BibliographicReferenceControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/common/description/bibref/BibliographicReferenceControllerImpl.java
@@ -43,7 +43,6 @@ import ubic.gemma.web.util.EntityNotFoundException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.security.InvalidParameterException;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -72,7 +71,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
         String pubMedId = request.getParameter( "accession" ); // FIXME: allow use of the primary key as well.
 
         if ( StringUtils.isBlank( pubMedId ) ) {
-            throw new EntityNotFoundException( "Must provide a PubMed Id" );
+            throw new IllegalArgumentException( "Must provide a PubMed Id" );
         }
 
         BibliographicReference bibRef = bibliographicReferenceService.findByExternalId( pubMedId );
@@ -135,7 +134,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
 
         if ( pubMedId == null ) {
             // should be a validation error.
-            throw new EntityNotFoundException( "Must provide a PubMed Id" );
+            throw new IllegalArgumentException( "Must provide a PubMed Id" );
         }
 
         BibliographicReference bibRef = bibliographicReferenceService.findByExternalId( pubMedId );
@@ -159,7 +158,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
         if ( returnVal.getRecords() != null && !returnVal.getRecords().isEmpty() ) {
             return returnVal.getRecords().iterator().next();
         }
-        throw new InvalidParameterException( "Error retrieving bibliographic reference for id = " + id );
+        throw new EntityNotFoundException( "Error retrieving bibliographic reference for id = " + id );
 
     }
 
@@ -210,7 +209,7 @@ public class BibliographicReferenceControllerImpl extends BaseController impleme
         // FIXME: allow use of the primary key as well.
 
         if ( StringUtils.isBlank( pubMedId ) && StringUtils.isBlank( gemmaId ) ) {
-            throw new EntityNotFoundException( "Must provide a gamma database id or a PubMed id" );
+            throw new IllegalArgumentException( "Must provide a gamma database id or a PubMed id" );
         }
 
         if ( !StringUtils.isBlank( gemmaId ) ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignControllerImpl.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/arrayDesign/ArrayDesignControllerImpl.java
@@ -294,7 +294,7 @@ public class ArrayDesignControllerImpl implements ArrayDesignController {
             return new ModelAndView( new RedirectView( "/arrays/showAllArrayDesigns.html?id=" + id, true ) )
                     .addObject( "taskId", taskId );
         } catch ( NumberFormatException e ) {
-            throw new RuntimeException( "Invalid ID: " + sId );
+            throw new IllegalArgumentException( "Invalid ID: " + sId );
         }
 
     }
@@ -566,7 +566,7 @@ public class ArrayDesignControllerImpl implements ArrayDesignController {
 
         if ( arrayDesignIdStr == null ) {
             // should be a validation error, on 'submit'.
-            throw new EntityNotFoundException( "Must provide a platform name or Id" );
+            throw new IllegalArgumentException( "Must provide a platform name or Id" );
         }
 
         ArrayDesign arrayDesign = arrayDesignService.load( Long.parseLong( arrayDesignIdStr ) );
@@ -575,7 +575,7 @@ public class ArrayDesignControllerImpl implements ArrayDesignController {
         if ( !AJAX ) {
             Collection<CompositeSequenceMapValueObject> compositeSequenceSummary = getDesignSummaries( arrayDesign );
             if ( compositeSequenceSummary == null || compositeSequenceSummary.size() == 0 ) {
-                throw new RuntimeException( "No probes found for " + arrayDesign );
+                throw new EntityNotFoundException( "No probes found for " + arrayDesign );
             }
             mav.addObject( "sequenceData", compositeSequenceSummary );
             mav.addObject( "numCompositeSequences", compositeSequenceSummary.size() );
@@ -701,7 +701,7 @@ public class ArrayDesignControllerImpl implements ArrayDesignController {
         public TaskResult call() {
             ArrayDesign ad = arrayDesignService.load( taskCommand.getEntityId() );
             if ( ad == null ) {
-                throw new IllegalArgumentException( "Could not load platform with id=" + taskCommand.getEntityId() );
+                throw new EntityNotFoundException( "Could not load platform with id=" + taskCommand.getEntityId() );
             }
             arrayDesignService.remove( ad );
             return new TaskResult( taskCommand,

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentFormController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentFormController.java
@@ -45,6 +45,7 @@ import ubic.gemma.persistence.service.expression.bioAssay.BioAssayService;
 import ubic.gemma.persistence.service.expression.biomaterial.BioMaterialService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
 import ubic.gemma.web.controller.BaseFormController;
+import ubic.gemma.web.util.EntityNotFoundException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -174,10 +175,7 @@ public class ExpressionExperimentFormController extends BaseFormController {
         BaseFormController.log.debug( id );
         ExpressionExperimentEditValueObject obj;
 
-        ExpressionExperiment ee = expressionExperimentService.load( id );
-        if ( ee == null ) {
-            throw new IllegalArgumentException( "Could not load experiment with id=" + id );
-        }
+        ExpressionExperiment ee = expressionExperimentService.loadOrFail( id, EntityNotFoundException.class );
 
         ee = expressionExperimentService.thawLite( ee );
 
@@ -234,11 +232,7 @@ public class ExpressionExperimentFormController extends BaseFormController {
             BindException errors ) {
 
         ExpressionExperimentEditValueObject eeCommand = ( ExpressionExperimentEditValueObject ) command;
-        ExpressionExperiment expressionExperiment = expressionExperimentService.load( eeCommand.getId() );
-
-        if ( expressionExperiment == null ) {
-            throw new IllegalArgumentException( "Could not load experiment" );
-        }
+        ExpressionExperiment expressionExperiment = expressionExperimentService.loadOrFail( eeCommand.getId(), EntityNotFoundException.class );
 
         expressionExperiment = expressionExperimentService.thawLite( expressionExperiment );
 


### PR DESCRIPTION
Following up on 660fde3f76b6d6d515eb531f2a7e63cb220bcd30, we can now raise `EntityNotFoundException`, `IllegalArgumentException` and `AccessDeniedException` to respectively produce 404, 400 and 403 status.

This PR is about making all the errors raised in Gemma Web consistent with the status code that should be produced.