### PR TITLE
Adapt warning depending on the profile

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/core/apps/GemmaCLI.java
+++ b/gemma-cli/src/main/java/ubic/gemma/core/apps/GemmaCLI.java
@@ -24,10 +24,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import ubic.gemma.core.logging.LoggingConfigurer;
+import ubic.gemma.core.logging.log4j.Log4jConfigurer;
 import ubic.gemma.core.util.AbstractCLI;
 import ubic.gemma.core.util.CLI;
-import ubic.gemma.core.logging.log4j.Log4jConfigurer;
-import ubic.gemma.core.logging.LoggingConfigurer;
 import ubic.gemma.persistence.util.Settings;
 import ubic.gemma.persistence.util.SpringContextUtil;
 import ubic.gemma.persistence.util.SpringProfiles;
@@ -149,6 +149,19 @@ public class GemmaCLI {
         // check for the -testing/--testing flag to load the appropriate application context
         if ( commandLine.hasOption( TESTING_OPTION ) ) {
             profiles.add( SpringProfiles.TEST );
+        }
+
+        // check some common settings that might affect initialization time
+        if ( Settings.getBoolean( "load.ontologies" ) ) {
+            log.warn( "Auto-loading of ontologies is enabled, this is not recommended for the CLI. Disable it by setting load.ontologies=false in Gemma.properties." );
+        }
+
+        if ( Settings.getBoolean( "load.homologene" ) ) {
+            log.warn( "Homologene is enabled, this is not recommended for the CLI. Disable it by setting load.homologene=false in Gemma.properties." );
+        }
+
+        if ( Settings.getString( "gemma.hibernate.hbm2ddl.auto" ).equals( "validate" ) ) {
+            log.warn( "Hibernate is configured to validate the database schema, this is not recommended for the CLI. Disable it by setting gemma.hibernate.hbm2ddl.auto= in Gemma.properties." );
         }
 
         ApplicationContext ctx = SpringContextUtil.getApplicationContext( profiles.toArray( new String[0] ) );

--- a/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssociationManagerServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/association/phenotype/PhenotypeAssociationManagerServiceImpl.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ubic.basecode.ontology.model.OntologyTerm;
@@ -101,6 +102,12 @@ public class PhenotypeAssociationManagerServiceImpl implements PhenotypeAssociat
             "http://purl.obolibrary.org/obo/MP_0000001"
     };
 
+    /**
+     * Determine if ontologies are to be loaded on startup.
+     */
+    @Value("${load.ontologies}")
+    private boolean isAutoLoad;
+
     @Autowired
     private PhenotypeAssociationService phenoAssocService;
 
@@ -151,7 +158,7 @@ public class PhenotypeAssociationManagerServiceImpl implements PhenotypeAssociat
         Set<ubic.basecode.ontology.providers.OntologyService> disabledOntologies = ontologyHelper.getOntologyServices().stream()
                 .filter( os -> !os.isEnabled() )
                 .collect( Collectors.toSet() );
-        if ( !disabledOntologies.isEmpty() ) {
+        if ( isAutoLoad && !disabledOntologies.isEmpty() ) {
             log.warn( String.format( "The following ontologies are required by Phenocarta are not enabled:\n\t%s.",
                     disabledOntologies.stream().map( Object::toString ).collect( Collectors.joining( "\n\t" ) ) ) );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/service/GeoBrowserServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/geo/service/GeoBrowserServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -53,6 +54,7 @@ import java.util.concurrent.Executors;
 /**
  * @author pavlidis
  */
+@Lazy
 @Component
 public class GeoBrowserServiceImpl implements GeoBrowserService, InitializingBean, DisposableBean {
     private static final int MIN_SAMPLES = 5;

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/homology/HomologeneServiceFactory.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/genome/gene/ncbi/homology/HomologeneServiceFactory.java
@@ -50,9 +50,6 @@ public class HomologeneServiceFactory extends AbstractAsyncFactoryBean<Homologen
         HomologeneService homologeneService = new HomologeneServiceImpl( geneService, taxonService, homologeneFile );
         if ( loadHomologene ) {
             homologeneService.refresh();
-        } else {
-            log.warn( String.format( "Homologene is not enabled, set %s=true in Gemma.properties to load it on startup.",
-                    LOAD_HOMOLOGENE_CONFIG ) );
         }
         return homologeneService;
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,6 @@ import ubic.basecode.ontology.jena.AbstractOntologyMemoryBackedService;
 import ubic.basecode.ontology.model.AnnotationProperty;
 import ubic.basecode.ontology.model.OntologyTerm;
 import ubic.basecode.ontology.search.OntologySearchException;
-import ubic.basecode.util.Configuration;
 import ubic.gemma.core.genome.gene.service.GeneService;
 import ubic.gemma.model.common.description.Characteristic;
 import ubic.gemma.model.genome.Gene;
@@ -40,7 +40,6 @@ import ubic.gemma.model.genome.GeneOntologyTermValueObject;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.association.Gene2GOAssociationService;
 import ubic.gemma.persistence.util.CacheUtils;
-import ubic.gemma.persistence.util.Settings;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -57,7 +56,6 @@ public class GeneOntologyServiceImpl extends AbstractOntologyMemoryBackedService
         BIOLOGICAL_PROCESS, CELLULAR_COMPONENT, MOLECULAR_FUNCTION
     }
 
-    private final static String GO_URL = Settings.getString( "url.geneOntology" );
     private static final Log log = LogFactory.getLog( GeneOntologyServiceImpl.class.getName() );
 
     /**
@@ -91,7 +89,7 @@ public class GeneOntologyServiceImpl extends AbstractOntologyMemoryBackedService
 
     @Override
     protected String getOntologyUrl() {
-        return Settings.getString( "url.geneOntology" );
+        return ontologyUrl;
     }
 
     /**
@@ -110,7 +108,11 @@ public class GeneOntologyServiceImpl extends AbstractOntologyMemoryBackedService
     @Autowired
     private CacheManager cacheManager;
 
-    private final boolean autoLoad;
+    @Value("${url.geneOntology}")
+    private String ontologyUrl;
+
+    @Value("${load.ontologies}")
+    private boolean isAutoLoad;
 
     /**
      * Cache of gene -> go terms.
@@ -122,37 +124,22 @@ public class GeneOntologyServiceImpl extends AbstractOntologyMemoryBackedService
      */
     private Cache term2Aspect;
 
-    /**
-     * If this load.ontologies is NOT configured, we go ahead (per-ontology config will be checked).
-     */
-    private static boolean isAutoLoad() {
-        String doLoad = Configuration.getString( "load.ontologies" );
-        return StringUtils.isBlank( doLoad ) || Configuration.getBoolean( "load.ontologies" );
-    }
-
     public GeneOntologyServiceImpl() {
-        this( isAutoLoad() );
-    }
 
-    public GeneOntologyServiceImpl( boolean autoLoad ) {
-        this.autoLoad = autoLoad;
     }
-
 
     @Override
     public void afterPropertiesSet() throws InterruptedException {
         goTerms = CacheUtils.getCache( cacheManager, "GeneOntologyService.goTerms" );
         term2Aspect = CacheUtils.getCache( cacheManager, "GeneOntologyService.term2Aspect" );
-        if ( autoLoad ) {
+        if ( isAutoLoad ) {
             startInitializationThread( false, false );
-        } else {
-            log.info( "Auto-loading of ontologies is disabled, GO terms will not be available." );
         }
     }
 
     @Override
     public void destroy() throws Exception {
-        if ( isAutoLoad() ) {
+        if ( isInitializationThreadAlive() ) {
             cancelInitializationThread();
         }
     }

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/OntologyServiceFactory.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/providers/OntologyServiceFactory.java
@@ -18,13 +18,7 @@ public class OntologyServiceFactory<T extends OntologyService> extends AbstractF
     /**
      * Determine if ontologies are to be loaded on startup.
      */
-    private static final boolean isAutoLoad = ( StringUtils.isBlank( Configuration.getString( "load.ontologies" ) ) || Configuration.getBoolean( "load.ontologies" ) );
-
-    static {
-        if ( !isAutoLoad ) {
-            log.warn( "Auto-loading of ontologies is disabled, enable it by setting load.ontologies=true in Gemma.properties." );
-        }
-    }
+    private static final boolean isAutoLoad = StringUtils.isBlank( Configuration.getString( "load.ontologies" ) ) || Configuration.getBoolean( "load.ontologies" );
 
     private final Class<T> ontologyServiceClass;
     private boolean forceLoad = false;

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
@@ -21,7 +21,6 @@ package ubic.gemma.core.search;
 
 import com.google.common.collect.Sets;
 import gemma.gsec.util.SecurityUtil;
-import lombok.Value;
 import lombok.extern.apachecommons.CommonsLog;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -29,8 +28,6 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.Cache;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.TypeDescriptor;
@@ -74,6 +71,7 @@ import ubic.gemma.persistence.util.EntityUtils;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -231,7 +229,7 @@ public class SearchServiceImpl implements SearchService, InitializingBean {
     public void afterPropertiesSet() throws Exception {
         searchSource = new CompositeSearchSource( Arrays.asList( databaseSearchSource, hibernateSearchSource, ontologySearchSource ) );
         initializeSupportedResultTypes();
-        this.initializeNameToTaxonMap();
+        Executors.newSingleThreadExecutor().submit( this::initializeNameToTaxonMap );
     }
 
     private void initializeSupportedResultTypes() {

--- a/gemma-core/src/main/java/ubic/gemma/core/util/BeanInitializationTimeMonitor.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/BeanInitializationTimeMonitor.java
@@ -30,7 +30,7 @@ public class BeanInitializationTimeMonitor implements BeanPostProcessor, Ordered
     /**
      * Total amount of time that has to elapse while initializing the context for emitting a warning.
      */
-    private static final int TOTAL_TIME_WARN_THRESHOLD = 5000;
+    private static final int TOTAL_TIME_WARN_THRESHOLD = 0;
 
     private final Map<String, StopWatch> stopWatches = new HashMap<>();
 

--- a/gemma-core/src/test/java/ubic/gemma/core/ontology/providers/GeneOntologyService2Test.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/ontology/providers/GeneOntologyService2Test.java
@@ -55,7 +55,7 @@ public class GeneOntologyService2Test extends AbstractJUnit4SpringContextTests {
     public static class GeneOntologyService2TestContextConfiguration {
         @Bean
         public GeneOntologyService geneOntologyService() throws IOException, InterruptedException {
-            GeneOntologyServiceImpl gos = new GeneOntologyServiceImpl( false );
+            GeneOntologyServiceImpl gos = new GeneOntologyServiceImpl();
             InputStream is = new GZIPInputStream(
                     new ClassPathResource( "/data/loader/ontology/go.bptest.owl.gz" ).getInputStream() );
             OntologyTestUtils.initialize( gos, is );

--- a/gemma-core/src/test/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/ontology/providers/GeneOntologyServiceTest.java
@@ -56,7 +56,7 @@ public class GeneOntologyServiceTest extends AbstractJUnit4SpringContextTests {
     static class GeneOntologyServiceTestContextConfiguration {
         @Bean
         public GeneOntologyService geneOntologyService() throws IOException, InterruptedException {
-            GeneOntologyService goService = new GeneOntologyServiceImpl( false );
+            GeneOntologyService goService = new GeneOntologyServiceImpl();
             /*
              * Note that this test file is out of date in some ways. See GeneOntologyServiceTest2
              */

--- a/gemma-web/src/main/java/ubic/gemma/web/listener/StartupListener.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/listener/StartupListener.java
@@ -105,6 +105,8 @@ public class StartupListener extends ContextLoaderListener {
 
         this.loadTrackerInformation( config );
 
+        this.lintConfiguration();
+
         ApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext( servletContext );
 
         servletContext.setAttribute( Constants.CONFIG, config );
@@ -116,6 +118,18 @@ public class StartupListener extends ContextLoaderListener {
         StartupListener.log.info( String.format( "Initialization of Gemma Web context took %d s. The following profiles are active: %s.",
                 sw.getTime( TimeUnit.SECONDS ),
                 String.join( ", ", ctx.getEnvironment().getActiveProfiles() ) ) );
+    }
+
+    /**
+     * Perform some basic sanity checks for the configuration.
+     */
+    private void lintConfiguration() {
+        if ( !Settings.getBoolean( "load.ontologies" ) ) {
+            log.warn( "Auto-loading of ontologies is disabled, enable it by setting load.ontologies=true in Gemma.properties." );
+        }
+        if ( !Settings.getBoolean( "load.homologene" ) ) {
+            log.warn( "Homologene is not enabled, set load.homologene=true in Gemma.properties to load it on startup." );
+        }
     }
 
     private static final String JAWR_DEBUG_ON_SYSTEM_PROPERTY = "net.jawr.debug.on";

--- a/gemma-web/src/main/webapp/WEB-INF/gemma-servlet.xml
+++ b/gemma-web/src/main/webapp/WEB-INF/gemma-servlet.xml
@@ -18,6 +18,7 @@
         <context:exclude-filter type="annotation" expression="ubic.gemma.persistence.util.TestComponent"/>
     </context:component-scan>
 
+    <!-- resolves ${...} placeholders in the servlet configuration (i.e. web.xml) -->
     <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
         <property name="environment">
             <bean class="org.springframework.web.context.support.StandardServletEnvironment"/>


### PR DESCRIPTION
Warn on the CLI if ontologies or Homologene is enabled on startup and do the exact opposite for Gemma Web.

Only warn that load.ontologies is false if at least one ontology is enabled.

Warn on the CLI if Hibernate is configured to validate the database on startup. This is unnecessary and costly.

Remove redundant GO service warning if load.ontologies is false, this is already covered by the ontology service.

Make the GEO browser bean lazy. It's only used in Gemma Web, so it won't be loaded on the CLI.