### PR TITLE
keep default indentation for diff exp trees

### DIFF
--- a/gemma-web/src/main/webapp/styles/ext-overrides.css
+++ b/gemma-web/src/main/webapp/styles/ext-overrides.css
@@ -214,6 +214,4 @@
     font: normal 12px tahoma, arial, helvetica, sans-serif;
 }
 
-.x-tree-elbow-end{
-    display:none
-}
+


### PR DESCRIPTION
Reverts the indentation change to avoid problems with differential expression trees