### PR TITLE
Only update EE2C and EE2AD entries that were modified since last update

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/core/apps/UpdateEE2CCli.java
+++ b/gemma-cli/src/main/java/ubic/gemma/core/apps/UpdateEE2CCli.java
@@ -30,7 +30,7 @@ public class UpdateEE2CCli extends AbstractAuthenticatedCLI {
 
     @Override
     protected void doWork() throws Exception {
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( truncate );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, truncate );
     }
 
     @Nullable

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/TableMaintenanceUtil.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/TableMaintenanceUtil.java
@@ -20,6 +20,9 @@ package ubic.gemma.persistence.service;
 
 import org.springframework.security.access.annotation.Secured;
 
+import javax.annotation.Nullable;
+import java.util.Date;
+
 /**
  * @author paul
  */
@@ -68,7 +71,7 @@ public interface TableMaintenanceUtil {
      * @return the number of records that were created or updated
      */
     @Secured({ "GROUP_AGENT" })
-    int updateExpressionExperiment2CharacteristicEntries( boolean truncate );
+    int updateExpressionExperiment2CharacteristicEntries( @Nullable Date sinceLastUpdate, boolean truncate );
 
     /**
      * Update a specific level of the {@code EXPRESSION_EXPERIMENT2CHARACTERISTIC} table.
@@ -77,14 +80,14 @@ public interface TableMaintenanceUtil {
      * @return the number of records that were created or updated
      */
     @Secured({ "GROUP_AGENT" })
-    int updateExpressionExperiment2CharacteristicEntries( Class<?> level, boolean truncate );
+    int updateExpressionExperiment2CharacteristicEntries( Class<?> level, @Nullable Date sinceLastUpdate, boolean truncate );
 
     /**
      * Update the {@code EXPRESSION_EXPERIMENT2_ARRAY_DESIGN} table.
      * @return the number of records that were created or updated
      */
     @Secured({ "GROUP_AGENT" })
-    int updateExpressionExperiment2ArrayDesignEntries();
+    int updateExpressionExperiment2ArrayDesignEntries( @Nullable Date sinceLastUpdate );
 
     // for tests only, to keep from getting emails.
     @Secured({ "GROUP_ADMIN" })

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/TableMaintenanceUtilImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/TableMaintenanceUtilImpl.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
 import ubic.gemma.model.common.Auditable;
 import ubic.gemma.model.common.auditAndSecurity.AuditEvent;
 import ubic.gemma.model.common.auditAndSecurity.eventType.ArrayDesignGeneMappingEvent;
@@ -91,41 +92,52 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
     private static final String EE2C_EE_QUERY =
             "select MIN(C.ID), C.NAME, C.DESCRIPTION, C.CATEGORY, C.CATEGORY_URI, C.`VALUE`, C.VALUE_URI, C.ORIGINAL_VALUE, C.EVIDENCE_CODE, I.ID, (" + SELECT_ANONYMOUS_MASK + "), cast(? as char(255)) "
                     + "from INVESTIGATION I "
+                    + "join CURATION_DETAILS CD on I.CURATION_DETAILS_FK = CD.ID "
                     + "join CHARACTERISTIC C on I.ID = C.INVESTIGATION_FK "
                     + "where I.class = 'ExpressionExperiment' "
+                    + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
                     + "group by I.ID, COALESCE(C.CATEGORY_URI, C.CATEGORY), COALESCE(C.VALUE_URI, C.`VALUE`)";
 
     private static final String EE2C_BM_QUERY =
             "select MIN(C.ID), C.NAME, C.DESCRIPTION, C.CATEGORY, C.CATEGORY_URI, C.`VALUE`, C.VALUE_URI, C.ORIGINAL_VALUE, C.EVIDENCE_CODE, I.ID, (" + SELECT_ANONYMOUS_MASK + "), cast(? as char(255)) "
                     + "from INVESTIGATION I "
+                    + "join CURATION_DETAILS CD on I.CURATION_DETAILS_FK = CD.ID "
                     + "join BIO_ASSAY BA on I.ID = BA.EXPRESSION_EXPERIMENT_FK "
                     + "join BIO_MATERIAL BM on BA.SAMPLE_USED_FK = BM.ID "
                     + "join CHARACTERISTIC C on BM.ID = C.BIO_MATERIAL_FK "
                     + "where I.class = 'ExpressionExperiment' "
+                    + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
                     + "group by I.ID, COALESCE(C.CATEGORY_URI, C.CATEGORY), COALESCE(C.VALUE_URI, C.`VALUE`)";
 
     private static final String EE2C_ED_QUERY =
             "select MIN(C.ID), C.NAME, C.DESCRIPTION, C.CATEGORY, C.CATEGORY_URI, C.`VALUE`, C.VALUE_URI, C.ORIGINAL_VALUE, C.EVIDENCE_CODE, I.ID, (" + SELECT_ANONYMOUS_MASK + "), cast(? as char(255)) "
                     + "from INVESTIGATION I "
+                    + "join CURATION_DETAILS CD on I.CURATION_DETAILS_FK = CD.ID "
                     + "join EXPERIMENTAL_DESIGN on I.EXPERIMENTAL_DESIGN_FK = EXPERIMENTAL_DESIGN.ID "
                     + "join EXPERIMENTAL_FACTOR EF on EXPERIMENTAL_DESIGN.ID = EF.EXPERIMENTAL_DESIGN_FK "
                     + "join FACTOR_VALUE FV on FV.EXPERIMENTAL_FACTOR_FK = EF.ID "
                     + "join CHARACTERISTIC C on FV.ID = C.FACTOR_VALUE_FK "
+                    + "where I.class = 'ExpressionExperiment' "
                     // remove C.class = 'Statement' once the old-style characteristics are removed (see https://github.com/PavlidisLab/Gemma/issues/929 for details)
-                    + "where I.class = 'ExpressionExperiment' and C.class = 'Statement' "
+                    + "and C.class = 'Statement' "
+                    + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
                     + "group by I.ID, COALESCE(C.CATEGORY_URI, C.CATEGORY), COALESCE(C.VALUE_URI, C.`VALUE`)";
 
     private static final String EE2AD_QUERY = "insert into EXPRESSION_EXPERIMENT2ARRAY_DESIGN (EXPRESSION_EXPERIMENT_FK, ARRAY_DESIGN_FK, IS_ORIGINAL_PLATFORM, ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK) "
             + "select I.ID, AD.ID, FALSE, (" + SELECT_ANONYMOUS_MASK + ") from INVESTIGATION I "
+            + "join CURATION_DETAILS CD on I.CURATION_DETAILS_FK = CD.ID "
             + "join BIO_ASSAY BA on I.ID = BA.EXPRESSION_EXPERIMENT_FK "
             + "join ARRAY_DESIGN AD on BA.ARRAY_DESIGN_USED_FK = AD.ID "
             + "where I.class = 'ExpressionExperiment' "
+            + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
             + "group by I.ID, AD.ID "
             + "union "
             + "select I.ID, AD.ID, TRUE, (" + SELECT_ANONYMOUS_MASK + ") from INVESTIGATION I "
+            + "join CURATION_DETAILS CD on I.CURATION_DETAILS_FK = CD.ID "
             + "join BIO_ASSAY BA on I.ID = BA.EXPRESSION_EXPERIMENT_FK "
             + "join ARRAY_DESIGN AD on BA.ORIGINAL_PLATFORM_FK = AD.ID "
             + "where I.class = 'ExpressionExperiment' "
+            + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
             + "group by I.ID, AD.ID "
             + "on duplicate key update ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK = VALUES(ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK)";
 
@@ -218,8 +230,10 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
     @Override
     @Transactional
     @Timed
-    public int updateExpressionExperiment2CharacteristicEntries( boolean truncate ) {
-        log.info( "Updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table..." );
+    public int updateExpressionExperiment2CharacteristicEntries( @Nullable Date sinceLastUpdate, boolean truncate ) {
+        Assert.isTrue( !( sinceLastUpdate != null && truncate ), "Cannot perform a partial update with sinceLastUpdate with truncate." );
+        log.info( String.format( "Updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table%s...",
+                sinceLastUpdate != null ? " since " + sinceLastUpdate : "" ) );
         if ( truncate ) {
             log.info( "Truncating EXPRESSION_EXPERIMENT2CHARACTERISTIC..." );
             sessionFactory.getCurrentSession()
@@ -239,15 +253,19 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
                 .setParameter( 0, ExpressionExperiment.class )
                 .setParameter( 1, BioMaterial.class )
                 .setParameter( 2, ExperimentalDesign.class )
+                .setParameter( "since", sinceLastUpdate )
                 .executeUpdate();
-        log.info( String.format( "Done updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table; %d entries were updated.", updated ) );
+        log.info( String.format( "Done updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table; %d entries were updated%s.",
+                updated,
+                sinceLastUpdate != null ? " since " + sinceLastUpdate : "" ) );
         return updated;
     }
 
     @Override
     @Timed
     @Transactional
-    public int updateExpressionExperiment2CharacteristicEntries( Class<?> level, boolean truncate ) {
+    public int updateExpressionExperiment2CharacteristicEntries( Class<?> level, @Nullable Date sinceLastUpdate, boolean truncate ) {
+        Assert.isTrue( !( sinceLastUpdate != null && truncate ), "Cannot perform a partial update with sinceLastUpdate with truncate." );
         String query;
         if ( level.equals( ExpressionExperiment.class ) ) {
             query = EE2C_EE_QUERY;
@@ -258,7 +276,9 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
         } else {
             throw new IllegalArgumentException( "Level must be one of ExpressionExperiment.class, BioMaterial.class or ExperimentalDesign.class." );
         }
-        log.info( "Updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table at " + level.getSimpleName() + " level..." );
+        log.info( String.format( "Updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table at %s level%s...",
+                level.getSimpleName(),
+                sinceLastUpdate != null ? " since " + sinceLastUpdate : "" ) );
         if ( truncate ) {
             log.info( "Truncating EXPRESSION_EXPERIMENT2CHARACTERISTIC at " + level.getSimpleName() + " level..." );
             sessionFactory.getCurrentSession()
@@ -273,20 +293,25 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
                                 + "on duplicate key update NAME = VALUES(NAME), DESCRIPTION = VALUES(DESCRIPTION), CATEGORY = VALUES(CATEGORY), CATEGORY_URI = VALUES(CATEGORY_URI), `VALUE` = VALUES(`VALUE`), VALUE_URI = VALUES(VALUE_URI), ORIGINAL_VALUE = VALUES(ORIGINAL_VALUE), EVIDENCE_CODE = VALUES(EVIDENCE_CODE), ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK = VALUES(ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK), LEVEL = VALUES(LEVEL)" )
                 .addSynchronizedQuerySpace( EE2C_QUERY_SPACE )
                 .setParameter( 0, level )
+                .setParameter( "since", sinceLastUpdate )
                 .executeUpdate();
-        log.info( String.format( "Done updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table at %s level; %d entries were updated.",
-                level.getSimpleName(), updated ) );
+        log.info( String.format( "Done updating the EXPRESSION_EXPERIMENT2CHARACTERISTIC table at %s level; %d entries were updated%s.",
+                level.getSimpleName(), updated,
+                sinceLastUpdate != null ? " since " + sinceLastUpdate : "" ) );
         return updated;
     }
 
     @Override
     @Transactional
-    public int updateExpressionExperiment2ArrayDesignEntries() {
-        log.info( "Updating the EXPRESSION_EXPERIMENT2ARRAY_DESIGN table..." );
+    public int updateExpressionExperiment2ArrayDesignEntries( @Nullable Date sinceLastUpdate ) {
+        log.info( String.format( "Updating the EXPRESSION_EXPERIMENT2ARRAY_DESIGN table%s...",
+                sinceLastUpdate != null ? " since " + sinceLastUpdate : "" ) );
         int updated = sessionFactory.getCurrentSession().createSQLQuery( EE2AD_QUERY )
                 .addSynchronizedQuerySpace( EE2AD_QUERY_SPACE )
+                .setParameter( "since", sinceLastUpdate )
                 .executeUpdate();
-        log.info( String.format( "Done updating the EXPRESSION_EXPERIMENT2ARRAY_DESIGN table; %d entries were updated.", updated ) );
+        log.info( String.format( "Done updating the EXPRESSION_EXPERIMENT2ARRAY_DESIGN table; %d entries were updated%s.",
+                updated, sinceLastUpdate != null ? " since " + sinceLastUpdate : "" ) );
         return updated;
     }
 

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/TableMaintenanceUtilImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/TableMaintenanceUtilImpl.java
@@ -89,13 +89,18 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
                     + "and ACE.SID_FK = (select ACLSID.ID from ACLSID where ACLSID.GRANTED_AUTHORITY = 'IS_AUTHENTICATED_ANONYMOUSLY') "
                     + "group by AOI.ID), 0)";
 
+    /**
+     * Clause for selecting entities updated since a given date.
+     */
+    private static final String CD_LAST_UPDATED_SINCE = "(CD.LAST_UPDATED is null or :since is null or CD.LAST_UPDATED >= :since)";
+
     private static final String EE2C_EE_QUERY =
             "select MIN(C.ID), C.NAME, C.DESCRIPTION, C.CATEGORY, C.CATEGORY_URI, C.`VALUE`, C.VALUE_URI, C.ORIGINAL_VALUE, C.EVIDENCE_CODE, I.ID, (" + SELECT_ANONYMOUS_MASK + "), cast(? as char(255)) "
                     + "from INVESTIGATION I "
                     + "join CURATION_DETAILS CD on I.CURATION_DETAILS_FK = CD.ID "
                     + "join CHARACTERISTIC C on I.ID = C.INVESTIGATION_FK "
                     + "where I.class = 'ExpressionExperiment' "
-                    + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
+                    + "and " + CD_LAST_UPDATED_SINCE + " "
                     + "group by I.ID, COALESCE(C.CATEGORY_URI, C.CATEGORY), COALESCE(C.VALUE_URI, C.`VALUE`)";
 
     private static final String EE2C_BM_QUERY =
@@ -106,7 +111,7 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
                     + "join BIO_MATERIAL BM on BA.SAMPLE_USED_FK = BM.ID "
                     + "join CHARACTERISTIC C on BM.ID = C.BIO_MATERIAL_FK "
                     + "where I.class = 'ExpressionExperiment' "
-                    + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
+                    + "and " + CD_LAST_UPDATED_SINCE + " "
                     + "group by I.ID, COALESCE(C.CATEGORY_URI, C.CATEGORY), COALESCE(C.VALUE_URI, C.`VALUE`)";
 
     private static final String EE2C_ED_QUERY =
@@ -120,7 +125,7 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
                     + "where I.class = 'ExpressionExperiment' "
                     // remove C.class = 'Statement' once the old-style characteristics are removed (see https://github.com/PavlidisLab/Gemma/issues/929 for details)
                     + "and C.class = 'Statement' "
-                    + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
+                    + "and " + CD_LAST_UPDATED_SINCE + " "
                     + "group by I.ID, COALESCE(C.CATEGORY_URI, C.CATEGORY), COALESCE(C.VALUE_URI, C.`VALUE`)";
 
     private static final String EE2AD_QUERY = "insert into EXPRESSION_EXPERIMENT2ARRAY_DESIGN (EXPRESSION_EXPERIMENT_FK, ARRAY_DESIGN_FK, IS_ORIGINAL_PLATFORM, ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK) "
@@ -137,7 +142,7 @@ public class TableMaintenanceUtilImpl implements TableMaintenanceUtil {
             + "join BIO_ASSAY BA on I.ID = BA.EXPRESSION_EXPERIMENT_FK "
             + "join ARRAY_DESIGN AD on BA.ORIGINAL_PLATFORM_FK = AD.ID "
             + "where I.class = 'ExpressionExperiment' "
-            + "and COALESCE(CD.LAST_UPDATED, 0) >= COALESCE(:since, 0) "
+            + "and " + CD_LAST_UPDATED_SINCE + " "
             + "group by I.ID, AD.ID "
             + "on duplicate key update ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK = VALUES(ACL_IS_AUTHENTICATED_ANONYMOUSLY_MASK)";
 

--- a/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceIntegrationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/search/SearchServiceIntegrationTest.java
@@ -130,7 +130,7 @@ public class SearchServiceIntegrationTest extends BaseSpringContextTest {
         gene.setNcbiGeneId( new Integer( geneNcbiId ) );
         geneService.update( gene );
 
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
     }
 
     @After

--- a/gemma-core/src/test/java/ubic/gemma/model/common/description/CharacteristicServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/common/description/CharacteristicServiceTest.java
@@ -91,7 +91,7 @@ public class CharacteristicServiceTest extends BaseSpringContextTest {
         fv.setCharacteristics( this.getTestPersistentStatements( 1 ) );
         fvService.update( fv );
 
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
     }
 
     @Test

--- a/gemma-core/src/test/java/ubic/gemma/model/expression/experiment/ExpressionExperimentServiceIntegrationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/model/expression/experiment/ExpressionExperimentServiceIntegrationTest.java
@@ -430,7 +430,7 @@ public class ExpressionExperimentServiceIntegrationTest extends BaseSpringContex
             assertThat( c2.getNumberOfExpressionExperiments() ).isEqualTo( 1L );
         };
 
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
         assertThat( expressionExperimentService.getAnnotationsUsageFrequency( null, null, null, null, null, 0, null, 0 ) )
                 .noneSatisfy( consumer );
 
@@ -444,7 +444,7 @@ public class ExpressionExperimentServiceIntegrationTest extends BaseSpringContex
                 .noneSatisfy( consumer );
 
         // update the pivot table
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
         assertThat( expressionExperimentService.getAnnotationsUsageFrequency( null, null, null, null, null, 0, null, 0 ) )
                 .satisfiesOnlyOnce( consumer );
 

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/TableMaintenanceUtilIntegrationTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/TableMaintenanceUtilIntegrationTest.java
@@ -17,6 +17,7 @@ import ubic.gemma.model.expression.experiment.FactorValue;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,24 +61,26 @@ public class TableMaintenanceUtilIntegrationTest extends BaseSpringContextTest {
     @Test
     @WithMockUser(authorities = "GROUP_AGENT")
     public void testUpdateExpressionExperiment2CharacteristicEntries() {
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( ExpressionExperiment.class, false );
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( BioMaterial.class, false );
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( ExperimentalDesign.class, false );
-        assertThatThrownBy( () -> {
-            tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( FactorValue.class, false );
-        } ).isInstanceOf( IllegalArgumentException.class );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( ExpressionExperiment.class, null, false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( BioMaterial.class, null, false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( ExperimentalDesign.class, null, false );
+        assertThatThrownBy( () -> tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( FactorValue.class, null, false ) )
+                .isInstanceOf( IllegalArgumentException.class );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( new Date(), false );
+        assertThatThrownBy( () -> tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( new Date(), true ) )
+                .isInstanceOf( IllegalArgumentException.class );
     }
 
     @Test(expected = AccessDeniedException.class)
     public void testUpdateEE2CAsUser() {
         this.runAsAnonymous();
-        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
     }
 
     @Test
     @WithMockUser(authorities = "GROUP_AGENT")
     public void testUpdateExpressionExperiment2ArrayDesignEntries() {
-        tableMaintenanceUtil.updateExpressionExperiment2ArrayDesignEntries();
+        tableMaintenanceUtil.updateExpressionExperiment2ArrayDesignEntries( null );
     }
 }

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/common/description/CharacteristicDaoImplTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/common/description/CharacteristicDaoImplTest.java
@@ -174,7 +174,7 @@ public class CharacteristicDaoImplTest extends BaseDatabaseTest {
         acl.insertAce( 0, BasePermission.READ, new AclPrincipalSid( "bob" ), false );
         aclService.updateAcl( acl );
 
-        int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
         assertThat( updated ).isEqualTo( 1 );
         sessionFactory.getCurrentSession().flush();
         // ranking by level uses the order by field() which is not supported
@@ -201,7 +201,7 @@ public class CharacteristicDaoImplTest extends BaseDatabaseTest {
         aclService.updateAcl( acl );
         sessionFactory.getCurrentSession().flush();
 
-        int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
         assertThat( updated ).isEqualTo( 1 );
         sessionFactory.getCurrentSession().flush();
 
@@ -233,7 +233,7 @@ public class CharacteristicDaoImplTest extends BaseDatabaseTest {
         sessionFactory.getCurrentSession().persist( ee );
         sessionFactory.getCurrentSession().flush();
         aclService.createAcl( new AclObjectIdentity( ExpressionExperiment.class, ee.getId() ) );
-        int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( false );
+        int updated = tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( null, false );
         assertThat( updated ).isEqualTo( 1 );
         sessionFactory.getCurrentSession().flush();
         // ranking by level uses the order by field() which is not supported

--- a/gemma-web/src/main/java/ubic/gemma/web/scheduler/Ee2AdUpdateJob.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/scheduler/Ee2AdUpdateJob.java
@@ -1,0 +1,22 @@
+package ubic.gemma.web.scheduler;
+
+import lombok.Setter;
+import org.quartz.JobExecutionContext;
+import org.quartz.StatefulJob;
+import org.springframework.util.Assert;
+import ubic.gemma.persistence.service.TableMaintenanceUtil;
+
+/**
+ * @author poirigui
+ */
+@Setter
+public class Ee2AdUpdateJob extends SecureQuartzJobBean implements StatefulJob {
+
+    private TableMaintenanceUtil tableMaintenanceUtil;
+
+    @Override
+    protected void executeAsAgent( JobExecutionContext context ) {
+        Assert.notNull( tableMaintenanceUtil, "The tableMaintenanceUtil bean was not set." );
+        tableMaintenanceUtil.updateExpressionExperiment2ArrayDesignEntries( context.getPreviousFireTime() );
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/scheduler/Ee2cUpdateJob.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/scheduler/Ee2cUpdateJob.java
@@ -1,0 +1,28 @@
+package ubic.gemma.web.scheduler;
+
+import lombok.Setter;
+import org.quartz.JobExecutionContext;
+import org.quartz.StatefulJob;
+import org.springframework.util.Assert;
+import ubic.gemma.persistence.service.TableMaintenanceUtil;
+
+/**
+ * @author poirigui
+ */
+@Setter
+public class Ee2cUpdateJob extends SecureQuartzJobBean implements StatefulJob {
+
+    private TableMaintenanceUtil tableMaintenanceUtil;
+
+    private Class<?> level = null;
+
+    @Override
+    public void executeAsAgent( JobExecutionContext context ) {
+        Assert.notNull( tableMaintenanceUtil, "The tableMaintenanceUtil bean was not set." );
+        if ( level == null ) {
+            tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( context.getPreviousFireTime(), false );
+        } else {
+            tableMaintenanceUtil.updateExpressionExperiment2CharacteristicEntries( level, context.getPreviousFireTime(), false );
+        }
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureInvoker.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureInvoker.java
@@ -1,0 +1,58 @@
+package ubic.gemma.web.scheduler;
+
+import gemma.gsec.authentication.ManualAuthenticationService;
+import lombok.Setter;
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Invoke a callable as an authenticated user with given credentials.
+ * @author poirigui
+ */
+@Setter
+@CommonsLog
+public class SecureInvoker {
+
+    private final ManualAuthenticationService manualAuthenticationService;
+
+    private String userName;
+    private String password;
+
+    /**
+     * Fallback to an anonymous authentication if the authentication fails.
+     */
+    private boolean fallbackToAnonymous = false;
+
+    public SecureInvoker( ManualAuthenticationService manualAuthenticationService ) {
+        this.manualAuthenticationService = manualAuthenticationService;
+    }
+
+    public <T> T invoke( Callable<T> callable ) throws Exception {
+        SecurityContext previousSecurityContext = SecurityContextHolder.getContext();
+        try {
+            try {
+                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                securityContext.setAuthentication( manualAuthenticationService.attemptAuthentication( userName, password ) );
+                SecurityContextHolder.setContext( securityContext );
+            } catch ( AuthenticationException e ) {
+                if ( fallbackToAnonymous ) {
+                    log.error( "Failed to authenticate schedule job, jobs probably won't work, but trying anonymous" );
+                    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                    SecurityContextHolder.setContext( securityContext );
+                    // gsec will call SecurityContextHolder.getContext().setAuthentication()
+                    manualAuthenticationService.authenticateAnonymously();
+                } else {
+                    throw e;
+                }
+            }
+            assert SecurityContextHolder.getContext().getAuthentication() != null;
+            return callable.call();
+        } finally {
+            SecurityContextHolder.setContext( previousSecurityContext );
+        }
+    }
+}

--- a/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureMethodInvokingJobDetailFactoryBean.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureMethodInvokingJobDetailFactoryBean.java
@@ -18,17 +18,9 @@
  */
 package ubic.gemma.web.scheduler;
 
-import gemma.gsec.authentication.ManualAuthenticationService;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.Setter;
 import org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import ubic.gemma.core.security.audit.AuditAdvice;
-import ubic.gemma.core.security.authentication.UserManager;
-import ubic.gemma.persistence.util.Settings;
+import org.springframework.util.Assert;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -37,56 +29,22 @@ import java.lang.reflect.InvocationTargetException;
  * thread where Quartz is being run is authenticated as GROUP_AGENT.
  *
  * @author paul
+ * @see SecureQuartzJobBean
  */
-@SuppressWarnings({ "unused", "WeakerAccess" }) // Possible external use
+@Setter
 public class SecureMethodInvokingJobDetailFactoryBean extends MethodInvokingJobDetailFactoryBean {
 
-    private static final Log log = LogFactory.getLog( AuditAdvice.class.getName() );
-    @Autowired
-    ManualAuthenticationService manualAuthenticationService;
-    @Autowired
-    UserManager userManager;
+    private SecureInvoker secureInvoker;
 
     @Override
     public Object invoke() throws InvocationTargetException, IllegalAccessException {
-
-        String serverUserName = Settings.getString( "gemma.agent.userName" );
-        String serverPassword = Settings.getString( "gemma.agent.password" );
-        Object result;
-        SecurityContext previousSecurityContext = SecurityContextHolder.getContext();
-
+        Assert.notNull( secureInvoker, "groupAgentInvoker is not set." );
         try {
-            try {
-                assert manualAuthenticationService != null;
-                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-                securityContext.setAuthentication( manualAuthenticationService.attemptAuthentication( serverUserName, serverPassword ) );
-                SecurityContextHolder.setContext( securityContext );
-            } catch ( AuthenticationException e ) {
-                SecureMethodInvokingJobDetailFactoryBean.log
-                        .error( "Failed to authenticate schedule job, jobs probably won't work, but trying anonymous" );
-                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-                SecurityContextHolder.setContext( securityContext );
-                // gsec will call SecurityContextHolder.getContext().setAuthentication()
-                manualAuthenticationService.authenticateAnonymously();
-            }
-            assert SecurityContextHolder.getContext().getAuthentication() != null;
-            return super.invoke();
-        } finally {
-            SecurityContextHolder.setContext( previousSecurityContext );
+            return secureInvoker.invoke( super::invoke );
+        } catch ( InvocationTargetException | IllegalAccessException | RuntimeException e ) {
+            throw e;
+        } catch ( Exception e ) {
+            throw new InvocationTargetException( e );
         }
-    }
-
-    /**
-     * @param manualAuthenticationService the manualAuthenticationService to set
-     */
-    public void setManualAuthenticationService( ManualAuthenticationService manualAuthenticationService ) {
-        this.manualAuthenticationService = manualAuthenticationService;
-    }
-
-    /**
-     * @param userManager the userManager to set
-     */
-    public void setUserManager( UserManager userManager ) {
-        this.userManager = userManager;
     }
 }

--- a/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureMethodInvokingJobDetailFactoryBean.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureMethodInvokingJobDetailFactoryBean.java
@@ -18,9 +18,7 @@
  */
 package ubic.gemma.web.scheduler;
 
-import lombok.Setter;
 import org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean;
-import org.springframework.util.Assert;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -31,14 +29,16 @@ import java.lang.reflect.InvocationTargetException;
  * @author paul
  * @see SecureQuartzJobBean
  */
-@Setter
 public class SecureMethodInvokingJobDetailFactoryBean extends MethodInvokingJobDetailFactoryBean {
 
-    private SecureInvoker secureInvoker;
+    private final SecureInvoker secureInvoker;
+
+    public SecureMethodInvokingJobDetailFactoryBean( SecureInvoker secureInvoker ) {
+        this.secureInvoker = secureInvoker;
+    }
 
     @Override
     public Object invoke() throws InvocationTargetException, IllegalAccessException {
-        Assert.notNull( secureInvoker, "groupAgentInvoker is not set." );
         try {
             return secureInvoker.invoke( super::invoke );
         } catch ( InvocationTargetException | IllegalAccessException | RuntimeException e ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureQuartzJobBean.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/scheduler/SecureQuartzJobBean.java
@@ -1,0 +1,32 @@
+package ubic.gemma.web.scheduler;
+
+import lombok.Setter;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.util.Assert;
+
+/**
+ *
+ */
+@Setter
+public abstract class SecureQuartzJobBean extends QuartzJobBean {
+
+    private SecureInvoker secureInvoker;
+
+    @Override
+    protected final void executeInternal( JobExecutionContext context ) throws JobExecutionException {
+        Assert.notNull( secureInvoker, "The secureInvoker bean is not set." );
+        try {
+            secureInvoker.invoke( () -> {
+                executeAsAgent( context );
+                return null;
+            } );
+        } catch ( Exception e ) {
+            throw new JobExecutionException( e );
+        }
+    }
+
+    protected abstract void executeAsAgent( JobExecutionContext context ) throws JobExecutionException;
+}
+

--- a/gemma-web/src/main/resources/ubic/gemma/applicationContext-schedule.xml
+++ b/gemma-web/src/main/resources/ubic/gemma/applicationContext-schedule.xml
@@ -51,10 +51,10 @@
     <bean id="batchInfoTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
             <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+                <constructor-arg ref="groupAgentSecureInvoker"/>
                 <property name="targetObject" ref="expressionExperimentReportService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="recalculateBatchInfo"/>
-                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every day at 00:30:00 -->
@@ -64,10 +64,10 @@
         <property name="jobDetail">
             <bean
                 class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+                <constructor-arg ref="groupAgentSecureInvoker"/>
                 <property name="targetObject" ref="expressionExperimentReportService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="generateSummaryObjects"/>
-                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every first-of-the-month at 00:15:00 -->
@@ -77,10 +77,10 @@
         <property name="jobDetail">
             <bean
                 class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+                <constructor-arg ref="groupAgentSecureInvoker"/>
                 <property name="targetObject" ref="arrayDesignReportService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="generateArrayDesignReport"/>
-                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every first-of-the-month at 01:30:00 -->
@@ -90,10 +90,10 @@
         <property name="jobDetail">
             <bean
                 class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+                <constructor-arg ref="groupAgentSecureInvoker"/>
                 <property name="targetObject" ref="whatsNewService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="generateWeeklyReport"/>
-                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every day at 00:15:00 -->
@@ -101,12 +101,11 @@
     </bean>
     <bean id="gene2CsUpdateTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
-            <bean
-                class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+            <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+                <constructor-arg ref="groupAgentSecureInvoker"/>
                 <property name="targetObject" ref="tableMaintenanceUtil"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="updateGene2CsEntries"/>
-                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every day at 00:40:00 -->
@@ -181,6 +180,7 @@
     <bean id="indexExperimentsTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
             <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
+                <constructor-arg ref="groupAgentSecureInvoker"/>
                 <property name="targetObject" ref="indexerService"/>
                 <property name="targetMethod" value="index"/>
                 <property name="arguments">

--- a/gemma-web/src/main/resources/ubic/gemma/applicationContext-schedule.xml
+++ b/gemma-web/src/main/resources/ubic/gemma/applicationContext-schedule.xml
@@ -35,6 +35,14 @@
         <property name="autoStartup" value="${quartzOn}"/>
     </bean>
 
+    <!-- invoke methods as a member of the GROUP_AGENT -->
+    <bean id="groupAgentSecureInvoker" class="ubic.gemma.web.scheduler.SecureInvoker">
+        <constructor-arg ref="manualAuthenticationService"/>
+        <property name="userName" value="${gemma.agent.userName}"/>
+        <property name="password" value="${gemma.agent.password}"/>
+        <property name="fallbackToAnonymous" value="true"/>
+    </bean>
+
     <!-- Triggers -->
     <!-- Cron trigger fields are: Seconds 0-59 , - * / Minutes 0-59 , - * / Hours 0-23 , - * / Day-of-month 1-31 , - * ? / L
         W Month 1-12 or JAN-DEC , - * / Day-of-Week 1-7 or SUN-SAT , - * ? / L # Year (Optional) empty, 1970-2099 , - * / See http://www.opensymphony.com/quartz/api/org/quartz/CronExpression.html
@@ -46,6 +54,7 @@
                 <property name="targetObject" ref="expressionExperimentReportService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="recalculateBatchInfo"/>
+                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every day at 00:30:00 -->
@@ -58,6 +67,7 @@
                 <property name="targetObject" ref="expressionExperimentReportService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="generateSummaryObjects"/>
+                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every first-of-the-month at 00:15:00 -->
@@ -70,6 +80,7 @@
                 <property name="targetObject" ref="arrayDesignReportService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="generateArrayDesignReport"/>
+                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every first-of-the-month at 01:30:00 -->
@@ -82,6 +93,7 @@
                 <property name="targetObject" ref="whatsNewService"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="generateWeeklyReport"/>
+                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every day at 00:15:00 -->
@@ -94,6 +106,7 @@
                 <property name="targetObject" ref="tableMaintenanceUtil"/>
                 <property name="concurrent" value="false"/>
                 <property name="targetMethod" value="updateGene2CsEntries"/>
+                <property name="secureInvoker" ref="groupAgentSecureInvoker"/>
             </bean>
         </property>
         <!-- every day at 00:40:00 -->
@@ -101,16 +114,15 @@
     </bean>
     <bean id="ee2cExperimentUpdateTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
-            <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
-                <property name="targetObject" ref="tableMaintenanceUtil"/>
-                <property name="targetMethod" value="updateExpressionExperiment2CharacteristicEntries"/>
-                <property name="arguments">
-                    <array>
-                        <value type="java.lang.Class">ubic.gemma.model.expression.experiment.ExpressionExperiment</value>
-                        <value>false</value>
-                    </array>
+            <bean class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+                <property name="jobClass" value="ubic.gemma.web.scheduler.Ee2cUpdateJob"/>
+                <property name="jobDataAsMap">
+                    <map>
+                        <entry key="tableMaintenanceUtil" value-ref="tableMaintenanceUtil"/>
+                        <entry key="level" value="ubic.gemma.model.expression.experiment.ExpressionExperiment"/>
+                        <entry key="secureInvoker" value-ref="groupAgentSecureInvoker"/>
+                    </map>
                 </property>
-                <property name="concurrent" value="false"/>
             </bean>
         </property>
         <!-- hourly during working hours when the curators actively dataset tags -->
@@ -118,16 +130,15 @@
     </bean>
     <bean id="ee2cSampleUpdateTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
-            <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
-                <property name="targetObject" ref="tableMaintenanceUtil"/>
-                <property name="targetMethod" value="updateExpressionExperiment2CharacteristicEntries"/>
-                <property name="arguments">
-                    <array>
-                        <value type="java.lang.Class">ubic.gemma.model.expression.biomaterial.BioMaterial</value>
-                        <value>false</value>
-                    </array>
+            <bean class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+                <property name="jobClass" value="ubic.gemma.web.scheduler.Ee2cUpdateJob"/>
+                <property name="jobDataAsMap">
+                    <map>
+                        <entry key="tableMaintenanceUtil" value-ref="tableMaintenanceUtil"/>
+                        <entry key="level" value="ubic.gemma.model.expression.biomaterial.BioMaterial"/>
+                        <entry key="secureInvoker" value-ref="groupAgentSecureInvoker"/>
+                    </map>
                 </property>
-                <property name="concurrent" value="false"/>
             </bean>
         </property>
         <!-- hourly during working hours, when new experiments are imported -->
@@ -136,16 +147,15 @@
     </bean>
     <bean id="ee2cExperimentalDesignUpdateTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
-            <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
-                <property name="targetObject" ref="tableMaintenanceUtil"/>
-                <property name="targetMethod" value="updateExpressionExperiment2CharacteristicEntries"/>
-                <property name="arguments">
-                    <array>
-                        <value type="java.lang.Class">ubic.gemma.model.expression.experiment.ExperimentalDesign</value>
-                        <value>false</value>
-                    </array>
+            <bean class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+                <property name="jobClass" value="ubic.gemma.web.scheduler.Ee2cUpdateJob"/>
+                <property name="jobDataAsMap">
+                    <map>
+                        <entry key="tableMaintenanceUtil" value-ref="tableMaintenanceUtil"/>
+                        <entry key="level" value="ubic.gemma.model.expression.experiment.ExperimentalDesign"/>
+                        <entry key="secureInvoker" value-ref="groupAgentSecureInvoker"/>
+                    </map>
                 </property>
-                <property name="concurrent" value="false"/>
             </bean>
         </property>
         <!-- every 30 minutes during working hours (when the curators actively update annotations) -->
@@ -154,10 +164,14 @@
     </bean>
     <bean id="ee2adUpdateTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
         <property name="jobDetail">
-            <bean class="ubic.gemma.web.scheduler.SecureMethodInvokingJobDetailFactoryBean">
-                <property name="targetObject" ref="tableMaintenanceUtil"/>
-                <property name="targetMethod" value="updateExpressionExperiment2ArrayDesignEntries"/>
-                <property name="concurrent" value="false"/>
+            <bean class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+                <property name="jobClass" value="ubic.gemma.web.scheduler.Ee2AdUpdateJob"/>
+                <property name="jobDataAsMap">
+                    <map>
+                        <entry key="tableMaintenanceUtil" value-ref="tableMaintenanceUtil"/>
+                        <entry key="secureInvoker" value-ref="groupAgentSecureInvoker"/>
+                    </map>
+                </property>
             </bean>
         </property>
         <!-- every hour during working hours (mostly when new datasets are added & RNA-Seq data is imported which produce a platform switch) -->

--- a/gemma-web/src/test/java/ubic/gemma/web/scheduler/SchedulerSecurityTest.java
+++ b/gemma-web/src/test/java/ubic/gemma/web/scheduler/SchedulerSecurityTest.java
@@ -68,13 +68,12 @@ public class SchedulerSecurityTest extends BaseSpringWebTest {
 
         String jobName = "job_" + RandomStringUtils.randomAlphabetic( 10 );
 
-        SecureMethodInvokingJobDetailFactoryBean jobDetail = new SecureMethodInvokingJobDetailFactoryBean();
+        SecureMethodInvokingJobDetailFactoryBean jobDetail = new SecureMethodInvokingJobDetailFactoryBean( this.secureInvoker );
         jobDetail.setTargetMethod( "generateWeeklyReport" );
         jobDetail.setTargetObject( whatsNewService ); // access should be ok for GROUP_AGENT.
         jobDetail.setConcurrent( false );
         jobDetail.setBeanName( jobName );
         jobDetail.afterPropertiesSet(); // needed when we do this programatically.
-        jobDetail.setSecureInvoker( this.secureInvoker );
 
         jobDetail.invoke();
 
@@ -89,14 +88,13 @@ public class SchedulerSecurityTest extends BaseSpringWebTest {
 
         String jobName = "job_" + RandomStringUtils.randomAlphabetic( 10 );
 
-        SecureMethodInvokingJobDetailFactoryBean jobDetail = new SecureMethodInvokingJobDetailFactoryBean();
+        SecureMethodInvokingJobDetailFactoryBean jobDetail = new SecureMethodInvokingJobDetailFactoryBean( this.secureInvoker );
         jobDetail.setTargetMethod( "findByUpdatedLimit" );
         jobDetail.setArguments( new Object[] { 10 } );
         jobDetail.setTargetObject( expressionExperimentService ); // access should be ok for GROUP_AGENT.
         jobDetail.setConcurrent( false );
         jobDetail.setBeanName( jobName );
         jobDetail.afterPropertiesSet(); // needed when we do this programatically.
-        jobDetail.setSecureInvoker( this.secureInvoker );
 
         jobDetail.invoke();
 
@@ -114,14 +112,13 @@ public class SchedulerSecurityTest extends BaseSpringWebTest {
         /*
          * Mimics configuration in xml.
          */
-        SecureMethodInvokingJobDetailFactoryBean jobDetail = new SecureMethodInvokingJobDetailFactoryBean();
+        SecureMethodInvokingJobDetailFactoryBean jobDetail = new SecureMethodInvokingJobDetailFactoryBean( this.secureInvoker );
         jobDetail.setTargetMethod( "remove" );
         jobDetail.setArguments( new Object[] { null } );
         jobDetail.setTargetObject( expressionExperimentService ); // no access
         jobDetail.setConcurrent( false );
         jobDetail.setBeanName( jobName );
         jobDetail.afterPropertiesSet(); // needed when we do this programatically.
-        jobDetail.setSecureInvoker( this.secureInvoker );
         jobDetail.invoke();
 
     }


### PR DESCRIPTION
Add a since parameter to only update entries from datasets modified after the given date.

Rewrite the secure job to be more flexible so that it can also be used for direct Quartz job implementations.