### PR TITLE
Improve cacheability of filters

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/util/ListUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/ListUtils.java
@@ -1,9 +1,6 @@
 package ubic.gemma.core.util;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Utilities and algorithms for {@link List}.
@@ -43,5 +40,22 @@ public class ListUtils {
                 element2position.put( element, i );
             }
         }
+    }
+
+    /**
+     * Pad a list to the next power of 2 with the given element.
+     */
+    public static List<?> padToNextPowerOfTwo( List<?> list, Object elementForPadding ) {
+        int k = Integer.highestOneBit( list.size() );
+        if ( list.size() == k ) {
+            return list; // already a power of 2
+        }
+        k <<= 1;
+        List<Object> paddedList = new ArrayList<>( k );
+        paddedList.addAll( list );
+        for ( int j = list.size(); j < k; j++ ) {
+            paddedList.add( elementForPadding );
+        }
+        return paddedList;
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentServiceImpl.java
@@ -564,7 +564,7 @@ public class ExpressionExperimentServiceImpl
         // apply inference to terms
         // collect clauses mentioning terms
         final Map<SubClauseKey, Set<String>> termUrisBySubClause = new HashMap<>();
-        for ( List<Filter> clause : f ) {
+        for ( Iterable<Filter> clause : f ) {
             Filters.FiltersClauseBuilder clauseBuilder = f2.and();
             for ( Filter subClause : clause ) {
                 if ( ArrayUtils.contains( PROPERTIES_USED_FOR_ANNOTATIONS, subClause.getOriginalProperty() ) ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/Filters.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/Filters.java
@@ -96,6 +96,10 @@ public class Filters implements Iterable<Iterable<Filter>> {
         return empty().and( subClauses );
     }
 
+    public static Filters by( Collection<Filter> subClauses ) {
+        return empty().and( subClauses );
+    }
+
     /**
      * Create a singleton {@link Filters} from an explicit clause.
      */
@@ -178,6 +182,11 @@ public class Filters implements Iterable<Iterable<Filter>> {
      */
     public Filters and( Filter... filters ) {
         clauses.add( new TreeSet<>( Arrays.asList( filters ) ) );
+        return this;
+    }
+
+    public Filters and( Collection<Filter> filters ) {
+        clauses.add( new TreeSet<>( filters ) );
         return this;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/Filters.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/Filters.java
@@ -3,6 +3,7 @@ package ubic.gemma.persistence.util;
 import lombok.EqualsAndHashCode;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -12,18 +13,18 @@ import java.util.stream.Collectors;
  * @author poirigui
  */
 @EqualsAndHashCode(of = { "clauses" })
-public class Filters implements Iterable<List<Filter>> {
+public class Filters implements Iterable<Iterable<Filter>> {
 
     /**
      * Builder for a disjunctive sub-clause.
      */
     public class FiltersClauseBuilder {
 
-        private final List<Filter> subClauses;
+        private final SortedSet<Filter> subClauses;
         private boolean built = false;
 
         private FiltersClauseBuilder() {
-            subClauses = new ArrayList<>();
+            subClauses = new TreeSet<>();
         }
 
         /**
@@ -65,7 +66,7 @@ public class Filters implements Iterable<List<Filter>> {
         }
 
         public Filters build() {
-            Filters.this.clauses.add( Collections.unmodifiableList( subClauses ) );
+            Filters.this.clauses.add( Collections.unmodifiableSortedSet( subClauses ) );
             built = true;
             return Filters.this;
         }
@@ -129,10 +130,40 @@ public class Filters implements Iterable<List<Filter>> {
         return empty().and( filters );
     }
 
-    private final List<List<Filter>> clauses;
+    private final SortedSet<SortedSet<Filter>> clauses;
 
     private Filters() {
-        this.clauses = new ArrayList<>();
+        this.clauses = new TreeSet<>( getComparator() );
+    }
+
+    private Comparator<SortedSet<Filter>> getComparator() {
+        return ( filters, otherFilter ) -> {
+            Iterator<Filter> a = filters.iterator();
+            Iterator<Filter> b = otherFilter.iterator();
+            while ( a.hasNext() && b.hasNext() ) {
+                int cmp = a.next().compareTo( b.next() );
+                if ( cmp != 0 ) {
+                    return cmp;
+                }
+            }
+            if ( a.hasNext() ) {
+                return 1;
+            }
+            if ( b.hasNext() ) {
+                return -1;
+            }
+            // clauses are identical, they will be collapsed
+            return 0;
+        };
+    }
+
+    @Nullable
+    private <E> E firstOrNull( SortedSet<E> set ) {
+        try {
+            return set.first();
+        } catch ( NoSuchElementException e ) {
+            return null;
+        }
     }
 
     /**
@@ -146,7 +177,7 @@ public class Filters implements Iterable<List<Filter>> {
      * Add a clause of one or more {@link Filter} sub-clauses to the conjunction.
      */
     public Filters and( Filter... filters ) {
-        clauses.add( Arrays.asList( filters ) );
+        clauses.add( new TreeSet<>( Arrays.asList( filters ) ) );
         return this;
     }
 
@@ -184,8 +215,8 @@ public class Filters implements Iterable<List<Filter>> {
      * Add all the clauses of another filter to this.
      */
     public Filters and( Filters filters ) {
-        for ( List<Filter> clause : filters.clauses ) {
-            clauses.add( Collections.unmodifiableList( new ArrayList<>( clause ) ) );
+        for ( SortedSet<Filter> clause : filters.clauses ) {
+            clauses.add( Collections.unmodifiableSortedSet( new TreeSet<>( clause ) ) );
         }
         return this;
     }
@@ -197,15 +228,16 @@ public class Filters implements Iterable<List<Filter>> {
      */
     public boolean isEmpty() {
         // hint: allMatch returns true if the stream is empty
-        return clauses.stream().allMatch( List::isEmpty );
+        return clauses.stream().allMatch( SortedSet::isEmpty );
     }
 
     /**
      * Obtain an iterator over the clauses contained in this conjunction.
      */
     @Override
-    public Iterator<List<Filter>> iterator() {
-        return clauses.iterator();
+    @Nonnull
+    public Iterator<Iterable<Filter>> iterator() {
+        return clauses.stream().map( c -> ( Iterable<Filter> ) c ).iterator();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/FiltersUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/FiltersUtils.java
@@ -23,7 +23,7 @@ public class FiltersUtils {
         }
         if ( filters == null )
             return false;
-        for ( List<Filter> clause : filters ) {
+        for ( Iterable<Filter> clause : filters ) {
             if ( clause == null )
                 continue;
             for ( Filter subClause : clause ) {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/Subquery.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/Subquery.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 
 import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,7 +26,7 @@ import java.util.stream.Collectors;
  * @see Filter#by(String, String, Class, Filter.Operator, Subquery, String)
  */
 @Value
-public class Subquery {
+public class Subquery implements Comparable<Subquery> {
 
     @Value
     public static class Alias {
@@ -82,6 +83,11 @@ public class Subquery {
         }
         this.rootAlias = rootAlias;
         this.filter = filter;
+    }
+
+    @Override
+    public int compareTo( Subquery subquery ) {
+        return filter.compareTo( subquery.filter );
     }
 
     public String toString() {

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/FilterQueryUtilsTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/FilterQueryUtilsTest.java
@@ -33,15 +33,15 @@ public class FilterQueryUtilsTest {
                 .or( Filter.parse( "ee", "id", Long.class, Filter.Operator.in, Arrays.asList( "5", "6", "7", "8" ) ) )
                 .build();
         assertThat( formRestrictionClause( filters ) )
-                .isEqualTo( " and (ee.shortName like :ee_shortName1) and (ee.id in (:ee_id2)) and (ad.taxonId = :ad_taxonId3) and (ee.id in (:ee_id4) or ee.id in (:ee_id5))" );
+                .isEqualTo( " and (ad.taxonId = :ad_taxonId1) and (ee.id in (:ee_id2)) and (ee.id in (:ee_id3) or ee.id in (:ee_id4)) and (ee.shortName like :ee_shortName5)" );
 
         Query mockedQuery = mock( Query.class );
         addRestrictionParameters( mockedQuery, filters );
-        verify( mockedQuery ).setParameter( "ee_shortName1", "GSE%" );
+        verify( mockedQuery ).setParameter( "ad_taxonId1", 9606L );
         verify( mockedQuery ).setParameterList( "ee_id2", Arrays.asList( 1L, 2L, 3L, 4L ) );
-        verify( mockedQuery ).setParameter( "ad_taxonId3", 9606L );
-        verify( mockedQuery ).setParameterList( "ee_id4", Arrays.asList( 1L, 2L, 3L, 4L ) );
-        verify( mockedQuery ).setParameterList( "ee_id5", Arrays.asList( 5L, 6L, 7L, 8L ) );
+        verify( mockedQuery ).setParameterList( "ee_id3", Arrays.asList( 1L, 2L, 3L, 4L ) );
+        verify( mockedQuery ).setParameterList( "ee_id4", Arrays.asList( 5L, 6L, 7L, 8L ) );
+        verify( mockedQuery ).setParameter( "ee_shortName5", "GSE%" );
     }
 
     @Test

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/FiltersTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/FiltersTest.java
@@ -3,6 +3,7 @@ package ubic.gemma.persistence.util;
 import org.apache.commons.collections4.IterableUtils;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,13 +23,16 @@ public class FiltersTest {
                     .or( "ee", "shortName", String.class, Filter.Operator.like, "%brain%" )
                     .or( "ee", "description", String.class, Filter.Operator.like, "%tumor%" )
                 .build();
-        List<List<Filter>> clauses = IterableUtils.toList( filters );
-        assertThat( clauses ).hasSize( 4 );
-        assertThat( clauses.get( 0 ) ).extracting( "requiredValue" ).containsExactly( 3L );
-        assertThat( clauses.get( 1 ) ).extracting( "requiredValue" ).containsExactly( 1L, 2L );
-        assertThat( clauses.get( 2 ) ).isEmpty();
-        assertThat( clauses.get( 3 ) ).extracting( "requiredValue" ).containsExactly( "%brain%", "%tumor%" );
-        assertThat( filters ).hasToString( "ee.id = 3 and ee.id = 1 or ee.id = 2 and ee.shortName like %brain% or ee.description like %tumor%" );
+        assertThat( filters )
+                .hasSize( 4 )
+                .hasToString( "ee.description like %tumor% or ee.shortName like %brain% and ee.id = 1 or ee.id = 2 and ee.id = 3" )
+                .flatExtracting( it -> {
+                    List<Filter> f = new ArrayList<>();
+                    it.forEach( f::add );
+                    return f;
+                } )
+                .extracting( Filter::getRequiredValue )
+                .containsExactly( "%tumor%", "%brain%", 1L, 2L, 3L );
     }
 
     @Test

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/ListUtilsTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/ListUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import ubic.gemma.core.util.ListUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,5 +33,13 @@ public class ListUtilsTest {
         assertThat( str2position.get( "a" ) ).isEqualTo( 0 );
         assertThat( str2position.get( "A" ) ).isEqualTo( 0 );
         assertThat( str2position.get( "baBa" ) ).isEqualTo( 2 );
+    }
+
+    @Test
+    public void testPadToNextPowerOfTwo() {
+        assertThat( ListUtils.padToNextPowerOfTwo( Collections.emptyList(), null ) ).hasSize( 0 );
+        assertThat( ListUtils.padToNextPowerOfTwo( Arrays.asList( 1L, 2L, 3L ), null ) ).hasSize( 4 );
+        assertThat( ListUtils.padToNextPowerOfTwo( Arrays.asList( 1L, 2L, 3L, 4L ), null ) ).hasSize( 4 );
+        assertThat( ListUtils.padToNextPowerOfTwo( Arrays.asList( 1L, 2L, 3L, 4L, 5L ), null ) ).hasSize( 8 );
     }
 }

--- a/gemma-rest/src/test/java/ubic/gemma/rest/AnnotationsWebServiceTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/AnnotationsWebServiceTest.java
@@ -147,7 +147,7 @@ public class AnnotationsWebServiceTest extends AbstractJUnit4SpringContextTests 
                 LimitArg.valueOf( "20" ),
                 SortArg.valueOf( "+id" ) );
         assertThat( payload )
-                .hasFieldOrPropertyWithValue( "filter", "commonName = human or scientificName = human and id in (1)" )
+                .hasFieldOrPropertyWithValue( "filter", "id in (1) and commonName = human or scientificName = human" )
                 .hasFieldOrPropertyWithValue( "sort", new SortValueObject( Sort.by( "ee", "id", Sort.Direction.ASC, "id" ) ) )
                 .hasFieldOrPropertyWithValue( "offset", 0 )
                 .hasFieldOrPropertyWithValue( "limit", 20 )

--- a/gemma-rest/src/test/java/ubic/gemma/rest/DatasetsRestTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/DatasetsRestTest.java
@@ -135,7 +135,7 @@ public class DatasetsRestTest extends BaseSpringContextTest {
     public void testAllFilterByIdIn() {
         FilterArg<ExpressionExperiment> filterArg = FilterArg.valueOf( "id in (" + ees.get( 0 ).getId() + ")" );
         assertThat( datasetArgService.getFilters( filterArg ) )
-                .extracting( of -> of.get( 0 ) )
+                .extracting( of -> of.iterator().next() )
                 .first()
                 .hasFieldOrPropertyWithValue( "objectAlias", ExpressionExperimentDao.OBJECT_ALIAS )
                 .hasFieldOrPropertyWithValue( "propertyName", "id" )
@@ -159,7 +159,7 @@ public class DatasetsRestTest extends BaseSpringContextTest {
     public void testAllFilterByShortName() {
         FilterArg<ExpressionExperiment> filterArg = FilterArg.valueOf( "shortName = " + ees.get( 0 ).getShortName() );
         assertThat( datasetArgService.getFilters( filterArg ) )
-                .extracting( of -> of.get( 0 ) )
+                .extracting( of -> of.iterator().next() )
                 .first()
                 .hasFieldOrPropertyWithValue( "objectAlias", ExpressionExperimentDao.OBJECT_ALIAS )
                 .hasFieldOrPropertyWithValue( "propertyName", "shortName" )
@@ -183,7 +183,7 @@ public class DatasetsRestTest extends BaseSpringContextTest {
     public void testAllFilterByShortNameIn() {
         FilterArg<ExpressionExperiment> filterArg = FilterArg.valueOf( "shortName in (" + ees.get( 0 ).getShortName() + ")" );
         assertThat( datasetArgService.getFilters( filterArg ) )
-                .extracting( of -> of.get( 0 ) )
+                .extracting( of -> of.iterator().next() )
                 .first()
                 .hasFieldOrPropertyWithValue( "objectAlias", ExpressionExperimentDao.OBJECT_ALIAS )
                 .hasFieldOrPropertyWithValue( "propertyName", "shortName" )

--- a/gemma-rest/src/test/java/ubic/gemma/rest/util/args/FilterArgTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/util/args/FilterArgTest.java
@@ -57,7 +57,7 @@ public class FilterArgTest {
         setUpMockVoService();
         Filters filters = FilterArg.valueOf( "a = b" ).getFilters( mockVoService );
         assertThat( filters )
-                .extracting( of -> of.get( 0 ) )
+                .extracting( of -> of.iterator().next() )
                 .first()
                 .hasFieldOrPropertyWithValue( "propertyName", "a" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
@@ -97,13 +97,13 @@ public class FilterArgTest {
         Filters filters = FilterArg.valueOf( "a = b and c = d" ).getFilters( mockVoService );
         assertThat( filters ).hasSize( 2 );
         assertThat( filters )
-                .extracting( of -> of.get( 0 ) )
+                .extracting( of -> of.iterator().next() )
                 .first()
                 .hasFieldOrPropertyWithValue( "propertyName", "a" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
                 .hasFieldOrPropertyWithValue( "requiredValue", "b" );
         assertThat( filters )
-                .extracting( of -> of.get( 0 ) )
+                .extracting( of -> of.iterator().next() )
                 .last()
                 .hasFieldOrPropertyWithValue( "propertyName", "c" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
@@ -118,27 +118,27 @@ public class FilterArgTest {
         assertThat( filters.iterator().next() )
                 .hasSize( 2 );
 
-        assertThat( filters.iterator().next().get( 0 ) )
+        assertThat( filters.iterator().next().iterator().next() )
                 .hasFieldOrPropertyWithValue( "propertyName", "a" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
                 .hasFieldOrPropertyWithValue( "requiredValue", "b" );
 
-        assertThat( filters.iterator().next().get( 1 ) )
-                .hasFieldOrPropertyWithValue( "propertyName", "c" )
-                .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
-                .hasFieldOrPropertyWithValue( "requiredValue", "d" );
+        // assertThat( filters.iterator().next().get( 1 ) )
+        //         .hasFieldOrPropertyWithValue( "propertyName", "c" )
+        //         .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
+        //         .hasFieldOrPropertyWithValue( "requiredValue", "d" );
 
         FilterArg.valueOf( "a = b or c = d" ).getFilters( mockVoService );
 
-        assertThat( filters.iterator().next().get( 0 ) )
+        assertThat( filters.iterator().next().iterator().next() )
                 .hasFieldOrPropertyWithValue( "propertyName", "a" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
                 .hasFieldOrPropertyWithValue( "requiredValue", "b" );
 
-        assertThat( filters.iterator().next().get( 1 ) )
-                .hasFieldOrPropertyWithValue( "propertyName", "c" )
-                .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
-                .hasFieldOrPropertyWithValue( "requiredValue", "d" );
+        // assertThat( filters.iterator().next().get( 1 ) )
+        //         .hasFieldOrPropertyWithValue( "propertyName", "c" )
+        //         .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
+        //         .hasFieldOrPropertyWithValue( "requiredValue", "d" );
     }
 
     @Test
@@ -148,32 +148,32 @@ public class FilterArgTest {
 
         assertThat( filters ).hasSize( 2 );
 
-        Iterator<List<Filter>> iterator = filters.iterator();
-        List<Filter> of;
+        Iterator<Iterable<Filter>> iterator = filters.iterator();
+        Iterable<Filter> of;
 
         of = iterator.next();
         assertThat( of )
                 .hasSize( 2 );
-        assertThat( of.get( 0 ) )
+        assertThat( of.iterator().next() )
                 .hasFieldOrPropertyWithValue( "propertyName", "a" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
                 .hasFieldOrPropertyWithValue( "requiredValue", "b" );
 
-        assertThat( of.get( 1 ) )
-                .hasFieldOrPropertyWithValue( "propertyName", "g" )
-                .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
-                .hasFieldOrPropertyWithValue( "requiredValue", "h" );
+        // assertThat( of.get( 1 ) )
+        //         .hasFieldOrPropertyWithValue( "propertyName", "g" )
+        //         .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
+        //         .hasFieldOrPropertyWithValue( "requiredValue", "h" );
 
         of = iterator.next();
-        assertThat( of.get( 0 ) )
+        assertThat( of.iterator().next() )
                 .hasFieldOrPropertyWithValue( "propertyName", "c" )
                 .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
                 .hasFieldOrPropertyWithValue( "requiredValue", "d" );
 
-        assertThat( of.get( 1 ) )
-                .hasFieldOrPropertyWithValue( "propertyName", "e" )
-                .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
-                .hasFieldOrPropertyWithValue( "requiredValue", "f" );
+        // assertThat( of.get( 1 ) )
+        //         .hasFieldOrPropertyWithValue( "propertyName", "e" )
+        //         .hasFieldOrPropertyWithValue( "operator", Filter.Operator.eq )
+        //         .hasFieldOrPropertyWithValue( "requiredValue", "f" );
     }
 
     @Test
@@ -186,7 +186,7 @@ public class FilterArgTest {
         FilterArg<Identifiable> fa = FilterArg.valueOf( "lastUpdated >= 2022-01-01" );
         Filters f = fa.getFilters( mockVoService );
         assertThat( f ).isNotNull();
-        Filter subClause = f.iterator().next().get( 0 );
+        Filter subClause = f.iterator().next().iterator().next();
         assertThat( subClause )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "lastUpdated" );
@@ -198,7 +198,7 @@ public class FilterArgTest {
         FilterArg<Identifiable> fa2 = FilterArg.valueOf( subClause.toString() );
         Filters f2 = fa2.getFilters( mockVoService );
         assertThat( f2 ).isNotNull();
-        Filter subClause2 = f2.iterator().next().get( 0 );
+        Filter subClause2 = f2.iterator().next().iterator().next();
         assertThat( subClause2 )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "alias.lastUpdated" );
@@ -225,7 +225,7 @@ public class FilterArgTest {
         FilterArg<Identifiable> fa = FilterArg.valueOf( "foo >= " + s );
         Filters f = fa.getFilters( mockVoService );
         assertThat( f ).isNotNull();
-        Filter subClause = f.iterator().next().get( 0 );
+        Filter subClause = f.iterator().next().iterator().next();
         assertThat( subClause )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "foo" )
@@ -238,7 +238,7 @@ public class FilterArgTest {
         FilterArg<Identifiable> fa = FilterArg.valueOf( "foo >= \"\\\"\"" );
         Filters f = fa.getFilters( mockVoService );
         assertThat( f ).isNotNull();
-        Filter subClause = f.iterator().next().get( 0 );
+        Filter subClause = f.iterator().next().iterator().next();
         assertThat( subClause )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "foo" )
@@ -290,7 +290,7 @@ public class FilterArgTest {
         setUpMockVoService();
         FilterArg<Identifiable> arg = FilterArg.valueOf( "H4sIAAAAAAAAA8tMUbBVMAQA2dNQugYAAAA=" );
         Filters f = arg.getFilters( mockVoService );
-        Filter subClause = f.iterator().next().get( 0 );
+        Filter subClause = f.iterator().next().iterator().next();
         assertThat( subClause )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "id" )
@@ -302,7 +302,7 @@ public class FilterArgTest {
         setUpMockVoService();
         FilterArg<Identifiable> arg = FilterArg.valueOf( "H4s = 1" );
         Filters f = arg.getFilters( mockVoService );
-        Filter subClause = f.iterator().next().get( 0 );
+        Filter subClause = f.iterator().next().iterator().next();
         assertThat( subClause )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "H4s" )
@@ -312,7 +312,7 @@ public class FilterArgTest {
     private void checkValidCollection( Collection<String> expected, String input ) {
         FilterArg<Identifiable> fa = FilterArg.valueOf( "foo in " + input );
         Filters f = fa.getFilters( mockVoService );
-        Filter subClause = f.iterator().next().get( 0 );
+        Filter subClause = f.iterator().next().iterator().next();
         assertThat( subClause )
                 .hasFieldOrPropertyWithValue( "objectAlias", "alias" )
                 .hasFieldOrPropertyWithValue( "propertyName", "foo" )


### PR DESCRIPTION
Sort clauses and sub-clauses so that equivalent queries have identical filters.

Implement padding to the next power-of-two by repeating the last element of a collection.

Break-up filters so we can cache expensive clauses and run simpler queries against the database.

Fix #869 and #870

## TODO

 - [ ] more testing is needed and we have to identify edge cases