### PR TITLE
Add a nodb profile

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/core/apps/GemmaCLI.java
+++ b/gemma-cli/src/main/java/ubic/gemma/core/apps/GemmaCLI.java
@@ -52,6 +52,7 @@ public class GemmaCLI {
             HELP_ALL_OPTION = "ha",
             COMPLETION_OPTION = "c",
             COMPLETION_SHELL_OPTION = "cs",
+            NODB_OPTION = "nodb",
             VERSION_OPTION = "version",
             LOGGER_OPTION = "logger",
             VERBOSITY_OPTION = "v",
@@ -81,6 +82,7 @@ public class GemmaCLI {
                 .addOption( HELP_ALL_OPTION, "help-all", false, "Show complete help with all available CLI commands" )
                 .addOption( COMPLETION_OPTION, "completion", false, "Generate a completion script" )
                 .addOption( COMPLETION_SHELL_OPTION, "completion-shell", true, "Indicate which shell to generate completion for. Only fish and bash are supported" )
+                .addOption( NODB_OPTION, "nodb", false, String.format( "Enable the %s profile which prevents database access; not all commands support this option", SpringProfiles.NODB ) )
                 .addOption( VERSION_OPTION, "version", false, "Show Gemma version" )
                 .addOption( otherLogOpt )
                 .addOption( logOpt )
@@ -153,6 +155,13 @@ public class GemmaCLI {
         // check for the -testing/--testing flag to load the appropriate application context
         if ( commandLine.hasOption( TESTING_OPTION ) ) {
             profiles.add( SpringProfiles.TEST );
+        }
+
+        // this profile will ensure that no database connection is used during application initialization, making
+        // --help-all, 'subcommand --help' and --complete work even if the database is down
+        if ( commandLine.hasOption( HELP_ALL_OPTION ) || commandLine.hasOption( COMPLETION_OPTION ) || commandLine.hasOption( NODB_OPTION )
+                || commandLine.getArgList().contains( "-help" ) || commandLine.getArgList().contains( "--help" ) ) {
+            profiles.add( SpringProfiles.NODB );
         }
 
         ApplicationContext ctx = SpringContextUtil.getApplicationContext( profiles.toArray( new String[0] ) );

--- a/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/search/SearchServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -46,6 +47,7 @@ import ubic.gemma.model.association.phenotype.PhenotypeAssociation;
 import ubic.gemma.model.common.Identifiable;
 import ubic.gemma.model.common.description.BibliographicReference;
 import ubic.gemma.model.common.description.BibliographicReferenceValueObject;
+import ubic.gemma.model.common.description.CharacteristicValueObject;
 import ubic.gemma.model.common.search.SearchSettings;
 import ubic.gemma.model.expression.BlacklistedEntity;
 import ubic.gemma.model.expression.BlacklistedValueObject;
@@ -62,12 +64,12 @@ import ubic.gemma.model.genome.biosequence.BioSequence;
 import ubic.gemma.model.genome.gene.GeneSet;
 import ubic.gemma.model.genome.gene.GeneSetValueObject;
 import ubic.gemma.model.genome.gene.GeneValueObject;
-import ubic.gemma.model.common.description.CharacteristicValueObject;
 import ubic.gemma.model.genome.sequenceAnalysis.BioSequenceValueObject;
 import ubic.gemma.persistence.service.expression.arrayDesign.ArrayDesignService;
 import ubic.gemma.persistence.service.expression.experiment.BlacklistedEntityService;
 import ubic.gemma.persistence.service.genome.taxon.TaxonService;
 import ubic.gemma.persistence.util.EntityUtils;
+import ubic.gemma.persistence.util.SpringProfiles;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -1231,7 +1233,15 @@ public class SearchServiceImpl implements SearchService, InitializingBean {
         return results;
     }
 
+    @Autowired
+    private Environment environment;
+
     private void initializeNameToTaxonMap() {
+        if ( environment.acceptsProfiles( SpringProfiles.NODB ) ) {
+            log.debug( String.format( "The %s profile is enabled, will not populate keywords for taxa from the database.",
+                    SpringProfiles.NODB ) );
+            return;
+        }
 
         Collection<? extends Taxon> taxonCollection = taxonService.loadAll();
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/SpringProfiles.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/SpringProfiles.java
@@ -10,4 +10,9 @@ public class SpringProfiles {
     public static final String PRODUCTION = "production",
             DEV = "dev",
             TEST = "test";
+
+    /**
+     * A special profile that indicates that no database connection should be used.
+     */
+    public static final String NODB = "nodb";
 }

--- a/gemma-core/src/main/resources/default.properties
+++ b/gemma-core/src/main/resources/default.properties
@@ -167,6 +167,7 @@ gemma.hibernate.jdbc_fetch_size=128
 gemma.hibernate.jdbc_batch_size=32
 # Default size for batch-fetching data (adjust as needed, requires more memory!)
 gemma.hibernate.default_batch_fetch_size=100
+gemma.hibernate.use_jdbc_metadata_defaults=true
 #coexpression vis/grid properties
 #controls how many results will be returned per query gene:
 gemma.coexpressionSearch.maxResultsPerQueryGene=200

--- a/gemma-core/src/main/resources/ubic/gemma/applicationContext-dataSource.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/applicationContext-dataSource.xml
@@ -36,6 +36,12 @@
         </bean>
     </beans>
 
+    <beans profile="nodb">
+        <bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
+            <!-- intentionally left blank -->
+        </bean>
+    </beans>
+
     <beans profile="production">
         <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
             <property name="host" value="${mail.host}"/>

--- a/gemma-core/src/main/resources/ubic/gemma/applicationContext-hibernate.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/applicationContext-hibernate.xml
@@ -82,6 +82,8 @@
 				<prop key="hibernate.format_sql">${gemma.hibernate.format_sql}</prop>
 				<prop key="hibernate.search.lucene_version">LUCENE_36</prop>
 				<prop key="hibernate.search.default.indexBase">${gemma.search.dir}</prop>
+				<!-- prevents Hibernate from obtaining a JDBC connection when initializing; this is not stable -->
+				<prop key="hibernate.temp.use_jdbc_metadata_defaults">${gemma.hibernate.use_jdbc_metadata_defaults}</prop>
 			</props>
 		</property>
 	</bean>

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/NodbProfileTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/NodbProfileTest.java
@@ -1,0 +1,43 @@
+package ubic.gemma.persistence.util;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import ubic.gemma.core.util.test.BaseSpringContextTest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * This test cover the case where the {@link SpringProfiles#NODB} is active. In this scenario, the database cannot be
+ * accessed either during initialization or later at runtime. This is achieved by a misconfigured data source declared
+ * in applicationContext-dataSource.xml.
+ * @author poirigui
+ */
+@ActiveProfiles({ "nodb" })
+public class NodbProfileTest extends BaseSpringContextTest {
+
+    @BeforeClass
+    public static void disableHibernateUsageOfJdbcMetadataDefaults() {
+        // FIXME: this is merely there to mimic the behaviour of SpringContextUtil.prepareContext()
+        System.setProperty( "gemma.hibernate.use_jdbc_metadata_defaults", "false" );
+    }
+
+    @AfterClass
+    public static void restoreSystemProperties() {
+        System.clearProperty( "gemma.hibernate.use_jdbc_metadata_defaults" );
+    }
+
+    @Autowired
+    private HikariDataSource dataSource;
+
+    @Test
+    public void test() {
+        // TODO: check that dataSource.getConnection() has never been used
+        assertThatThrownBy( dataSource::getConnection )
+                .isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "dataSource or dataSourceClassName or jdbcUrl is required" );
+    }
+}


### PR DESCRIPTION
This approach allows --completion and --help to work without a database connection.

I've added a `-nodb` option to essentially prevent database access during the execution of a command. I think this can be a useful safety mechanism when no database interaction is intended.