### PR TITLE
Implement file-level locking for expression data files

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/util/ReadWriteFileLock.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/ReadWriteFileLock.java
@@ -1,0 +1,258 @@
+package ubic.gemma.core.util;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLockInterruptionException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A read/write lock to synchronize access to a file.
+ * <p>
+ * The implementation uses {@link ReentrantReadWriteLock} to guard a {@link java.nio.channels.FileLock}, providing
+ * locking capabilities at the OS-level.
+ * <p>
+ * Only one {@link ReadWriteFileLock} may be used for a given file at a time throughout the JVM.
+ * @author poirigui
+ */
+public class ReadWriteFileLock implements ReadWriteLock {
+
+    /**
+     * Open a read/write file lock.
+     * @param path    a path to lock
+     */
+    public static ReadWriteFileLock open( Path path ) {
+        return new ReadWriteFileLock( new ReentrantReadWriteLock(), path );
+    }
+
+    private final Path path;
+    private final Lock readLock;
+    private final Lock writeLock;
+
+    @Nullable
+    private volatile FileChannel channel;
+    /**
+     * Number of holders for the channel.
+     * <p>
+     * When it drops to zero, the channel is closed.
+     */
+    private final AtomicInteger channelHolders = new AtomicInteger( 0 );
+
+    private ReadWriteFileLock( ReadWriteLock rwLock, Path path ) {
+        this.path = path;
+        this.readLock = new FileLock( rwLock.readLock(), true );
+        this.writeLock = new FileLock( rwLock.writeLock(), false );
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    private FileChannel getChannel() throws IOException {
+        FileChannel fc = channel;
+        if ( fc == null ) {
+            fc = FileChannel.open( path, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE );
+            channel = fc;
+        }
+        return fc;
+    }
+
+    @Override
+    public Lock readLock() {
+        return readLock;
+    }
+
+    @Override
+    public Lock writeLock() {
+        return writeLock;
+    }
+
+    private class FileLock implements Lock {
+
+        private final Lock lock;
+        private final boolean shared;
+        /**
+         * Total holders for this lock for this thread.
+         */
+        private final ThreadLocal<Integer> holders = ThreadLocal.withInitial( () -> 0 );
+
+        @Nullable
+        private volatile java.nio.channels.FileLock fileLock;
+        /**
+         * Total holders for the file lock.
+         * <p>
+         * When it drops to zero, the lock is released.
+         */
+        private final AtomicInteger fileLockHolders = new AtomicInteger( 0 );
+
+        private FileLock( Lock lock, boolean shared ) {
+            this.lock = lock;
+            this.shared = shared;
+        }
+
+        @Override
+        public void lock() {
+            lock.lock();
+            if ( fileLock != null ) {
+                incrementHolders();
+                return;
+            }
+            try {
+                fileLock = getChannel().lock( 0, Long.MAX_VALUE, shared );
+                incrementHolders();
+            } catch ( IOException e ) {
+                lock.unlock();
+                throw new RuntimeException( "Failed to acquire " + ( shared ? "shared" : "exclusive" ) + " lock on " + path + ".", e );
+            }
+        }
+
+        @Override
+        public void lockInterruptibly() throws InterruptedException {
+            lock.lockInterruptibly();
+            if ( fileLock != null ) {
+                incrementHolders();
+                return;
+            }
+            try {
+                fileLock = getChannel().lock( 0, Long.MAX_VALUE, shared );
+                incrementHolders();
+            } catch ( FileLockInterruptionException e ) {
+                lock.unlock();
+                throw new InterruptedException( e.getMessage() );
+            } catch ( IOException e ) {
+                lock.unlock();
+                throw new RuntimeException( "Failed to acquire " + ( shared ? "shared" : "exclusive" ) + " lock on " + path + ".", e );
+            }
+        }
+
+        @Override
+        public boolean tryLock() {
+            if ( !lock.tryLock() ) {
+                return false;
+            }
+
+            if ( fileLock != null ) {
+                incrementHolders();
+                return true;
+            }
+
+            try {
+                java.nio.channels.FileLock fl = getChannel().tryLock( 0, Long.MAX_VALUE, shared );
+                if ( fl == null ) {
+                    lock.unlock();
+                    return false;
+                }
+                fileLock = fl;
+                incrementHolders();
+                return true;
+            } catch ( IOException e ) {
+                lock.unlock();
+                throw new RuntimeException( "Failed to acquire " + ( shared ? "shared" : "exclusive" ) + " lock on " + path + ".", e );
+            }
+        }
+
+        @Override
+        public boolean tryLock( long l, TimeUnit timeUnit ) throws InterruptedException {
+            long startNs = System.nanoTime();
+            if ( !lock.tryLock( l, timeUnit ) ) {
+                return false;
+            }
+
+            if ( fileLock != null ) {
+                incrementHolders();
+                return true;
+            }
+
+            // use the remaining time to acquire a file lock
+            while ( ( System.nanoTime() - startNs ) < timeUnit.toNanos( l ) ) {
+                if ( Thread.interrupted() ) {
+                    lock.unlock();
+                    throw new InterruptedException( "Current thread was interrupted while waiting for a " + ( shared ? "shared" : "exclusive" ) + " lock on " + path + "." );
+                }
+                try {
+                    java.nio.channels.FileLock fl = getChannel().tryLock( 0, Long.MAX_VALUE, shared );
+                    if ( fl != null ) {
+                        fileLock = fl;
+                        incrementHolders();
+                        return true;
+                    }
+                } catch ( IOException e ) {
+                    lock.unlock();
+                    throw new RuntimeException( "Failed to acquire " + ( shared ? "shared" : "exclusive" ) + " lock on " + path + ".", e );
+                }
+            }
+
+            // timed out
+            lock.unlock();
+            return false;
+        }
+
+        @Override
+        public void unlock() {
+            try {
+                decrementHolders();
+            } catch ( IOException e ) {
+                throw new RuntimeException( "Failed to release lock on " + path + ".", e );
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public Condition newCondition() {
+            return lock.newCondition();
+        }
+
+        private void incrementHolders() {
+            FileChannel c = channel;
+            if ( c == null || !c.isOpen() ) {
+                throw new IllegalStateException( "Channel is not open." );
+            }
+            channelHolders.incrementAndGet();
+            java.nio.channels.FileLock fl = fileLock;
+            if ( fl == null || !fl.isValid() ) {
+                throw new IllegalStateException( "There is no valid file lock to be held." );
+            }
+            fileLockHolders.incrementAndGet();
+            holders.set( holders.get() + 1 );
+        }
+
+        /**
+         * @throws IllegalMonitorStateException if the number of holders goes below zero
+         */
+        private void decrementHolders() throws IllegalMonitorStateException, IOException {
+            int th = holders.get() - 1;
+            if ( th < 0 ) {
+                holders.remove();
+                throw new IllegalMonitorStateException();
+            } else if ( th == 0 ) {
+                holders.remove();
+            } else {
+                holders.set( th );
+            }
+            java.nio.channels.FileLock fl = fileLock;
+            if ( fileLockHolders.decrementAndGet() == 0 ) {
+                if ( fl == null ) {
+                    throw new IllegalStateException();
+                }
+                fileLock = null;
+                fl.release();
+            }
+            FileChannel c = channel;
+            if ( channelHolders.decrementAndGet() == 0 ) {
+                if ( c == null ) {
+                    throw new IllegalStateException();
+                }
+                channel = null;
+                c.close();
+            }
+        }
+    }
+}

--- a/gemma-core/src/test/java/ubic/gemma/core/util/ReadWriteFileLockTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/util/ReadWriteFileLockTest.java
@@ -1,0 +1,136 @@
+package ubic.gemma.core.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ReadWriteFileLockTest {
+
+    @Test
+    public void test() throws IOException {
+        Path tempDir = Files.createTempDirectory( "test" );
+        ReadWriteFileLock lock = ReadWriteFileLock.open( tempDir.resolve( "test.txt" ) );
+
+        lock.writeLock().lock();
+        Files.write( lock.getPath(), Collections.singleton( "Hello world!" ), StandardCharsets.UTF_8 );
+        lock.writeLock().unlock();
+
+        lock.readLock().lock();
+        assertThat( Files.readAllLines( lock.getPath(), StandardCharsets.UTF_8 ) )
+                .containsExactly( "Hello world!" );
+        lock.readLock().unlock();
+
+        // make sure the write lock is re-usable
+        lock.writeLock().lock();
+        Files.write( lock.getPath(), Collections.singleton( "Hello world!" ), StandardCharsets.UTF_8 );
+        lock.writeLock().unlock();
+
+        // make sure the read lock is re-usable
+        lock.readLock().lock();
+        assertThat( Files.readAllLines( lock.getPath(), StandardCharsets.UTF_8 ) )
+                .containsExactly( "Hello world!" );
+        lock.readLock().unlock();
+    }
+
+    @Test
+    public void testConcurrentReadWriteAccess() throws IOException, InterruptedException {
+        Path tempDir = Files.createTempDirectory( "test" );
+        ReadWriteFileLock lock = ReadWriteFileLock.open( tempDir.resolve( "test.txt" ) );
+        lock.writeLock().lock();
+        Files.write( lock.getPath(), Collections.singleton( "Hello world!" ), StandardCharsets.UTF_8 );
+
+        AtomicBoolean result = new AtomicBoolean();
+        AtomicBoolean result2 = new AtomicBoolean();
+        AtomicBoolean result3 = new AtomicBoolean();
+        Thread t = new Thread( () -> {
+            result.set( lock.readLock().tryLock() );
+            if ( result.get() ) {
+                lock.readLock().unlock();
+            }
+            result2.set( lock.writeLock().tryLock() );
+            if ( result2.get() ) {
+                lock.writeLock().unlock();
+            }
+            result3.set( lock.writeLock().tryLock() );
+            if ( result3.get() ) {
+                lock.writeLock().unlock();
+            }
+        } );
+        t.start();
+        t.join();
+
+        lock.writeLock().unlock();
+
+        assertThat( result ).isFalse();
+        assertThat( result2 ).isFalse();
+        assertThat( result3 ).isFalse();
+
+        lock.readLock().lock();
+
+        Thread t2 = new Thread( () -> {
+            result.set( lock.readLock().tryLock() );
+            if ( result.get() ) {
+                lock.readLock().unlock();
+            }
+            result2.set( lock.writeLock().tryLock() );
+            if ( result2.get() ) {
+                lock.writeLock().unlock();
+            }
+            result3.set( lock.writeLock().tryLock() );
+            if ( result3.get() ) {
+                lock.writeLock().unlock();
+            }
+        } );
+        t2.start();
+        t2.join();
+        lock.readLock().unlock();
+
+        assertThat( result ).isTrue();
+        assertThat( result2 ).isFalse();
+        assertThat( result3 ).isFalse();
+    }
+
+    @Test
+    public void testReentrantLocking() throws IOException {
+        Path tempDir = Files.createTempDirectory( "test" );
+        ReadWriteFileLock lock = ReadWriteFileLock.open( tempDir.resolve( "test.txt" ) );
+        lock.writeLock().lock();
+        lock.writeLock().lock();
+        lock.writeLock().unlock();
+        lock.writeLock().unlock();
+        assertThatThrownBy( () -> lock.writeLock().unlock() )
+                .isInstanceOf( IllegalMonitorStateException.class );
+    }
+
+    @Test
+    public void testReentrantLockingWithConcurrency() throws IOException, InterruptedException {
+        Path tempDir = Files.createTempDirectory( "test" );
+        ReadWriteFileLock lock = ReadWriteFileLock.open( tempDir.resolve( "test.txt" ) );
+        lock.readLock().lock();
+        lock.readLock().lock();
+
+        Thread t = new Thread( () -> {
+            lock.readLock().lock();
+            lock.readLock().lock();
+            lock.readLock().unlock();
+            lock.readLock().unlock();
+            assertThatThrownBy( () -> lock.readLock().unlock() )
+                    .isInstanceOf( IllegalMonitorStateException.class );
+        } );
+        t.start();
+        t.join();
+
+        lock.readLock().unlock();
+        lock.readLock().unlock();
+        assertThatThrownBy( () -> lock.readLock().unlock() )
+                .isInstanceOf( IllegalMonitorStateException.class );
+    }
+}

--- a/gemma-core/src/test/java/ubic/gemma/core/util/ReadWriteFileLockTestScript.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/util/ReadWriteFileLockTestScript.java
@@ -1,0 +1,33 @@
+package ubic.gemma.core.util;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Test script to validate locking behaviors for {@link ReadWriteFileLockTest}.
+ * @author poirigui
+ */
+public class ReadWriteFileLockTestScript {
+
+    public static void main( String[] args ) {
+        boolean shared = args[1].equals( "shared" );
+        try ( FileChannel channel = FileChannel.open( Paths.get( args[0] ), StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE ) ) {
+            System.out.println( "Acquiring " + args[1] + " lock on " + args[0] + "..." );
+            try ( FileLock lock = channel.tryLock( 0, Long.MAX_VALUE, shared ) ) {
+                if ( lock != null ) {
+                    System.out.println( "Lock acquired." );
+                    System.exit( 0 );
+                } else {
+                    System.out.println( "Lock not acquired." );
+                    System.exit( 2 );
+                }
+            }
+        } catch ( IOException e ) {
+            e.printStackTrace( System.err );
+            System.exit( 1 );
+        }
+    }
+}


### PR DESCRIPTION
This allows Gemma CLI and Gemma Web to coordinate when expression data files (and other files such as metadata and analysis files) are generated.

I had to resort to use a sibling `.lock` file because 1) a directory cannot be open in write mode and 2) deleting a file requires a file to exist in the first place.

Thus, every file that we read/write will have a companion `.lock`file to synchronize accesses. If no such file exists, it will be created automatically.

This is using POSIX lock under the hood and works with NFS 4. I will have to do some manual testing since I cannot do that conveniently in a unit test.