### PR TITLE
Eliminate offset/limit parameters and improve the code for retrieving…

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/report/ExpressionExperimentReportServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/report/ExpressionExperimentReportServiceImpl.java
@@ -465,7 +465,7 @@ public class ExpressionExperimentReportServiceImpl implements ExpressionExperime
         assert id != null;
 
         Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> analysis = differentialExpressionAnalysisService
-                .getAnalysesByExperiment( Collections.singleton( id ) );
+                .getAnalysesByExperimentIds( Collections.singleton( id ), true );
         if ( analysis != null && analysis.containsKey( eeVo ) ) {
             eeVo.setDifferentialExpressionAnalyses( analysis.get( eeVo ) );
         }

--- a/gemma-core/src/main/java/ubic/gemma/core/tasks/visualization/DifferentialExpressionSearchTaskImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/tasks/visualization/DifferentialExpressionSearchTaskImpl.java
@@ -131,7 +131,7 @@ public class DifferentialExpressionSearchTaskImpl
 
         // database hit: important that this be fast.
         Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> analyses = differentialExpressionAnalysisService
-                .getAnalysesByExperiment( EntityUtils.getIds( experimentGroup ) );
+                .getAnalysesByExperimentIds( EntityUtils.getIds( experimentGroup ), true );
 
         experiment:
         for ( ExpressionExperimentDetailsValueObject bas : analyses.keySet() ) {

--- a/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisValueObject.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/analysis/expression/diff/DifferentialExpressionAnalysisValueObject.java
@@ -16,7 +16,8 @@ package ubic.gemma.model.analysis.expression.diff;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.Hibernate;
 import ubic.gemma.model.analysis.AnalysisValueObject;
 import ubic.gemma.model.expression.experiment.ExperimentalFactorValueObject;
@@ -50,8 +51,15 @@ public class DifferentialExpressionAnalysisValueObject extends AnalysisValueObje
     private Collection<DiffExResultSetSummaryValueObject> resultSets = new HashSet<>();
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Collection<Long> arrayDesignsUsed;
+    /**
+     * The ID of the experiment being analyzed. Either an experiment or a subset.
+     */
     private Long bioAssaySetId;
-    private Long sourceExperiment;
+    /**
+     * If this is an analysis of a subset, the ID of the source experiment.
+     */
+    @Nullable
+    private Long sourceExperimentId;
     private ExperimentalFactorValueObject subsetFactor;
     private FactorValueValueObject subsetFactorValue;
 
@@ -70,7 +78,7 @@ public class DifferentialExpressionAnalysisValueObject extends AnalysisValueObje
         // experimentAnalyzed is eagerly fetched
         if ( analysis.getExperimentAnalyzed() instanceof ExpressionExperimentSubSet ) {
             // sourceExperiment is eagerly fetched too
-            this.sourceExperiment = ( ( ExpressionExperimentSubSet ) analysis.getExperimentAnalyzed() ).getSourceExperiment().getId();
+            this.sourceExperimentId = ( ( ExpressionExperimentSubSet ) analysis.getExperimentAnalyzed() ).getSourceExperiment().getId();
         }
         if ( analysis.getSubsetFactorValue() != null && Hibernate.isInitialized( ( analysis.getSubsetFactorValue() ) ) ) {
             this.subsetFactorValue = new FactorValueValueObject( analysis.getSubsetFactorValue() );
@@ -78,6 +86,14 @@ public class DifferentialExpressionAnalysisValueObject extends AnalysisValueObje
                     analysis.getSubsetFactorValue().getExperimentalFactor() );
             // fill in the factorValuesUsed separately, needs access to details of the subset.
         }
+    }
+
+    /**
+     * @deprecated this was renamed to {@link #getSourceExperimentId()} for consistency
+     */
+    @Deprecated
+    public Long getSourceExperiment() {
+        return sourceExperimentId;
     }
 
     /**

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDao.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDao.java
@@ -24,6 +24,7 @@ import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
 import ubic.gemma.model.expression.experiment.BioAssaySet;
 import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.model.expression.experiment.ExpressionExperimentSubSet;
 import ubic.gemma.model.genome.Gene;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.analysis.SingleExperimentAnalysisDao;
@@ -71,6 +72,11 @@ public interface DifferentialExpressionAnalysisDao extends SingleExperimentAnaly
 
     Collection<Long> getExperimentsWithAnalysis( Taxon taxon );
 
+    /**
+     * Obtain analyses per experiment IDs which can be either IDs of {@link ExpressionExperiment} or {@link ExpressionExperimentSubSet}.
+     * @param includeAnalysesOfSubsets whether to include the analysis of subsets if th experiment ID is that of an {@link ExpressionExperiment}
+     * @return a mapping of IDs of {@link BioAssaySet} to lists of {@link DifferentialExpressionAnalysisValueObject}
+     */
     Map<Long, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperimentIds(
-            Collection<Long> expressionExperimentIds, int offset, int limit );
+            Collection<Long> experimentIds, boolean includeAnalysesOfSubsets );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisDaoImpl.java
@@ -18,7 +18,6 @@
  */
 package ubic.gemma.persistence.service.analysis.expression.diff;
 
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.Hibernate;
@@ -477,16 +476,15 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
 
     @Override
     public Map<Long, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperimentIds(
-            Collection<Long> expressionExperimentIds, int offset, int limit ) {
+            Collection<Long> experimentIds, boolean includeAnalysesOfSubsets ) {
 
         /*
          * There are three cases to consider: the ids are experiments; the ids are experiment subsets; the ids are
          * experiments that have subsets.
          */
-        Map<Long, List<DifferentialExpressionAnalysisValueObject>> r = new HashMap<>();
 
         Map<Long, Collection<Long>> arrayDesignsUsed = CommonQueries
-                .getArrayDesignsUsedEEMap( expressionExperimentIds, this.getSessionFactory().getCurrentSession() );
+                .getArrayDesignsUsedEEMap( experimentIds, this.getSessionFactory().getCurrentSession() );
 
         /*
          * Fetch analyses of experiments or subsets.
@@ -496,10 +494,56 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
                         "select distinct a from DifferentialExpressionAnalysis a "
                                 + "join fetch a.experimentAnalyzed e "
                                 + "where e.id in (:eeIds)" )
-                .setParameterList( "eeIds", expressionExperimentIds )
-                .setFirstResult( offset )
-                .setMaxResults( limit )
+                .setParameterList( "eeIds", experimentIds )
                 .list();
+
+        Map<Long, Collection<FactorValue>> ee2fv = new HashMap<>();
+
+        if ( !hits.isEmpty() ) {
+            // factor values for the experiments.
+            //noinspection unchecked
+            List<Object[]> fvs = this.getSessionFactory().getCurrentSession().createQuery(
+                            "select ee.id, fv from ExpressionExperiment ee "
+                                    + "join ee.bioAssays ba join ba.sampleUsed bm join bm.factorValues fv "
+                                    + "where ee.id in (:ees) "
+                                    + "group by ee, fv" )
+                    .setParameterList( "ees", experimentIds ).list();
+            this.addFactorValues( ee2fv, fvs );
+        }
+
+        if ( includeAnalysesOfSubsets ) {
+            // Subsets of those same experiments (there might not be any)
+            //noinspection unchecked
+            List<DifferentialExpressionAnalysis> analysesOfSubsets = this.getSessionFactory().getCurrentSession()
+                    .createQuery( "select distinct a from ExpressionExperimentSubSet ee, DifferentialExpressionAnalysis a "
+                            + "join ee.sourceExperiment see "
+                            + "join fetch a.experimentAnalyzed eeanalyzed "
+                            + "where see.id in (:eeids) and ee=eeanalyzed" )
+                    .setParameterList( "eeids", experimentIds ).list();
+
+            if ( !analysesOfSubsets.isEmpty() ) {
+                hits.addAll( analysesOfSubsets );
+                Collection<Long> experimentSubsetIds = new HashSet<>();
+                for ( DifferentialExpressionAnalysis a : analysesOfSubsets ) {
+                    experimentSubsetIds.add( a.getExperimentAnalyzed().getId() );
+                }
+                // factor value information for the subset. The key output is the ID of the subset, not of the source
+                // experiment.
+                //noinspection unchecked
+                List<Object[]> fvs = this.getSessionFactory().getCurrentSession()
+                        .createQuery( "select ee.id, fv from ExpressionExperimentSubSet ee "
+                                + "join ee.bioAssays ba join ba.sampleUsed bm join bm.factorValues fv "
+                                + "where ee.id in (:ees) "
+                                + "group by ee, fv" )
+                        .setParameterList( "ees", experimentSubsetIds ).list();
+                this.addFactorValues( ee2fv, fvs );
+            }
+        }
+
+        // postprocesss...
+        if ( hits.isEmpty() ) {
+            return Collections.emptyMap();
+        }
 
         // initialize result sets and hit list sizes
         // this is necessary because the DEA VO constructor will ignore uninitialized associations
@@ -510,88 +554,21 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
             }
         }
 
-        Map<Long, Collection<FactorValue>> ee2fv = new HashMap<>();
-        List<Object[]> fvs;
-
-        if ( !hits.isEmpty() ) {
-            // factor values for the experiments.
-            //noinspection unchecked
-            fvs = this.getSessionFactory().getCurrentSession().createQuery(
-                            "select distinct ee.id, fv from " + "ExpressionExperiment"
-                                    + " ee join ee.bioAssays ba join ba.sampleUsed bm join bm.factorValues fv where ee.id in (:ees)" )
-                    .setParameterList( "ees", expressionExperimentIds ).list();
-            this.addFactorValues( ee2fv, fvs );
-
-            // also get factor values for subsets - those not found yet.
-            Collection<Long> used = new HashSet<>();
-            for ( DifferentialExpressionAnalysis a : hits ) {
-                used.add( a.getExperimentAnalyzed().getId() );
-            }
-
-            List probableSubSetIds = ListUtils.removeAll( used, ee2fv.keySet() );
-            if ( !probableSubSetIds.isEmpty() ) {
-                //noinspection unchecked
-                fvs = this.getSessionFactory().getCurrentSession().createQuery(
-                                "select distinct ee.id, fv from " + "ExpressionExperimentSubSet"
-                                        + " ee join ee.bioAssays ba join ba.sampleUsed bm join bm.factorValues fv where ee.id in (:ees)" )
-                        .setParameterList( "ees", probableSubSetIds ).list();
-                this.addFactorValues( ee2fv, fvs );
-            }
-
-        }
-
-        /*
-         * Subsets of those same experiments (there might not be any)
-         */
-        //noinspection unchecked
-        List<DifferentialExpressionAnalysis> analysesOfSubsets = this.getSessionFactory().getCurrentSession()
-                .createQuery( "select distinct a from " + "ExpressionExperimentSubSet"
-                        + " ee, DifferentialExpressionAnalysis a" + " join ee.sourceExperiment see "
-                        + " join fetch a.experimentAnalyzed eeanalyzed where see.id in (:eeids) and ee=eeanalyzed" )
-                .setParameterList( "eeids", expressionExperimentIds ).list();
-
-        if ( !analysesOfSubsets.isEmpty() ) {
-            hits.addAll( analysesOfSubsets );
-
-            Collection<Long> experimentSubsetIds = new HashSet<>();
-            for ( DifferentialExpressionAnalysis a : analysesOfSubsets ) {
-                ExpressionExperimentSubSet subset = ( ExpressionExperimentSubSet ) a.getExperimentAnalyzed();
-                experimentSubsetIds.add( subset.getId() );
-            }
-
-            // factor value information for the subset. The key output is the ID of the subset, not of the source
-            // experiment.
-            //noinspection unchecked
-            fvs = this.getSessionFactory().getCurrentSession().createQuery(
-                            "select distinct ee.id, fv from " + "ExpressionExperimentSubSet"
-                                    + " ee join ee.bioAssays ba join ba.sampleUsed bm join bm.factorValues fv where ee.id in (:ees)" )
-                    .setParameterList( "ees", experimentSubsetIds ).list();
-            this.addFactorValues( ee2fv, fvs );
-        }
-
-        // postprocesss...
-        if ( hits.isEmpty() ) {
-            return r;
-        }
         Collection<DifferentialExpressionAnalysisValueObject> summaries = this
                 .convertToValueObjects( hits, arrayDesignsUsed, ee2fv );
 
+        Map<Long, List<DifferentialExpressionAnalysisValueObject>> r = new HashMap<>();
         for ( DifferentialExpressionAnalysisValueObject an : summaries ) {
-
             Long bioAssaySetId;
-            if ( an.getSourceExperiment() != null ) {
-                bioAssaySetId = an.getSourceExperiment();
+            if ( an.getSourceExperimentId() != null ) {
+                bioAssaySetId = an.getSourceExperimentId();
             } else {
                 bioAssaySetId = an.getBioAssaySetId();
             }
-            if ( !r.containsKey( bioAssaySetId ) ) {
-                r.put( bioAssaySetId, new ArrayList<DifferentialExpressionAnalysisValueObject>() );
-            }
-            r.get( bioAssaySetId ).add( an );
+            r.computeIfAbsent( bioAssaySetId, k -> new ArrayList<>() ).add( an );
         }
 
         return r;
-
     }
 
     @Override
@@ -699,12 +676,12 @@ class DifferentialExpressionAnalysisDaoImpl extends SingleExperimentAnalysisDaoB
                 avo.setSubsetFactor(
                         new ExperimentalFactorValueObject( analysis.getSubsetFactorValue().getExperimentalFactor() ) );
                 assert bioAssaySet instanceof ExpressionExperimentSubSet;
-                avo.setSourceExperiment( ( ( ExpressionExperimentSubSet ) bioAssaySet ).getSourceExperiment().getId() );
+                avo.setSourceExperimentId( ( ( ExpressionExperimentSubSet ) bioAssaySet ).getSourceExperiment().getId() );
                 if ( arrayDesignsUsed.containsKey( bioAssaySet.getId() ) ) {
                     avo.setArrayDesignsUsed( arrayDesignsUsed.get( bioAssaySet.getId() ) );
                 } else {
-                    assert arrayDesignsUsed.containsKey( avo.getSourceExperiment() );
-                    avo.setArrayDesignsUsed( arrayDesignsUsed.get( avo.getSourceExperiment() ) );
+                    assert arrayDesignsUsed.containsKey( avo.getSourceExperimentId() );
+                    avo.setArrayDesignsUsed( arrayDesignsUsed.get( avo.getSourceExperimentId() ) );
                 }
             } else {
                 Collection<Long> adids = arrayDesignsUsed.get( bioAssaySet.getId() );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisService.java
@@ -22,10 +22,7 @@ import org.springframework.security.access.annotation.Secured;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysisValueObject;
 import ubic.gemma.model.analysis.expression.diff.ExpressionAnalysisResultSet;
-import ubic.gemma.model.expression.experiment.BioAssaySet;
-import ubic.gemma.model.expression.experiment.ExperimentalFactor;
-import ubic.gemma.model.expression.experiment.ExpressionExperiment;
-import ubic.gemma.model.expression.experiment.ExpressionExperimentDetailsValueObject;
+import ubic.gemma.model.expression.experiment.*;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.persistence.service.BaseService;
 import ubic.gemma.persistence.service.analysis.SingleExperimentAnalysisService;
@@ -118,19 +115,37 @@ public interface DifferentialExpressionAnalysisService extends BaseService<Diffe
     boolean canDelete( DifferentialExpressionAnalysis differentialExpressionAnalysis );
 
     /**
-     * Given a set of ids, find experiments or experimentsubsets that have differential expression analyses. Subsets are
-     * handled two ways: if the ID given is of a subset, or if the ID is of an experiment that has subsets. In the
+     * Retrieve all the analysis VOs for a given {@link BioAssaySet}.
+     * <p>
+     * If the given experiment has subsets, the returned list will contain experiments for its {@link ExpressionExperimentSubSet}
+     * as per {@link #getAnalysesByExperiments(Collection, boolean)}.
+     */
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    List<DifferentialExpressionAnalysisValueObject> getAnalysesByExperiment( BioAssaySet experiment, boolean includeAnalysesOfSubsets );
+
+    /**
+     * Retrieve differential expression analyses by their associated experiment.
+     * <p>
+     * If the experiment is a {@link ExpressionExperiment} that has subsets, the returned values will contain analyses
+     * of its {@link ExpressionExperimentSubSet}.
+     * <p>
+     * Subsets are handled two ways: if the given experiment is a subset, or if the experiment has subsets. In the
      * latter case, the return value will contain experiments that were not explicitly queried for.
      *
-     * @param ids of experiments or experimentsubsets.
-     * @return map of bioassayset (valueobjects) to analyses (valueobjects) for each.
+     * @param experiments a collection of {@link ExpressionExperiment} or {@link ExpressionExperimentSubSet}
+     * @return a mapping of {@link BioAssaySet} VOs to analysies VOs
      */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_MAP_READ" })
-    Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
-            Collection<Long> ids );
+    Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiments( Collection<? extends BioAssaySet> experiments, boolean includeAnalysesOfSubsets );
 
+    /**
+     * Retrieve differential expression analyses by IDs of their associated experiment.
+     * <p>
+     * If the ID represent a {@link ExpressionExperiment} that has subsets, the returned values will contain analyses of
+     * its {@link ExpressionExperimentSubSet}.
+     *
+     * @see DifferentialExpressionAnalysisDao#getAnalysesByExperimentIds(Collection, boolean)
+     */
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "AFTER_ACL_VALUE_OBJECT_MAP_READ" })
-    Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
-            Collection<Long> ids, int offset, int limit );
-
+    Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperimentIds( Collection<Long> experimentIds, boolean includeAnalysesOfSubsets );
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/analysis/expression/diff/DifferentialExpressionAnalysisServiceImpl.java
@@ -192,17 +192,24 @@ public class DifferentialExpressionAnalysisServiceImpl extends AbstractService<D
 
     @Override
     @Transactional(readOnly = true)
-    public Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
-            Collection<Long> ids ) {
-        return this.getAnalysesByExperiment( ids, 0, -1 );
+    public List<DifferentialExpressionAnalysisValueObject> getAnalysesByExperiment( BioAssaySet experiment, boolean includeAnalysesOfSubsets ) {
+        return differentialExpressionAnalysisDao
+                .getAnalysesByExperimentIds( Collections.singleton( experiment.getId() ), includeAnalysesOfSubsets )
+                .getOrDefault( experiment.getId(), Collections.emptyList() );
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment(
-            Collection<Long> ids, int offset, int limit ) {
+    public Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiments(
+            Collection<? extends BioAssaySet> experiments, boolean includeAnalysesOfSubsets ) {
+        return getAnalysesByExperimentIds( EntityUtils.getIds( experiments ), includeAnalysesOfSubsets );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperimentIds( Collection<Long> experimentIds, boolean includeAnalysesOfSubsets ) {
         Map<Long, List<DifferentialExpressionAnalysisValueObject>> analysesByExperimentIds = this.differentialExpressionAnalysisDao
-                .getAnalysesByExperimentIds( ids, offset, limit );
+                .getAnalysesByExperimentIds( experimentIds, includeAnalysesOfSubsets );
 
         Map<Long, ExpressionExperimentDetailsValueObject> idMap = EntityUtils.getIdMap( expressionExperimentDao
                 .loadDetailsValueObjectsByIds( analysesByExperimentIds.keySet() ) );

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DiffExMetaAnalyzerServiceTest.java
@@ -426,7 +426,7 @@ public class DiffExMetaAnalyzerServiceTest extends AbstractGeoServiceTest {
         assertTrue( !differentialExpressionResultService.find( g, 0.05, 10 ).isEmpty() );
 
         Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> analysesByExperiment = differentialExpressionAnalysisService
-                .getAnalysesByExperiment( EntityUtils.getIds( Arrays.asList( ds1, ds2, ds3 ) ) );
+                .getAnalysesByExperiments( Arrays.asList( ds1, ds2, ds3 ), true );
 
         Collection<DiffExResultSetSummaryValueObject> resultSets = new HashSet<>();
         for ( ExpressionExperimentDetailsValueObject evo : analysesByExperiment.keySet() ) {

--- a/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/analysis/expression/diff/DifferentialExpressionAnalyzerServiceTest.java
@@ -297,7 +297,7 @@ public class DifferentialExpressionAnalyzerServiceTest extends AbstractGeoServic
         // check that we read it back correctly.
         {
             Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> vos = differentialExpressionAnalysisService
-                    .getAnalysesByExperiment( Collections.singleton( ee.getId() ) );
+                    .getAnalysesByExperiments( Collections.singleton( ee ), true );
             // it will retrieve the analysis of the subset.
             assertEquals( 1, vos.size() );
         }
@@ -305,7 +305,7 @@ public class DifferentialExpressionAnalyzerServiceTest extends AbstractGeoServic
         // retrieve the analysis of the subset directly.
         {
             Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> vos = differentialExpressionAnalysisService
-                    .getAnalysesByExperiment( Collections.singleton( eeset.getId() ) );
+                    .getAnalysesByExperiments( Collections.singleton( eeset ), true );
             assertEquals( 1, vos.size() );
             for ( DifferentialExpressionAnalysisValueObject vo : vos.entrySet().iterator().next().getValue() ) {
                 assertNotNull( vo.getSubsetFactorValue() );

--- a/gemma-rest/src/main/java/ubic/gemma/rest/DatasetsWebService.java
+++ b/gemma-rest/src/main/java/ubic/gemma/rest/DatasetsWebService.java
@@ -55,7 +55,6 @@ import ubic.gemma.model.expression.bioAssay.BioAssayValueObject;
 import ubic.gemma.model.expression.bioAssayData.ExperimentExpressionLevelsValueObject;
 import ubic.gemma.model.expression.bioAssayData.RawExpressionDataVector;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
-import ubic.gemma.model.expression.experiment.ExpressionExperimentDetailsValueObject;
 import ubic.gemma.model.expression.experiment.ExpressionExperimentValueObject;
 import ubic.gemma.model.genome.Taxon;
 import ubic.gemma.model.genome.TaxonValueObject;
@@ -603,13 +602,9 @@ public class DatasetsWebService {
                     content = @Content(schema = @Schema(implementation = ResponseErrorObject.class))) })
     public ResponseDataObject<List<DifferentialExpressionAnalysisValueObject>> getDatasetDifferentialExpressionAnalyses( // Params:
             @PathParam("dataset") DatasetArg<?> datasetArg, // Required
-            @QueryParam("offset") @DefaultValue("0") OffsetArg offset, // Optional, default 0
-            @QueryParam("limit") @DefaultValue("20") LimitArg limit // Optional, default 20
+            @QueryParam("includeAnalysesOfSubsets") @DefaultValue("false") Boolean includeAnalysesOfSubsets
     ) {
-        return Responder.respond(
-                this.getDiffExVos( datasetArgService.getEntity( datasetArg ).getId(),
-                        offset.getValue(), limit.getValue() )
-        );
+        return datasetArgService.getAnalysesByExperiment( datasetArg, includeAnalysesOfSubsets );
     }
 
     /**
@@ -1006,14 +1001,6 @@ public class DatasetsWebService {
                 .build();
     }
 
-    private List<DifferentialExpressionAnalysisValueObject> getDiffExVos( Long eeId, int offset, int limit ) {
-        Map<ExpressionExperimentDetailsValueObject, List<DifferentialExpressionAnalysisValueObject>> map = differentialExpressionAnalysisService
-                .getAnalysesByExperiment( Collections.singleton( eeId ), offset, limit );
-        if ( map == null || map.size() < 1 ) {
-            return Collections.emptyList();
-        }
-        return map.get( map.keySet().iterator().next() );
-    }
 
     @Value
     private static class SimpleSVDValueObject {

--- a/gemma-rest/src/main/java/ubic/gemma/rest/util/args/DatasetArgService.java
+++ b/gemma-rest/src/main/java/ubic/gemma/rest/util/args/DatasetArgService.java
@@ -10,6 +10,7 @@ import ubic.gemma.core.search.Highlighter;
 import ubic.gemma.core.search.SearchException;
 import ubic.gemma.core.search.SearchResult;
 import ubic.gemma.core.search.SearchService;
+import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysisValueObject;
 import ubic.gemma.model.common.description.AnnotationValueObject;
 import ubic.gemma.model.common.quantitationtype.QuantitationTypeValueObject;
 import ubic.gemma.model.common.search.SearchSettings;
@@ -17,6 +18,7 @@ import ubic.gemma.model.expression.arrayDesign.ArrayDesignValueObject;
 import ubic.gemma.model.expression.bioAssay.BioAssay;
 import ubic.gemma.model.expression.bioAssay.BioAssayValueObject;
 import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.persistence.service.analysis.expression.diff.DifferentialExpressionAnalysisService;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 import ubic.gemma.persistence.service.expression.bioAssay.BioAssayService;
 import ubic.gemma.persistence.service.expression.experiment.ExpressionExperimentService;
@@ -24,6 +26,8 @@ import ubic.gemma.persistence.util.Filter;
 import ubic.gemma.persistence.util.Filters;
 import ubic.gemma.persistence.util.Sort;
 import ubic.gemma.rest.util.MalformedArgException;
+import ubic.gemma.rest.util.Responder;
+import ubic.gemma.rest.util.ResponseDataObject;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.BadRequestException;
@@ -37,14 +41,16 @@ public class DatasetArgService extends AbstractEntityArgService<ExpressionExperi
     private final ArrayDesignService adService;
     private final BioAssayService baService;
     private final OutlierDetectionService outlierDetectionService;
+    private final DifferentialExpressionAnalysisService differentialExpressionAnalysisService;
 
     @Autowired
-    public DatasetArgService( ExpressionExperimentService service, SearchService searchService, ArrayDesignService adService, BioAssayService baService, OutlierDetectionService outlierDetectionService ) {
+    public DatasetArgService( ExpressionExperimentService service, SearchService searchService, ArrayDesignService adService, BioAssayService baService, OutlierDetectionService outlierDetectionService, DifferentialExpressionAnalysisService differentialExpressionAnalysisService ) {
         super( service );
         this.searchService = searchService;
         this.adService = adService;
         this.baService = baService;
         this.outlierDetectionService = outlierDetectionService;
+        this.differentialExpressionAnalysisService = differentialExpressionAnalysisService;
     }
 
     @Override
@@ -159,5 +165,9 @@ public class DatasetArgService extends AbstractEntityArgService<ExpressionExperi
     public Set<AnnotationValueObject> getAnnotations( DatasetArg<?> arg ) {
         ExpressionExperiment ee = this.getEntity( arg );
         return service.getAnnotationsById( ee.getId() );
+    }
+
+    public ResponseDataObject<List<DifferentialExpressionAnalysisValueObject>> getAnalysesByExperiment( DatasetArg<?> datasetArg, boolean includeAnalysesOfSubsets ) {
+        return Responder.respond( differentialExpressionAnalysisService.getAnalysesByExperiment( getEntity( datasetArg ), includeAnalysesOfSubsets ) );
     }
 }

--- a/gemma-rest/src/test/java/ubic/gemma/rest/AnnotationsWebServiceTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/AnnotationsWebServiceTest.java
@@ -79,7 +79,7 @@ public class AnnotationsWebServiceTest extends AbstractJUnit4SpringContextTests 
 
         @Bean
         public DatasetArgService datasetRestService( ExpressionExperimentService service, SearchService searchService ) {
-            return new DatasetArgService( service, searchService, mock( ArrayDesignService.class ), mock( BioAssayService.class ), mock( OutlierDetectionService.class ) );
+            return new DatasetArgService( service, searchService, mock( ArrayDesignService.class ), mock( BioAssayService.class ), mock( OutlierDetectionService.class ), mock() );
         }
 
         @Bean

--- a/gemma-rest/src/test/java/ubic/gemma/rest/DatasetsWebServiceTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/DatasetsWebServiceTest.java
@@ -100,7 +100,7 @@ public class DatasetsWebServiceTest extends BaseJerseyTest {
 
         @Bean
         public DatasetArgService datasetArgService( ExpressionExperimentService expressionExperimentService, SearchService searchService ) {
-            return new DatasetArgService( expressionExperimentService, searchService, mock( ArrayDesignService.class ), mock( BioAssayService.class ), mock( OutlierDetectionService.class ) );
+            return new DatasetArgService( expressionExperimentService, searchService, mock( ArrayDesignService.class ), mock( BioAssayService.class ), mock( OutlierDetectionService.class ), mock() );
         }
 
         @Bean


### PR DESCRIPTION
… analysis VOs

Remove unnecessary offset/limit parameters of getDatasetDifferentialExpressionAnalyses() (fix #841).

Add a parameter to include analyses of subsets.

Tidy up the DAO:

 - don't retrieve FVs for subsets if includeAnalysesOfSubsets is false
 - initialize proxies of both experiments and subsets

Include analyses of subsets in the output of the endpoint.

Add two new service methods to retrieve analysis VOs: one by a collection of BioAssaySet and another one for a single BioAssaySet. Use the latter for the REST API.

Rename sourceExperiment to sourceExperimentId and retain the older name marked as deprecated (fix #844).