### PR TITLE
Add support for HDF5-based single-cell data formats

### DIFF
--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -324,6 +324,15 @@
             <version>1.0.4</version>
         </dependency>
 
+        <!-- HDF5 -->
+        <dependency>
+            <groupId>org.hdf5group</groupId>
+            <artifactId>hdf5</artifactId>
+            <version>${hdf5.version}</version>
+            <scope>system</scope>
+            <systemPath>${hdf5.jarPath}</systemPath>
+        </dependency>
+
         <!-- Testing -->
         <!-- specifically for spring-security-test which refers to definitions from javax.servlet-api, spring-web and spring-security-web -->
         <dependency>

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/AnnDataSingleCellDataLoader.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/AnnDataSingleCellDataLoader.java
@@ -1,0 +1,207 @@
+package ubic.gemma.core.loader.expression.singleCell;
+
+import hdf.hdf5lib.HDF5Constants;
+import lombok.Setter;
+import lombok.extern.apachecommons.CommonsLog;
+import ubic.gemma.core.loader.util.hdf5.H5Dataset;
+import ubic.gemma.core.loader.util.hdf5.H5File;
+import ubic.gemma.core.loader.util.hdf5.H5Group;
+import ubic.gemma.model.common.description.Categories;
+import ubic.gemma.model.common.description.Characteristic;
+import ubic.gemma.model.common.quantitationtype.QuantitationType;
+import ubic.gemma.model.expression.bioAssay.BioAssay;
+import ubic.gemma.model.expression.bioAssayData.CellTypeAssignment;
+import ubic.gemma.model.expression.bioAssayData.SingleCellDimension;
+import ubic.gemma.model.expression.bioAssayData.SingleCellExpressionDataVector;
+import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.experiment.ExperimentalFactor;
+import ubic.gemma.model.expression.experiment.FactorType;
+import ubic.gemma.model.expression.experiment.FactorValue;
+import ubic.gemma.model.expression.experiment.Statement;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Reads single-cell vectors from the <a href="https://anndata.readthedocs.io/en/latest/fileformat-prose.html">AnnData on-disk HDF5 format</a>.
+ *
+ * @author poirigui
+ */
+@CommonsLog
+@Setter
+public class AnnDataSingleCellDataLoader implements SingleCellDataLoader {
+
+    /**
+     * Path to the HDF5 file.
+     */
+    private final Path file;
+
+    /**
+     * An indicator for unknown cell type if the dataset uses something else than the {@code -1} code.
+     */
+    @Nullable
+    private String unknownCellTypeIndicator;
+
+    public AnnDataSingleCellDataLoader( Path file ) {
+        this.file = file;
+    }
+
+    @Override
+    public SingleCellDimension getSingleCellDimension( Collection<BioAssay> bioAssays ) {
+        return new SingleCellDimension();
+    }
+
+    @Override
+    public Set<QuantitationType> getQuantitationTypes() {
+        return Collections.singleton( new QuantitationType() );
+    }
+
+    @Override
+    public Optional<CellTypeAssignment> getCellTypeAssignment() {
+        try ( H5File h5File = openFile() ) {
+            return h5File.getChildren( "obs" ).stream()
+                    // find a cell type indicator
+                    .filter( s -> s.toLowerCase().startsWith( "celltype" )
+                            && Objects.equals( h5File.getStringAttribute( "obs/" + s, "encoding-type" ), "categorical" ) )
+                    .map( s -> h5File.getGroup( "obs/" + s ) )
+                    .findFirst()
+                    .map( group -> {
+                        CellTypeAssignment assignment = new CellTypeAssignment();
+                        int unknownCellTypeCode = -1;
+                        try ( H5Dataset categories = group.getDataset( "categories" ) ) {
+                            String[] cellTypes = categories.toStringVector();
+                            for ( int i = 0; i < cellTypes.length; i++ ) {
+                                String ct = cellTypes[i];
+                                if ( ct.equals( unknownCellTypeIndicator ) ) {
+                                    if ( unknownCellTypeCode != -1 ) {
+                                        throw new IllegalStateException( "There is not than one unknown cell type indicator." );
+                                    }
+                                    log.info( "Dataset uses a special indicator for unknown cell types: " + ct + " with code: " + i + ", its occurrences will be replaced with -1." );
+                                    unknownCellTypeCode = i;
+                                    continue;
+                                }
+                                assignment.getCellTypes().add( Characteristic.Factory.newInstance( Categories.CELL_TYPE, ct, null ) );
+                            }
+                            if ( unknownCellTypeIndicator != null && unknownCellTypeCode == -1 ) {
+                                throw new IllegalStateException( "The unknown cell type indicator %s was not found." );
+                            }
+                            assignment.setNumberOfCellTypes( assignment.getCellTypes().size() );
+                        }
+                        try ( H5Dataset codes = group.getDataset( "codes" ) ) {
+                            int[] vec = codes.toIntegerVector();
+                            if ( unknownCellTypeCode != -1 ) {
+                                log.info( "Rewriting unknown cell type codes..." );
+                                // rewrite unknown codes
+                                for ( int i = 0; i < vec.length; i++ ) {
+                                    if ( vec[i] == unknownCellTypeCode ) {
+                                        vec[i] = CellTypeAssignment.UNKNOWN_CELL_TYPE;
+                                    }
+                                }
+                            }
+                            assignment.setCellTypeIndices( vec );
+                        }
+                        return assignment;
+                    } );
+        }
+    }
+
+    @Override
+    public Set<ExperimentalFactor> getFactors() throws IOException {
+        Set<ExperimentalFactor> factors = new HashSet<>();
+        try ( H5File h5File = openFile() ) {
+            for ( String g : h5File.getChildren( "obs" ) ) {
+                boolean isCategorical = Objects.equals( h5File.getStringAttribute( "obs/" + g, "encoding-type" ), "categorical" );
+                ExperimentalFactor factor = ExperimentalFactor.Factory.newInstance( g, isCategorical ? FactorType.CATEGORICAL : FactorType.CONTINUOUS );
+                Characteristic c = Characteristic.Factory.newInstance( g, null );
+                factor.setCategory( c );
+                if ( isCategorical ) {
+                    try ( H5Dataset categories = h5File.getDataset( "obs/" + g + "/categories" ) ) {
+                        // popuate FVs
+                        for ( String fv : categories.toStringVector() ) {
+                            FactorValue fvO = FactorValue.Factory.newInstance( factor );
+                            fvO.getCharacteristics().add( Statement.Factory.newInstance( c.getCategory(), c.getCategoryUri(), fv, null ) );
+                            fvO.setValue( fv );
+                            factor.getFactorValues().add( fvO );
+                        }
+                    }
+                }
+                factors.add( factor );
+            }
+        }
+        return factors;
+    }
+
+    @Override
+    public Stream<SingleCellExpressionDataVector> loadVectors( Map<String, CompositeSequence> elementsMapping, SingleCellDimension dimension, QuantitationType quantitationType ) {
+        H5File h5File = openFile();
+        Stream<SingleCellExpressionDataVector> stream;
+        try {
+            String matrixEncodingType = h5File.getStringAttribute( "X", "encoding-type" );
+            if ( matrixEncodingType == null ) {
+                throw new IllegalArgumentException( "The 'X' location does not have an encoding-type attribute." );
+            }
+            if ( matrixEncodingType.equals( "csr_matrix" ) ) {
+                stream = loadVectorsFromSparseMatrix( h5File.getGroup( "X" ) );
+            } else if ( matrixEncodingType.equals( "array" ) ) {
+                stream = loadVectorsFromDenseMatrix( h5File.getDataset( "X" ) );
+            } else {
+                throw new UnsupportedOperationException( "Loading single-cell data from " + matrixEncodingType + " is not supported." );
+            }
+        } catch ( Throwable e ) {
+            h5File.close();
+            throw e;
+        }
+        return stream.onClose( h5File::close );
+    }
+
+    private H5File openFile() {
+        H5File h5File = H5File.open( file );
+        String encodingType = h5File.getStringAttribute( "encoding-type" );
+        if ( !Objects.equals( encodingType, "anndata" ) ) {
+            h5File.close();
+            throw new IllegalArgumentException( "The HDF5 file does not have its 'encoding-type' set to 'anndata'." );
+        }
+        String encodingVersion = h5File.getStringAttribute( "encoding-version" );
+        if ( encodingVersion == null ) {
+            h5File.close();
+            throw new IllegalArgumentException( "The HDF5 file does not have an 'encoding-version' attribute set." );
+        }
+        return h5File;
+    }
+
+    private Stream<SingleCellExpressionDataVector> loadVectorsFromSparseMatrix( H5Group X ) {
+        int[] shape = requireNonNull( X.getAttribute( "shape" ) ).toIntegerVector();
+        int[] intptr;
+        try ( H5Dataset indptr = X.getDataset( "indptr" ) ) {
+            intptr = indptr.toIntegerVector();
+        }
+        assert intptr.length == shape[0] + 1;
+        H5Dataset data = X.getDataset( "data" );
+        H5Dataset indices = X.getDataset( "indices" );
+        return IntStream.range( 0, shape[0] )
+                .mapToObj( i -> {
+                    assert intptr[i] < intptr[i + 1];
+                    SingleCellExpressionDataVector vector = new SingleCellExpressionDataVector();
+                    // this is using the same storage strategy from ByteArrayConverter
+                    System.out.printf( "slicing data from %d to %d...%n", intptr[i], intptr[i + 1] );
+                    vector.setData( data.slice( intptr[i], intptr[i + 1] ).toByteVector( HDF5Constants.H5T_IEEE_F64BE ) );
+                    System.out.printf( "slicing indices from %d to %d...%n", intptr[i], intptr[i + 1] );
+                    vector.setDataIndices( indices.slice( intptr[i], intptr[i + 1] ).toIntegerVector() );
+                    return vector;
+                } )
+                .onClose( indices::close )
+                .onClose( data::close )
+                .onClose( X::close );
+    }
+
+    private Stream<SingleCellExpressionDataVector> loadVectorsFromDenseMatrix( H5Dataset X ) {
+        X.close();
+        throw new UnsupportedOperationException( "Loading single-cell data from dense matrices is not supported." );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/MexSingleCellDataLoader.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/MexSingleCellDataLoader.java
@@ -13,6 +13,7 @@ import ubic.gemma.model.expression.bioAssayData.CellTypeAssignment;
 import ubic.gemma.model.expression.bioAssayData.SingleCellDimension;
 import ubic.gemma.model.expression.bioAssayData.SingleCellExpressionDataVector;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -109,6 +110,14 @@ public class MexSingleCellDataLoader implements SingleCellDataLoader {
     @Override
     public Optional<CellTypeAssignment> getCellTypeAssignment() {
         return Optional.empty();
+    }
+
+    /**
+     * MEX does not provide experimental factors.
+     */
+    @Override
+    public Set<ExperimentalFactor> getFactors() throws IOException {
+        return Collections.emptySet();
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/SeuratDiskSingleCellDataLoader.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/SeuratDiskSingleCellDataLoader.java
@@ -1,0 +1,58 @@
+package ubic.gemma.core.loader.expression.singleCell;
+
+import ubic.gemma.model.common.quantitationtype.QuantitationType;
+import ubic.gemma.model.expression.bioAssay.BioAssay;
+import ubic.gemma.model.expression.bioAssayData.CellTypeAssignment;
+import ubic.gemma.model.expression.bioAssayData.SingleCellDimension;
+import ubic.gemma.model.expression.bioAssayData.SingleCellExpressionDataVector;
+import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.experiment.ExperimentalFactor;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of <a href="https://mojaveazure.github.io/seurat-disk/index.html">SeuratDisk</a>.
+ *
+ * @author poirigui
+ */
+public class SeuratDiskSingleCellDataLoader implements SingleCellDataLoader {
+
+    private final Path path;
+
+    public SeuratDiskSingleCellDataLoader( Path path ) {
+        this.path = path;
+    }
+
+    @Override
+    public SingleCellDimension getSingleCellDimension( Collection<BioAssay> bioAssays ) {
+        return null;
+    }
+
+    @Override
+    public Set<QuantitationType> getQuantitationTypes() throws IOException {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Optional<CellTypeAssignment> getCellTypeAssignment() throws IOException {
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<ExperimentalFactor> getFactors() throws IOException {
+        return null;
+    }
+
+    @Override
+    public Stream<SingleCellExpressionDataVector> loadVectors( Map<String, CompositeSequence> elementsMapping, SingleCellDimension dimension, QuantitationType quantitationType ) throws IOException {
+        return null;
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/SingleCellDataLoader.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/expression/singleCell/SingleCellDataLoader.java
@@ -6,6 +6,7 @@ import ubic.gemma.model.expression.bioAssayData.CellTypeAssignment;
 import ubic.gemma.model.expression.bioAssayData.SingleCellDimension;
 import ubic.gemma.model.expression.bioAssayData.SingleCellExpressionDataVector;
 import ubic.gemma.model.expression.designElement.CompositeSequence;
+import ubic.gemma.model.expression.experiment.ExperimentalFactor;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -42,6 +43,11 @@ public interface SingleCellDataLoader {
      * Load single-cell type labelling present in the data.
      */
     Optional<CellTypeAssignment> getCellTypeAssignment() throws IOException;
+
+    /**
+     * Load experimental factors present in the data.
+     */
+    Set<ExperimentalFactor> getFactors() throws IOException;
 
     /**
      * Produces a stream of single-cell expression data vectors for the given {@link QuantitationType}.

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Attribute.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Attribute.java
@@ -1,0 +1,67 @@
+package ubic.gemma.core.loader.util.hdf5;
+
+import hdf.hdf5lib.HDF5Constants;
+
+import static hdf.hdf5lib.H5.*;
+
+/**
+ * Represents an HDF5 attribute.
+ * @author poirigui
+ */
+public class H5Attribute implements AutoCloseable {
+
+    /**
+     * Represents a UTF-8 variable-length string.
+     */
+    private static final long UTF8_VARIABLE_STRING;
+
+    static {
+        long type = H5Tcopy( HDF5Constants.H5T_C_S1 );
+        H5Tset_size( type, HDF5Constants.H5T_VARIABLE );
+        H5Tset_cset( type, HDF5Constants.H5T_CSET_UTF8 );
+        H5Tset_strpad( type, HDF5Constants.H5T_STR_NULLPAD );
+        UTF8_VARIABLE_STRING = type;
+    }
+
+    static H5Attribute open( long locId, String name ) {
+        long attrId = H5Aopen( locId, name, HDF5Constants.H5P_DEFAULT );
+        return new H5Attribute( attrId );
+    }
+
+    public static H5Attribute open( long locId, String path, String name ) {
+        long attrId = H5Aopen_by_name( locId, path, name, HDF5Constants.H5P_DEFAULT, HDF5Constants.H5P_DEFAULT );
+        return new H5Attribute( attrId );
+    }
+
+    private final long attrId;
+
+    private H5Attribute( long attrId ) {
+        this.attrId = attrId;
+    }
+
+    public int[] toIntegerVector() {
+        int[] vec = new int[( int ) size()];
+        H5Aread_int( attrId, HDF5Constants.H5T_NATIVE_INT32, vec );
+        return vec;
+    }
+
+    public String[] toStringVector() {
+        String[] buf = new String[( int ) size()];
+        H5Aread_VLStrings( attrId, UTF8_VARIABLE_STRING, buf );
+        return buf;
+    }
+
+    public long size() {
+        long spaceId = H5Aget_space( attrId );
+        try {
+            return H5Sget_select_npoints( spaceId );
+        } finally {
+            H5Sclose( spaceId );
+        }
+    }
+
+    @Override
+    public void close() {
+        H5Aclose( attrId );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Dataset.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Dataset.java
@@ -1,0 +1,149 @@
+package ubic.gemma.core.loader.util.hdf5;
+
+import hdf.hdf5lib.HDF5Constants;
+import org.springframework.util.Assert;
+
+import javax.annotation.Nullable;
+
+import static hdf.hdf5lib.H5.*;
+import static hdf.hdf5lib.HDF5Constants.H5P_DEFAULT;
+
+/**
+ * Represents an HDF5 dataset.
+ * @author poirigui
+ */
+public class H5Dataset implements AutoCloseable {
+
+    /**
+     * Represents a UTF-8 variable-length string.
+     */
+    private static final long UTF8_VARIABLE_STRING;
+
+    static {
+        long type = H5Tcopy( HDF5Constants.H5T_C_S1 );
+        H5Tset_size( type, HDF5Constants.H5T_VARIABLE );
+        H5Tset_cset( type, HDF5Constants.H5T_CSET_UTF8 );
+        H5Tset_strpad( type, HDF5Constants.H5T_STR_NULLPAD );
+        UTF8_VARIABLE_STRING = type;
+    }
+
+    static H5Dataset open( long locId, String path ) {
+        return new H5Dataset( locId, H5Dopen( locId, path, H5P_DEFAULT ) );
+    }
+
+    private final long locId;
+    private final long datasetId;
+
+    private H5Dataset( long locId, long datasetId ) {
+        this.locId = locId;
+        this.datasetId = datasetId;
+    }
+
+    @Nullable
+    public H5Attribute getAttribute( String name ) {
+        if ( !H5Aexists( locId, name ) ) {
+            return null;
+        }
+        return H5Attribute.open( locId, name );
+    }
+
+    @Nullable
+    public H5Attribute getAttribute( String path, String name ) {
+        if ( !H5Aexists_by_name( locId, path, name, HDF5Constants.H5P_DEFAULT ) ) {
+            return null;
+        }
+        return H5Attribute.open( locId, path, name );
+    }
+
+    /**
+     * Obtain a 1D slice of the dataset.
+     */
+    public H5Dataspace slice( int start, int end ) {
+        Assert.isTrue( start >= 0 && end <= size() && start < end, "Invalid slice" );
+        long diskSpaceId = H5Dget_space( datasetId );
+        H5Sselect_hyperslab( diskSpaceId, HDF5Constants.H5S_SELECT_SET, new long[] { start }, null, new long[] { end - start }, null );
+        H5Dataspace ds = new H5Dataspace( diskSpaceId );
+        assert H5Sget_select_npoints( diskSpaceId ) == end - start;
+        return ds;
+    }
+
+    public byte[] toByteVector( int scalarType ) {
+        byte[] buf = new byte[( int ) size() * ( int ) H5Tget_size( scalarType )];
+        H5Dread( datasetId, scalarType, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, buf );
+        return buf;
+    }
+
+    public int[] toIntegerVector() {
+        int[] buf = new int[( int ) size()];
+        H5Dread( datasetId, HDF5Constants.H5T_NATIVE_INT32, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, buf );
+        return buf;
+    }
+
+    public double[] toDoubleVector() {
+        double[] buf = new double[( int ) size()];
+        H5Dread( datasetId, HDF5Constants.H5T_NATIVE_DOUBLE, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, buf );
+        return buf;
+    }
+
+    public String[] toStringVector() {
+        String[] buf = new String[( int ) size()];
+        H5Dread_VLStrings( datasetId, UTF8_VARIABLE_STRING, HDF5Constants.H5S_ALL, HDF5Constants.H5S_ALL, HDF5Constants.H5P_DEFAULT, buf );
+        return buf;
+    }
+
+    public long size() {
+        long space = H5Dget_space( datasetId );
+        try {
+            return H5Sget_select_npoints( space );
+        } finally {
+            H5Sclose( space );
+        }
+    }
+
+    @Override
+    public void close() {
+        H5Dclose( datasetId );
+    }
+
+    /**
+     * Represents a dataspace of a {@link H5Dataset}.
+     */
+    public class H5Dataspace implements AutoCloseable {
+
+        private final long diskSpaceId;
+
+        private H5Dataspace( long diskSpaceId ) {
+            this.diskSpaceId = diskSpaceId;
+        }
+
+        public byte[] toByteVector( long scalarType ) {
+            byte[] buf = new byte[( int ) size() * ( int ) H5Tget_size( scalarType )];
+            assert buf.length == size() * 8;
+            H5Dread( datasetId, scalarType, HDF5Constants.H5S_ALL, diskSpaceId, HDF5Constants.H5P_DEFAULT, buf );
+            return buf;
+        }
+
+        public int[] toIntegerVector() {
+            System.out.println( "about to check size..." );
+            int[] buf = new int[( int ) size()];
+            System.out.println( "about to read " + buf.length + " integers..." );
+            H5Dread_int( datasetId, HDF5Constants.H5T_NATIVE_INT, HDF5Constants.H5S_ALL, diskSpaceId, HDF5Constants.H5P_DEFAULT, buf );
+            return buf;
+        }
+
+        public double[] toDoubleVector() {
+            double[] buf = new double[( int ) size()];
+            H5Dread_double( datasetId, HDF5Constants.H5T_NATIVE_DOUBLE, HDF5Constants.H5S_ALL, diskSpaceId, HDF5Constants.H5P_DEFAULT, buf );
+            return buf;
+        }
+
+        public long size() {
+            return H5Sget_select_npoints( diskSpaceId );
+        }
+
+        @Override
+        public void close() {
+            H5Sclose( diskSpaceId );
+        }
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5File.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5File.java
@@ -1,0 +1,29 @@
+package ubic.gemma.core.loader.util.hdf5;
+
+import hdf.hdf5lib.exceptions.HDF5LibraryException;
+
+import java.nio.file.Path;
+
+import static hdf.hdf5lib.H5.H5Fclose;
+import static hdf.hdf5lib.H5.H5Fopen;
+import static hdf.hdf5lib.HDF5Constants.H5F_ACC_RDONLY;
+import static hdf.hdf5lib.HDF5Constants.H5P_DEFAULT;
+
+public class H5File extends H5Location implements AutoCloseable {
+
+    public static H5File open( Path path ) {
+        return new H5File( H5Fopen( path.toString(), H5F_ACC_RDONLY, H5P_DEFAULT ) );
+    }
+
+    private final long fd;
+
+    private H5File( long fd ) {
+        super( fd );
+        this.fd = fd;
+    }
+
+    @Override
+    public void close() throws HDF5LibraryException {
+        H5Fclose( fd );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Group.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Group.java
@@ -1,0 +1,24 @@
+package ubic.gemma.core.loader.util.hdf5;
+
+import static hdf.hdf5lib.H5.H5Gclose;
+import static hdf.hdf5lib.H5.H5Gopen;
+import static hdf.hdf5lib.HDF5Constants.H5P_DEFAULT;
+
+public class H5Group extends H5Location implements AutoCloseable {
+
+    static H5Group open( long locId, String path ) {
+        return new H5Group( H5Gopen( locId, path, H5P_DEFAULT ) );
+    }
+
+    private final long groupId;
+
+    private H5Group( long groupId ) {
+        super( groupId );
+        this.groupId = groupId;
+    }
+
+    @Override
+    public void close() {
+        H5Gclose( groupId );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Location.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/H5Location.java
@@ -1,0 +1,115 @@
+package ubic.gemma.core.loader.util.hdf5;
+
+import hdf.hdf5lib.HDF5Constants;
+import hdf.hdf5lib.callbacks.H5A_iterate_t;
+import hdf.hdf5lib.callbacks.H5L_iterate_opdata_t;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static hdf.hdf5lib.H5.*;
+
+/**
+ * Represents a location which is either a {@link H5File} or a {@link H5Group}.
+ */
+public abstract class H5Location {
+
+    private static final H5A_iterate_t ATTR_ITERATOR_DATA = new H5A_iterate_t() {
+    };
+
+    private static final H5L_iterate_opdata_t LOC_ITERATOR_DATA = new H5L_iterate_opdata_t() {
+    };
+
+    private final long locId;
+
+    protected H5Location( long locId ) {
+        this.locId = locId;
+    }
+
+    public List<String> getAttributes() {
+        List<String> attributes = new ArrayList<>();
+        H5Aiterate( locId, HDF5Constants.H5_INDEX_NAME, HDF5Constants.H5_ITER_NATIVE, 0, ( loc_id, name, info, op_data ) -> {
+            attributes.add( name );
+            return 0;
+        }, ATTR_ITERATOR_DATA );
+        return attributes;
+    }
+
+    public List<String> getAttributes( String path ) {
+        List<String> attributes = new ArrayList<>();
+        H5Aiterate_by_name( locId, path, HDF5Constants.H5_INDEX_NAME, HDF5Constants.H5_ITER_NATIVE, 0, ( loc_id, name, info, op_data ) -> {
+            attributes.add( name );
+            return 0;
+        }, ATTR_ITERATOR_DATA, HDF5Constants.H5P_DEFAULT );
+        return attributes;
+    }
+
+    @Nullable
+    public H5Attribute getAttribute( String name ) {
+        if ( !H5Aexists( locId, name ) ) {
+            return null;
+        }
+        return H5Attribute.open( locId, name );
+    }
+
+    @Nullable
+    public H5Attribute getAttribute( String path, String name ) {
+        if ( !H5Aexists_by_name( locId, path, name, HDF5Constants.H5P_DEFAULT ) ) {
+            return null;
+        }
+        return H5Attribute.open( locId, path, name );
+    }
+
+    @Nullable
+    public String getStringAttribute( String name ) {
+        try ( H5Attribute attr = getAttribute( name ) ) {
+            if ( attr == null ) {
+                return null;
+            }
+            return attr.toStringVector()[0];
+        }
+    }
+
+    /**
+     * Obtain an attribute for a given path.
+     */
+    @Nullable
+    public String getStringAttribute( String path, String name ) {
+        try ( H5Attribute attr = getAttribute( path, name ) ) {
+            if ( attr == null ) {
+                return null;
+            }
+            return attr.toStringVector()[0];
+        }
+    }
+
+    /**
+     * Obtain the children of the given H5 location.
+     */
+    public List<String> getChildren() {
+        List<String> paths = new ArrayList<>();
+        H5Literate( locId, HDF5Constants.H5_INDEX_NAME, HDF5Constants.H5_ITER_NATIVE, 0, ( loc_id, name, info, op_data ) -> {
+            paths.add( name );
+            return 0;
+        }, LOC_ITERATOR_DATA );
+        return paths;
+    }
+
+    public List<String> getChildren( String path ) {
+        List<String> paths = new ArrayList<>();
+        H5Literate_by_name( locId, path, HDF5Constants.H5_INDEX_NAME, HDF5Constants.H5_ITER_NATIVE, 0, ( loc_id, name, info, op_data ) -> {
+            paths.add( name );
+            return 0;
+        }, LOC_ITERATOR_DATA, HDF5Constants.H5P_DEFAULT );
+        return paths;
+    }
+
+    public H5Group getGroup( String path ) {
+        return H5Group.open( locId, path );
+    }
+
+    public H5Dataset getDataset( String path ) {
+        return H5Dataset.open( locId, path );
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/package-info.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/loader/util/hdf5/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Minimalistic read-only wrapper around HDF5 native library.
+ * <p>
+ * For this wrapper to work properly, you need the following:
+ * <ul>
+ * <li>an installed</li>
+ * </ul>
+ * @author poirigui
+ */
+@ParametersAreNonnullByDefault
+package ubic.gemma.core.loader.util.hdf5;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/gemma-core/src/main/java/ubic/gemma/model/common/description/Characteristic.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/common/description/Characteristic.java
@@ -33,6 +33,8 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 
+import static org.apache.commons.lang3.StringUtils.stripToNull;
+
 /**
  * Instances of this are used to describe other entities. This base class is just a characteristic that is simply a
  * 'tag' of free text.
@@ -285,27 +287,35 @@ public class Characteristic extends AbstractDescribable implements Serializable,
             entity.setName( name );
             entity.setDescription( description );
             entity.setValue( value );
-            entity.setValueUri( StringUtils.stripToNull( valueUri ) );
+            entity.setValueUri( stripToNull( valueUri ) );
             entity.setCategory( category );
-            entity.setCategoryUri( StringUtils.stripToNull( categoryUri ) );
+            entity.setCategoryUri( stripToNull( categoryUri ) );
             entity.setEvidenceCode( evidenceCode );
             return entity;
         }
 
-        public static Characteristic newInstance( Category category ) {
+        public static Characteristic newInstance( String category, @Nullable String categoryUri ) {
             Characteristic entity = new Characteristic();
-            entity.setCategory( category.getCategory() );
-            entity.setCategoryUri( category.getCategoryUri() );
+            entity.setCategory( category );
+            entity.setCategoryUri( stripToNull( categoryUri ) );
+            return entity;
+        }
+
+        public static Characteristic newInstance( Category category ) {
+            return newInstance( category.getCategory(), category.getCategoryUri() );
+        }
+
+        public static Characteristic newInstance( String category, @Nullable String categoryUri, String value, @Nullable String valueUri ) {
+            final Characteristic entity = new Characteristic();
+            entity.setCategory( category );
+            entity.setCategoryUri( stripToNull( categoryUri ) );
+            entity.setValue( value );
+            entity.setValueUri( stripToNull( valueUri ) );
             return entity;
         }
 
         public static Characteristic newInstance( Category category, String value, @Nullable String valueUri ) {
-            Characteristic entity = new Characteristic();
-            entity.setCategory( category.getCategory() );
-            entity.setCategoryUri( category.getCategoryUri() );
-            entity.setValue( value );
-            entity.setValueUri( StringUtils.stripToNull( valueUri ) );
-            return entity;
+            return newInstance( category.getCategory(), category.getCategoryUri(), value, valueUri );
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/bioAssayData/CellTypeAssignment.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/bioAssayData/CellTypeAssignment.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Represents the labelling of cell types.
@@ -71,5 +72,11 @@ public class CellTypeAssignment extends Analysis {
     @Override
     public boolean equals( Object object ) {
         return super.equals( object );
+    }
+
+    @Override
+    public String toString() {
+        return super.toString()
+                + ( cellTypes != null ? " Cell Types=" + cellTypes.stream().map( Characteristic::getValue ).collect( Collectors.joining( ", " ) ) : "" );
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExperimentalFactor.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/ExperimentalFactor.java
@@ -193,16 +193,28 @@ public class ExperimentalFactor extends AbstractDescribable implements SecuredCh
         return this.type;
     }
 
-    public void setType( ubic.gemma.model.expression.experiment.FactorType type ) {
+    public void setType( FactorType type ) {
         this.type = type;
+    }
+
+
+    @Override
+    public String toString() {
+        return super.toString() + ( type != null ? " Type=" + type : "" );
     }
 
     public static final class Factory {
 
-        public static ubic.gemma.model.expression.experiment.ExperimentalFactor newInstance() {
-            return new ubic.gemma.model.expression.experiment.ExperimentalFactor();
+        public static ExperimentalFactor newInstance() {
+            return new ExperimentalFactor();
         }
 
+        public static ExperimentalFactor newInstance( String name, FactorType factorType ) {
+            ExperimentalFactor experimentalFactor = new ExperimentalFactor();
+            experimentalFactor.setName( name );
+            experimentalFactor.setType( factorType );
+            return experimentalFactor;
+        }
     }
 
 }

--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/Statement.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/Statement.java
@@ -12,6 +12,8 @@ import javax.persistence.Transient;
 import java.util.Comparator;
 import java.util.Objects;
 
+import static org.apache.commons.lang3.StringUtils.stripToNull;
+
 /**
  * A special kind of characteristic that act as a statement.
  * <p>
@@ -33,6 +35,15 @@ public class Statement extends Characteristic {
     public static class Factory {
         public static Statement newInstance() {
             return new Statement();
+        }
+
+        public static Statement newInstance( String category, @Nullable String categoryUri, String subject, @Nullable String subjectUri ) {
+            final Statement entity = new Statement();
+            entity.setCategory( category );
+            entity.setCategoryUri( stripToNull( categoryUri ) );
+            entity.setSubject( subject );
+            entity.setSubjectUri( stripToNull( subjectUri ) );
+            return entity;
         }
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDaoImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/ExpressionExperimentDaoImpl.java
@@ -1801,25 +1801,29 @@ public class ExpressionExperimentDaoImpl
         ee.getCurationDetails().setLastTroubledEvent( null );
 
         // dissociate this EE from other parts
-        for ( ExpressionExperiment e : ee.getOtherParts() ) {
-            e.getOtherParts().remove( ee );
-        }
-        ee.getOtherParts().clear();
-
-        // detach from BA dimensions
-        Collection<BioAssayDimension> dims = this.getBioAssayDimensions( ee );
-        for ( BioAssayDimension dim : dims ) {
-            dim.getBioAssays().clear();
+        if ( !ee.getOtherParts().isEmpty() ) {
+            log.info( String.format( "Detaching split experiment from %d other parts", ee.getOtherParts().size() ) );
+            for ( ExpressionExperiment e : ee.getOtherParts() ) {
+                e.getOtherParts().remove( ee );
+            }
+            ee.getOtherParts().clear();
         }
 
-        // first pass, detach BAs from the samples
-        for ( BioAssay ba : ee.getBioAssays() ) {
-            ba.getSampleUsed().getBioAssaysUsedIn().remove( ba );
+        // detach from BAs from dimensions, completely detached dimension will be removed later
+        Set<BioAssayDimension> dimensionsToRemove = new HashSet<>();
+        for ( BioAssayDimension dim : this.getBioAssayDimensions( ee ) ) {
+            dim.getBioAssays().removeAll( ee.getBioAssays() );
+            if ( dim.getBioAssays().isEmpty() ) {
+                dimensionsToRemove.add( dim );
+            } else {
+                log.warn( String.format( "%s is attached to more than one ExpressionExperiment, the dimension will not be deleted.", dim ) );
+            }
         }
 
-        // second pass, delete samples that are no longer attached to BAs
+        // detach BAs from the samples, completely detached samples will be removed later
         Set<BioMaterial> samplesToRemove = new HashSet<>();
         for ( BioAssay ba : ee.getBioAssays() ) {
+            ba.getSampleUsed().getBioAssaysUsedIn().removeAll( ee.getBioAssays() );
             if ( ba.getSampleUsed().getBioAssaysUsedIn().isEmpty() ) {
                 samplesToRemove.add( ba.getSampleUsed() );
             } else {
@@ -1829,11 +1833,22 @@ public class ExpressionExperimentDaoImpl
 
         super.remove( ee );
 
-        // those need to be removed afterward because otherwise the BioAssay.sampleUsed would become transient while
-        // cascading and that is not allowed in the data model
-        log.debug( String.format( "Removing %d BioMaterial that are no longer attached to any BioAssay", samplesToRemove.size() ) );
-        for ( BioMaterial bm : samplesToRemove ) {
-            getSessionFactory().getCurrentSession().delete( bm );
+        if ( !samplesToRemove.isEmpty() ) {
+            // those need to be removed afterward because otherwise the BioAssay.sampleUsed would become transient while
+            // cascading and that is not allowed in the data model
+            log.info( String.format( "Removing %d BioMaterial that are no longer attached to any BioAssay", samplesToRemove.size() ) );
+            for ( BioMaterial bm : samplesToRemove ) {
+                log.debug( "Removing " + bm + "..." );
+                getSessionFactory().getCurrentSession().delete( bm );
+            }
+        }
+
+        if ( !dimensionsToRemove.isEmpty() ) {
+            log.info( String.format( "Removing %d BioAssayDimension that are no longer attached to any BioAssay", dimensionsToRemove.size() ) );
+            for ( BioAssayDimension dim : dimensionsToRemove ) {
+                log.debug( "Removing " + dim + "..." );
+                getSessionFactory().getCurrentSession().delete( dim );
+            }
         }
     }
 

--- a/gemma-core/src/test/java/ubic/gemma/core/loader/expression/singleCell/AnnDataSingleCellDataLoaderTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/loader/expression/singleCell/AnnDataSingleCellDataLoaderTest.java
@@ -1,0 +1,67 @@
+package ubic.gemma.core.loader.expression.singleCell;
+
+import org.junit.Test;
+import ubic.gemma.model.common.description.Characteristic;
+import ubic.gemma.model.expression.bioAssayData.SingleCellExpressionDataVector;
+import ubic.gemma.model.expression.experiment.FactorType;
+import ubic.gemma.model.expression.experiment.FactorValue;
+import ubic.gemma.persistence.util.ByteArrayUtils;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AnnDataSingleCellDataLoaderTest {
+
+    @Test
+    public void test() throws IOException {
+        AnnDataSingleCellDataLoader loader = new AnnDataSingleCellDataLoader( Paths.get( "/home/guillaume/Téléchargements/GSE225158_BU_OUD_Striatum_refined_all_SeuratObj_N22.h5ad" ) );
+        loader.setUnknownCellTypeIndicator( "UNK_ALL" );
+
+        assertThat( loader.getCellTypeAssignment() ).hasValueSatisfying( assignment -> {
+            assertThat( assignment.getCellTypes() )
+                    .hasSize( 8 )
+                    .extracting( Characteristic::getValue )
+                    .containsExactly( "Astrocytes", "Endothelial", "Interneurons", "MSNs", "Microglia", "Mural/Fibroblast", "Oligos", "Oligos_Pre" );
+            assertThat( assignment.getNumberOfCellTypes() )
+                    .isEqualTo( 8 );
+            assertThat( assignment.getCellTypeIndices() )
+                    .startsWith( 4, 4, 6, 6, 6, 6, 4, 6, 6, 6, 6, 4, 3, 4, 3, 3, 6, 3, 6 );
+        } );
+
+        assertThat( loader.getFactors() )
+                .hasSize( 56 )
+                .satisfiesOnlyOnce( factor -> {
+                    assertThat( factor.getName() ).isEqualTo( "BMI" );
+                    assertThat( factor.getType() ).isEqualTo( FactorType.CONTINUOUS );
+                    // continuous factors are not populated (yet!)
+                    assertThat( factor.getFactorValues() ).isEmpty();
+                } )
+                .satisfiesOnlyOnce( factor -> {
+                    assertThat( factor.getName() ).isEqualTo( "Cause.of.Death" );
+                    assertThat( factor.getFactorValues() )
+                            .hasSize( 7 )
+                            .extracting( FactorValue::getValue )
+                            .contains( "Aspiration", "Cardiac Tamponade", "Cardiovascular Disease" );
+                } );
+
+        try ( Stream<SingleCellExpressionDataVector> vectors = loader.loadVectors( null, null, null ) ) {
+            List<SingleCellExpressionDataVector> v = vectors.limit( 20 ).collect( Collectors.toList() );
+            assertThat( v ).first().satisfies( vector -> {
+                assertThat( ByteArrayUtils.byteArrayToDoubles( vector.getData() ) )
+                        .usingComparatorWithPrecision( 0.00001 )
+                        .startsWith( 0.934177, 0.934177, 0.934177, 0.934177, 0.934177, 0.934177, 0, 2.16626, 0.934177,
+                                0.934177, 0, 0.934177, 2.70177, 0.934177 )
+                        .hasSize( 3069 );
+                assertThat( vector.getDataIndices() )
+                        .hasSize( 3069 )
+                        .startsWith( 9, 60, 69, 73, 75, 79, 82, 87, 150, 154, 157, 169, 180, 182, 186, 196, 198, 205,
+                                220, 224, 248, 255, 256, 267, 273, 278, 288, 296 );
+            } );
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,9 @@
 		<profile>
 			<!-- For deployment where host is local (and ssh isn't available for builder, e.g. CI) -->
 			<id>local-deploy</id>
+			<properties>
+				<hdf5.prefix>/space/opt/hdf5-${hdf5.version}</hdf5.prefix>
+			</properties>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 				<property>
@@ -662,8 +665,8 @@
 		<dom4j.version>2.1.4</dom4j.version>
 		<!-- HDF5 -->
 		<hdf5.version>1.14.3</hdf5.version>
-		<!-- override this in your settings.xml -->
-		<hdf5.prefix>/space/opt/hdf5-${hdf5.version}</hdf5.prefix>
+		<!-- override this as needed in ~/.m2/settings.xml -->
+		<hdf5.prefix>${user.home}/hdf5-${hdf5.version}</hdf5.prefix>
 		<!-- directory containing the HDF5 shared library -->
 		<hdf5.libDir>${hdf5.prefix}/lib</hdf5.libDir>
 		<!-- full path to the HDF5 JAR -->

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<argLine>-Dlog4j1.compatibility=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager</argLine>
+					<argLine>-Dlog4j1.compatibility=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Djava.library.path=${hdf5.libDir}</argLine>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<includes>
 						<include>**/*Test.java</include>
@@ -508,7 +508,7 @@
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<argLine>-Dlog4j1.compatibility=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager</argLine>
+					<argLine>-Dlog4j1.compatibility=true -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Djava.library.path=${hdf5.libDir}</argLine>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<includes>
 						<include>**/*Test.java</include>
@@ -660,6 +660,14 @@
 		<micrometer.version>1.11.0</micrometer.version>
 		<tomcat.version>9.0.80</tomcat.version>
 		<dom4j.version>2.1.4</dom4j.version>
+		<!-- HDF5 -->
+		<hdf5.version>1.14.3</hdf5.version>
+		<!-- override this in your settings.xml -->
+		<hdf5.prefix>/space/opt/hdf5-${hdf5.version}</hdf5.prefix>
+		<!-- directory containing the HDF5 shared library -->
+		<hdf5.libDir>${hdf5.prefix}/lib</hdf5.libDir>
+		<!-- full path to the HDF5 JAR -->
+		<hdf5.jarPath>${hdf5.prefix}/lib/jarhdf5-${hdf5.version}.jar</hdf5.jarPath>
 		<!-- this ensures that -DexcludedGroups works properly -->
 		<excludedGroups/>
 		<!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
This PR adds support for two HDF5-based single-cell data format: AnnData and SeuratDisk. It is still a rough draft at this point.

Add a minimalistic Java-friendly API on top of the HDF5 JNI layer. I couldn't find any up-to-date Java library that does this and our needs are very specific.

I'm still a bit uneasy about the way we require HDF5 since this is a non-Java dependency.