### PR TITLE
Add a nano context with minimal beans

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/MessagesConfig.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/MessagesConfig.java
@@ -1,0 +1,22 @@
+package ubic.gemma.persistence.util;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+@Nano
+@Configuration
+public class MessagesConfig {
+
+    /**
+     * Message source for this context, loaded from localized "messages_xx" files
+     */
+    @Bean
+    public MessageSource messageSource() {
+        ReloadableResourceBundleMessageSource bundle = new ReloadableResourceBundleMessageSource();
+        bundle.setBasenames( "classpath:messages", "classpath:ubic/gemma/core/messages" );
+        bundle.setFallbackToSystemLocale( false );
+        return bundle;
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/Nano.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/Nano.java
@@ -1,0 +1,8 @@
+package ubic.gemma.persistence.util;
+
+/**
+ * Marks a component as eligible to be part of the nano context.
+ * @author poirigui
+ */
+public @interface Nano {
+}

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/SettingsConfig.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/SettingsConfig.java
@@ -23,6 +23,7 @@ import java.util.Set;
  * Beans declaration for making the settings available via the Spring Environment and placeholder substitution.
  * @author poirigui
  */
+@Nano
 @CommonsLog
 @Configuration
 public class SettingsConfig {

--- a/gemma-core/src/main/java/ubic/gemma/persistence/util/SpringContextUtil.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/util/SpringContextUtil.java
@@ -88,6 +88,26 @@ public class SpringContextUtil {
     }
 
     /**
+     * Obtain a nano context for Gemma.
+     * <p>
+     * This context only contains bean annotated with {@link Nano}.
+     */
+    public static ApplicationContext getNanoContext( String... activeProfiles ) {
+        StopWatch timer = StopWatch.createStarted();
+        try {
+            ConfigurableApplicationContext context = new ClassPathXmlApplicationContext( new String[] { "classpath*:ubic/gemma/nanoContext-*.xml" }, false );
+            for ( String activeProfile : activeProfiles ) {
+                context.getEnvironment().addActiveProfile( activeProfile );
+            }
+            prepareContext( context );
+            context.refresh();
+            return context;
+        } finally {
+            SpringContextUtil.log.info( "Got Gemma nano context in " + timer.getTime( TimeUnit.MILLISECONDS ) + " ms." );
+        }
+    }
+
+    /**
      * Prepare a given context for prime time.
      * <p>
      * Perform the following steps:

--- a/gemma-core/src/main/resources/ubic/gemma/applicationContext-serviceBeans.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/applicationContext-serviceBeans.xml
@@ -12,17 +12,6 @@
         <property name="corePoolSize" value="${gemma.localTasks.corePoolSize}"/>
     </bean>
 
-    <!-- Message source for this context, loaded from localized "messages_xx" files -->
-    <bean id="messageSource" class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
-        <property name="basenames">
-            <list>
-                <value>classpath:messages</value>
-                <value>classpath:ubic/gemma/core/messages</value>
-            </list>
-        </property>
-        <property name="fallbackToSystemLocale" value="false"/>
-    </bean>
-
     <!-- Configure Velocity for sending e-mail -->
     <bean id="velocityEngine" class="org.apache.velocity.app.VelocityEngine">
         <constructor-arg>

--- a/gemma-core/src/main/resources/ubic/gemma/nanoContext-component-scan.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/nanoContext-component-scan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+    <context:component-scan base-package="ubic.gemma" name-generator="ubic.gemma.persistence.util.BeanNameGenerator"
+                            use-default-filters="false">
+        <context:include-filter type="annotation" expression="ubic.gemma.persistence.util.Nano"/>
+        <context:exclude-filter type="annotation" expression="ubic.gemma.persistence.util.TestComponent"/>
+    </context:component-scan>
+</beans>

--- a/gemma-core/src/test/java/ubic/gemma/persistence/util/NanoContextTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/util/NanoContextTest.java
@@ -1,0 +1,29 @@
+package ubic.gemma.persistence.util;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.MessageSource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@ContextConfiguration(locations = "classpath*:ubic/gemma/nanoContext-*.xml")
+public class NanoContextTest extends AbstractJUnit4SpringContextTests {
+
+    @Value("${gemma.appdata.home}")
+    private String gemmaAppdataHome;
+
+    @Autowired
+    private MessageSource messageSource;
+
+    @Test
+    public void test() {
+        assertNotNull( gemmaAppdataHome );
+        assertEquals( "Time", messageSource.getMessage( "MeasurementKind.TIME.label", null, Locale.ENGLISH ) );
+    }
+}


### PR DESCRIPTION
Only load components and configurations annotated with `@Nano`. The nano context only contains settings and i18n support by default and take less than a second to load.

I'll include this in #1039 to create fast CLI tools for curators. It can be merged immediately for the next minor release.