### PR TITLE
Denormalize the anonymous permission mask in the EE2C table

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDaoImpl.java
@@ -688,14 +688,14 @@ public class ExpressionExperimentDaoImpl
             }
         }
         String query = "select T.CATEGORY as CATEGORY, T.CATEGORY_URI as CATEGORY_URI, count(distinct T.EXPRESSION_EXPERIMENT_FK) as EE_COUNT from EXPRESSION_EXPERIMENT2CHARACTERISTIC T "
-                + AclQueryUtils.formNativeAclJoinClause( "T.EXPRESSION_EXPERIMENT_FK" ) + " "
+                + EE2CAclQueryUtils.formNativeAclJoinClause( "T.EXPRESSION_EXPERIMENT_FK" ) + " "
                 + "where T.ID is not null ";
         if ( eeIds != null ) {
             query += " and T.EXPRESSION_EXPERIMENT_FK in :eeIds";
         }
         query += getExcludeUrisClause( "T.CATEGORY_URI", "T.CATEGORY", "excludedCategoryUris", excludedCategoryUris, excludeFreeTextCategories, excludeUncategorized, retainedTermUris );
         query += getExcludeUrisClause( "T.VALUE_URI", "T.`VALUE`", "excludedTermUris", excludedTermUris, excludeFreeTextTerms, false, retainedTermUris );
-        query += AclQueryUtils.formNativeAclRestrictionClause( ( SessionFactoryImplementor ) getSessionFactory() ) + " "
+        query += EE2CAclQueryUtils.formNativeAclRestrictionClause( ( SessionFactoryImplementor ) getSessionFactory(), "T.ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK" ) + " "
                 + "group by COALESCE(T.CATEGORY_URI, T.CATEGORY) "
                 + "order by EE_COUNT desc";
         Query q = getSessionFactory().getCurrentSession().createSQLQuery( query )
@@ -717,7 +717,7 @@ public class ExpressionExperimentDaoImpl
         if ( retainedTermUris != null && !retainedTermUris.isEmpty() ) {
             q.setParameterList( "retainedTermUris", retainedTermUris );
         }
-        AclQueryUtils.addAclParameters( q, ExpressionExperiment.class );
+        EE2CAclQueryUtils.addAclParameters( q, ExpressionExperiment.class );
         //noinspection unchecked
         List<Object[]> result = q.list();
         TreeMap<Characteristic, Long> byC = new TreeMap<>( Characteristic.getByCategoryComparator() );
@@ -762,7 +762,7 @@ public class ExpressionExperimentDaoImpl
             }
         }
         String query = "select T.`VALUE` as `VALUE`, T.VALUE_URI as VALUE_URI, T.CATEGORY as CATEGORY, T.CATEGORY_URI as CATEGORY_URI, T.EVIDENCE_CODE as EVIDENCE_CODE, count(distinct T.EXPRESSION_EXPERIMENT_FK) as EE_COUNT from EXPRESSION_EXPERIMENT2CHARACTERISTIC T "
-                + AclQueryUtils.formNativeAclJoinClause( "T.EXPRESSION_EXPERIMENT_FK" ) + " "
+                + EE2CAclQueryUtils.formNativeAclJoinClause( "T.EXPRESSION_EXPERIMENT_FK" ) + " "
                 + "where T.ID is not null"; // this is necessary for the clause building since there might be no clause
         if ( eeIds != null ) {
             query += " and T.EXPRESSION_EXPERIMENT_FK in :eeIds";
@@ -779,7 +779,7 @@ public class ExpressionExperimentDaoImpl
         }
         query += getExcludeUrisClause( "T.CATEGORY_URI", "T.CATEGORY", "excludedCategoryUris", excludedCategoryUris, excludeFreeTextCategories, excludeUncategorized, retainedTermUris );
         query += getExcludeUrisClause( "T.VALUE_URI", "T.`VALUE`", "excludedTermUris", excludedTermUris, excludeFreeTextTerms, false, retainedTermUris );
-        query += AclQueryUtils.formNativeAclRestrictionClause( ( SessionFactoryImplementor ) getSessionFactory() ) + " "
+        query += EE2CAclQueryUtils.formNativeAclRestrictionClause( ( SessionFactoryImplementor ) getSessionFactory(), "T.ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK" ) + " "
                 + "group by COALESCE(T.CATEGORY_URI, T.CATEGORY), COALESCE(T.VALUE_URI, T.`VALUE`) "
                 + "having EE_COUNT >= :minFrequency ";
         if ( retainedTermUris != null && !retainedTermUris.isEmpty() ) {
@@ -817,7 +817,7 @@ public class ExpressionExperimentDaoImpl
             q.setParameter( "level", level );
         }
         q.setParameter( "minFrequency", minFrequency );
-        AclQueryUtils.addAclParameters( q, ExpressionExperiment.class );
+        EE2CAclQueryUtils.addAclParameters( q, ExpressionExperiment.class );
         //noinspection unchecked
         List<Object[]> result = q.list();
         TreeMap<Characteristic, Long> byC = new TreeMap<>( Characteristic.getByCategoryAndValueComparator() );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/EE2CAclQueryUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/EE2CAclQueryUtils.java
@@ -1,0 +1,45 @@
+package ubic.gemma.persistence.util;
+
+import gemma.gsec.model.Securable;
+import gemma.gsec.util.SecurityUtil;
+import org.hibernate.Query;
+import org.hibernate.dialect.function.SQLFunction;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.type.IntegerType;
+import org.springframework.security.acls.domain.BasePermission;
+
+import java.util.Arrays;
+
+/**
+ * This class provides a fast-path to {@link AclQueryUtils} that uses the denormalized mask for anonymous users.
+ * @author poirigui
+ */
+public class EE2CAclQueryUtils {
+
+    public static String formNativeAclJoinClause( String aoiIdColumn ) {
+        // ACLs are only necessary for regular, non-admin users
+        if ( SecurityUtil.isUserAnonymous() || SecurityUtil.isUserAdmin() ) {
+            return "";
+        } else {
+            return AclQueryUtils.formNativeAclJoinClause( aoiIdColumn );
+        }
+    }
+
+    public static String formNativeAclRestrictionClause( SessionFactoryImplementor sessionFactoryImplementor, String anonymousMaskColumn ) {
+        if ( SecurityUtil.isUserAnonymous() ) {
+            SQLFunction bitwiseAnd = sessionFactoryImplementor.getSqlFunctionRegistry().findSQLFunction( "bitwise_and" );
+            String mask = bitwiseAnd.render( new IntegerType(), Arrays.asList( anonymousMaskColumn, BasePermission.READ.getMask() ), sessionFactoryImplementor );
+            return " and " + mask + " <> 0";
+        } else if ( SecurityUtil.isUserAdmin() ) {
+            return "";
+        } else {
+            return AclQueryUtils.formNativeAclRestrictionClause( sessionFactoryImplementor );
+        }
+    }
+
+    public static void addAclParameters( Query query, Class<? extends Securable> aoiType ) {
+        if ( !SecurityUtil.isUserAdmin() && !SecurityUtil.isUserAnonymous() ) {
+            AclQueryUtils.addAclParameters( query, aoiType );
+        }
+    }
+}

--- a/gemma-core/src/main/resources/sql/init-entities.sql
+++ b/gemma-core/src/main/resources/sql/init-entities.sql
@@ -159,17 +159,18 @@ alter table GENE2CS
 drop table if exists EXPRESSION_EXPERIMENT2CHARACTERISTIC;
 create table EXPRESSION_EXPERIMENT2CHARACTERISTIC
 (
-    ID                       bigint,
-    NAME                     varchar(255),
-    DESCRIPTION              text,
-    CATEGORY                 varchar(255),
-    CATEGORY_URI             varchar(255),
-    VALUE                    varchar(255),
-    VALUE_URI                varchar(255),
-    ORIGINAL_VALUE           varchar(255),
-    EVIDENCE_CODE            varchar(255),
-    EXPRESSION_EXPERIMENT_FK bigint,
-    LEVEL                    varchar(255),
+    ID                                    bigint,
+    NAME                                  varchar(255),
+    DESCRIPTION                           text,
+    CATEGORY                              varchar(255),
+    CATEGORY_URI                          varchar(255),
+    VALUE                                 varchar(255),
+    VALUE_URI                             varchar(255),
+    ORIGINAL_VALUE                        varchar(255),
+    EVIDENCE_CODE                         varchar(255),
+    EXPRESSION_EXPERIMENT_FK              bigint,
+    ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK int,
+    LEVEL                                 varchar(255),
     primary key (ID, EXPRESSION_EXPERIMENT_FK, LEVEL)
 );
 

--- a/gemma-core/src/main/resources/sql/init-entities.sql
+++ b/gemma-core/src/main/resources/sql/init-entities.sql
@@ -169,7 +169,7 @@ create table EXPRESSION_EXPERIMENT2CHARACTERISTIC
     ORIGINAL_VALUE                        varchar(255),
     EVIDENCE_CODE                         varchar(255),
     EXPRESSION_EXPERIMENT_FK              bigint,
-    ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK int,
+    ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK int not null default 0,
     LEVEL                                 varchar(255),
     primary key (ID, EXPRESSION_EXPERIMENT_FK, LEVEL)
 );

--- a/gemma-core/src/main/resources/sql/migrations/db.1.31.1.sql
+++ b/gemma-core/src/main/resources/sql/migrations/db.1.31.1.sql
@@ -1,0 +1,3 @@
+-- add permission masks for all common group SIDs
+alter table EXPRESSION_EXPERIMENT2CHARACTERISTIC
+    add column ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK INTEGER not null default 0;

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/common/description/CharacteristicDaoImplTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/common/description/CharacteristicDaoImplTest.java
@@ -171,13 +171,12 @@ public class CharacteristicDaoImplTest extends BaseDatabaseTest {
         ee.setTaxon( taxon );
         ee.getCharacteristics().add( c );
         sessionFactory.getCurrentSession().persist( ee );
-        sessionFactory.getCurrentSession().flush();
-
         // add ACLs and read permission to everyone
         MutableAcl acl = aclService.createAcl( new AclObjectIdentity( ee ) );
         acl.insertAce( 0, BasePermission.READ, new AclGrantedAuthoritySid(
                 new SimpleGrantedAuthority( AuthorityConstants.IS_AUTHENTICATED_ANONYMOUSLY ) ), false );
         aclService.updateAcl( acl );
+        sessionFactory.getCurrentSession().flush();
 
         int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries();
         assertThat( updated ).isEqualTo( 1 );

--- a/gemma-core/src/test/resources/sql/init-entities.sql
+++ b/gemma-core/src/test/resources/sql/init-entities.sql
@@ -29,17 +29,18 @@ alter table GENE2CS
 drop table if exists EXPRESSION_EXPERIMENT2CHARACTERISTIC;
 create table EXPRESSION_EXPERIMENT2CHARACTERISTIC
 (
-    ID                       bigint,
-    NAME                     varchar(255),
-    DESCRIPTION              text,
-    CATEGORY                 varchar(255),
-    CATEGORY_URI             varchar(255),
-    `VALUE`                  varchar(255),
-    VALUE_URI                varchar(255),
-    ORIGINAL_VALUE           varchar(255),
-    EVIDENCE_CODE            varchar(255),
-    EXPRESSION_EXPERIMENT_FK bigint,
-    LEVEL                    varchar(255),
+    ID                                    bigint,
+    NAME                                  varchar(255),
+    DESCRIPTION                           text,
+    CATEGORY                              varchar(255),
+    CATEGORY_URI                          varchar(255),
+    `VALUE`                               varchar(255),
+    VALUE_URI                             varchar(255),
+    ORIGINAL_VALUE                        varchar(255),
+    EVIDENCE_CODE                         varchar(255),
+    EXPRESSION_EXPERIMENT_FK              bigint,
+    ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK int not null default 0,
+    LEVEL                                 varchar(255),
     primary key (ID, EXPRESSION_EXPERIMENT_FK, LEVEL)
 );
 


### PR DESCRIPTION
Provide a permission mask for the anonymous granted authority SID in the EE2C table to accelerate the process of producing usage statistics.