### PR TITLE
Prototype for writing Cell Browser-compatible metadata

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/apps/CellLevelMetadataWriterCli.java
+++ b/gemma-cli/src/main/java/ubic/gemma/apps/CellLevelMetadataWriterCli.java
@@ -1,0 +1,65 @@
+package ubic.gemma.apps;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.springframework.beans.factory.annotation.Autowired;
+import ubic.gemma.core.visualization.cellbrowser.CellBrowserMetadataWriter;
+import ubic.gemma.model.common.quantitationtype.QuantitationType;
+import ubic.gemma.model.expression.bioAssayData.SingleCellDimension;
+import ubic.gemma.model.expression.bioAssayData.SingleCellExpressionDataVector;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.persistence.service.expression.experiment.SingleCellExpressionExperimentService;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+public class CellLevelMetadataWriterCli extends ExpressionExperimentVectorsManipulatingCli<SingleCellExpressionDataVector> {
+
+    @Autowired
+    private SingleCellExpressionExperimentService singleCellExpressionExperimentService;
+
+    private boolean useBioAssayIds;
+    private boolean useRawColumnNames;
+
+    public CellLevelMetadataWriterCli() {
+        super( SingleCellExpressionDataVector.class );
+        setSingleExperimentMode();
+        setUsePreferredQuantitationType();
+    }
+
+    @Override
+    public String getCommandName() {
+        return "getSingleCellMetadata";
+    }
+
+    @Override
+    protected void buildExperimentVectorsOptions( Options options ) {
+        options.addOption( "useBioAssayIds", "use-bioassay-ids", false, "Use BioAssay IDs instead of their names." );
+        options.addOption( "useRawColumnNames", "use-raw-column-names", false, "Use raw names for the columns, otherwise R-friendly names are used." );
+    }
+
+    @Override
+    protected void processExperimentVectorsOptions( CommandLine commandLine ) {
+        useBioAssayIds = commandLine.hasOption( "useBioAssayIds" );
+        useRawColumnNames = commandLine.hasOption( "useRawColumnNames" );
+    }
+
+    @Override
+    protected void processExpressionExperimentVectors( ExpressionExperiment ee, QuantitationType qt ) throws IOException {
+        ee = eeService.thawLite( ee );
+        SingleCellDimension scd = singleCellExpressionExperimentService.getSingleCellDimensionWithAssaysAndCellLevelCharacteristics( ee, qt );
+        if ( scd == null ) {
+            addErrorObject( ee, "There is no single-cell dimension associated to " + qt + "." );
+            return;
+        }
+        try ( Writer out = new OutputStreamWriter( getCliContext().getOutputStream(), StandardCharsets.UTF_8 ) ) {
+            CellBrowserMetadataWriter writer = new CellBrowserMetadataWriter();
+            writer.setUseBioAssayIds( useBioAssayIds );
+            writer.setUseRawColumnNames( useRawColumnNames );
+            writer.setAutoFlush( true );
+            writer.write( ee, scd, out );
+        }
+    }
+}

--- a/gemma-cli/src/main/java/ubic/gemma/apps/ExpressionExperimentVectorsManipulatingCli.java
+++ b/gemma-cli/src/main/java/ubic/gemma/apps/ExpressionExperimentVectorsManipulatingCli.java
@@ -97,7 +97,7 @@ public abstract class ExpressionExperimentVectorsManipulatingCli<T extends DataV
     }
 
     @Override
-    protected void processExpressionExperiment( ExpressionExperiment expressionExperiment ) {
+    protected void processExpressionExperiment( ExpressionExperiment expressionExperiment ) throws Exception {
         Collection<QuantitationType> qts;
         if ( qtIdentifier != null ) {
             qts = Collections.singleton( entityLocator.locateQuantitationType( expressionExperiment, qtIdentifier, quantitationTypeService.getMappedDataVectorType( dataVectorType ) ) );
@@ -126,7 +126,7 @@ public abstract class ExpressionExperimentVectorsManipulatingCli<T extends DataV
     /**
      * Process a set of vectors identified by a {@link QuantitationType}.
      */
-    protected abstract void processExpressionExperimentVectors( ExpressionExperiment ee, QuantitationType qt );
+    protected abstract void processExpressionExperimentVectors( ExpressionExperiment ee, QuantitationType qt ) throws Exception;
 
     private QuantitationType locatePreferredQuantitationType( ExpressionExperiment expressionExperiment, Class<? extends DataVector> dataVectorType ) {
         if ( RawExpressionDataVector.class.isAssignableFrom( dataVectorType ) ) {

--- a/gemma-cli/src/main/java/ubic/gemma/apps/ListQuantitationTypesCli.java
+++ b/gemma-cli/src/main/java/ubic/gemma/apps/ListQuantitationTypesCli.java
@@ -45,7 +45,7 @@ public class ListQuantitationTypesCli extends ExpressionExperimentVectorsManipul
     }
 
     @Override
-    protected void processExpressionExperiment( ExpressionExperiment expressionExperiment ) {
+    protected void processExpressionExperiment( ExpressionExperiment expressionExperiment ) throws Exception {
         getCliContext().getOutputStream().println( formatExperiment( expressionExperiment ) );
         super.processExpressionExperiment( expressionExperiment );
         getCliContext().getOutputStream().println();

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -35,6 +35,7 @@ import ubic.gemma.core.datastructure.matrix.io.*;
 import ubic.gemma.core.util.BuildInfo;
 import ubic.gemma.core.util.locking.FileLockManager;
 import ubic.gemma.core.util.locking.LockedPath;
+import ubic.gemma.core.visualization.cellbrowser.CellBrowserTabularMatrixWriter;
 import ubic.gemma.model.analysis.expression.diff.DifferentialExpressionAnalysis;
 import ubic.gemma.model.common.quantitationtype.QuantitationType;
 import ubic.gemma.model.common.quantitationtype.ScaleType;

--- a/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserMetadataWriter.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserMetadataWriter.java
@@ -1,0 +1,107 @@
+package ubic.gemma.core.visualization.cellbrowser;
+
+import lombok.Setter;
+import lombok.extern.apachecommons.CommonsLog;
+import ubic.gemma.core.util.TsvUtils;
+import ubic.gemma.model.common.description.Characteristic;
+import ubic.gemma.model.expression.bioAssay.BioAssay;
+import ubic.gemma.model.expression.bioAssayData.CellLevelCharacteristics;
+import ubic.gemma.model.expression.bioAssayData.SingleCellDimension;
+import ubic.gemma.model.expression.experiment.ExperimentalFactor;
+import ubic.gemma.model.expression.experiment.ExpressionExperiment;
+import ubic.gemma.model.expression.experiment.FactorValue;
+import ubic.gemma.model.expression.experiment.FactorValueUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static ubic.gemma.core.datastructure.matrix.io.ExpressionDataWriterUtils.constructAssayName;
+
+/**
+ * Write metadata file for the Cell Browser visualization tool.
+ * @author poirigui
+ */
+@CommonsLog
+public class CellBrowserMetadataWriter {
+
+    @Setter
+    private boolean useBioAssayIds = false;
+    @Setter
+    private boolean autoFlush = false;
+
+    public void write( ExpressionExperiment ee, SingleCellDimension singleCellDimension, Writer writer ) throws IOException {
+        List<ExperimentalFactor> factors;
+        if ( ee.getExperimentalDesign() != null ) {
+            factors = ee.getExperimentalDesign().getExperimentalFactors().stream()
+                    .sorted()
+                    .collect( Collectors.toList() );
+        } else {
+            log.warn( ee + " does not have an experimental design, no factors will be written." );
+            factors = Collections.emptyList();
+        }
+        List<CellLevelCharacteristics> clcs = new ArrayList<>();
+        // TODO: sort these
+        clcs.addAll( singleCellDimension.getCellTypeAssignments() );
+        clcs.addAll( singleCellDimension.getCellLevelCharacteristics() );
+        writeHeader( factors, clcs, writer );
+        int cellIndex = 0;
+        for ( int sampleIndex = 0; sampleIndex < singleCellDimension.getBioAssays().size(); sampleIndex++ ) {
+            BioAssay bioAssay = singleCellDimension.getBioAssays().get( sampleIndex );
+            String sampleId = getSampleId( bioAssay );
+            for ( String cellId : singleCellDimension.getCellIdsBySample( sampleIndex ) ) {
+                writeCell( bioAssay, sampleId, cellId, cellIndex++, factors, clcs, writer );
+            }
+        }
+    }
+
+    private void writeHeader( List<ExperimentalFactor> factors, List<CellLevelCharacteristics> clcs, Writer writer ) throws IOException {
+        writer.append( "cell_id" );
+        for ( ExperimentalFactor factor : factors ) {
+            writer.append( "\t" );
+            writer.append( factor.getName() );
+        }
+        for ( CellLevelCharacteristics clc : clcs ) {
+            writer.append( "\t" );
+            writer.append( clc.getName() );
+        }
+        if ( autoFlush ) {
+            writer.flush();
+        }
+    }
+
+    public void writeCell( BioAssay bioAssay, String sampleId, String cellId, int cellIndex, List<ExperimentalFactor> factors, List<CellLevelCharacteristics> clcs, Writer writer ) throws IOException {
+        writer.append( sampleId ).append( "_" ).append( cellId );
+        writer.append( "\n" );
+        for ( ExperimentalFactor factor : factors ) {
+            writer.append( "\t" );
+            for ( FactorValue fv : bioAssay.getSampleUsed().getAllFactorValues() ) {
+                if ( fv.getExperimentalFactor().equals( factor ) ) {
+                    writer.append( FactorValueUtils.getValue( fv ) );
+                    break;
+                }
+            }
+        }
+        for ( CellLevelCharacteristics clc : clcs ) {
+            writer.append( "\t" );
+            Characteristic c = clc.getCharacteristic( cellIndex );
+            if ( c != null ) {
+                writer.append( TsvUtils.format( c.getValue() ) );
+            }
+        }
+        if ( autoFlush ) {
+            writer.flush();
+        }
+    }
+
+    private String getSampleId( BioAssay bioAssay ) {
+        if ( useBioAssayIds ) {
+            return String.valueOf( bioAssay.getId() );
+        } else {
+            return constructAssayName( bioAssay );
+        }
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserTabularMatrixWriter.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserTabularMatrixWriter.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static ubic.gemma.core.datastructure.matrix.io.ExpressionDataWriterUtils.constructAssayName;
-
 /**
  * Generate a tabular matrix format compatible with <a href="https://cellbrowser.readthedocs.io/en/master/tabsep.html">Cell Browser</a>.
  * @author poirigui
@@ -80,9 +78,8 @@ public class CellBrowserTabularMatrixWriter implements SingleCellExpressionDataM
         writer.append( "gene" );
         for ( int sampleIndex = 0; sampleIndex < singleCellDimension.getBioAssays().size(); sampleIndex++ ) {
             BioAssay bioAssay = singleCellDimension.getBioAssays().get( sampleIndex );
-            String sampleId = getSampleId( bioAssay );
             for ( String cellId : singleCellDimension.getCellIdsBySample( sampleIndex ) ) {
-                writer.append( "\t" ).append( sampleId ).append( "_" ).append( cellId );
+                writer.append( "\t" ).append( CellBrowserUtils.constructCellId( bioAssay, cellId, useBioAssayIds ) );
             }
         }
         writer.append( "\n" );
@@ -164,14 +161,6 @@ public class CellBrowserTabularMatrixWriter implements SingleCellExpressionDataM
                     writer.append( "|" ).append( gene.getOfficialSymbol() );
                 }
             }
-        }
-    }
-
-    private String getSampleId( BioAssay bioAssay ) {
-        if ( useBioAssayIds ) {
-            return String.valueOf( bioAssay.getId() );
-        } else {
-            return constructAssayName( bioAssay );
         }
     }
 }

--- a/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserTabularMatrixWriter.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserTabularMatrixWriter.java
@@ -1,9 +1,10 @@
-package ubic.gemma.core.datastructure.matrix.io;
+package ubic.gemma.core.visualization.cellbrowser;
 
 import ubic.gemma.core.analysis.preprocess.convert.ScaleTypeConversionUtils;
 import ubic.gemma.core.analysis.preprocess.convert.UnsupportedQuantitationScaleConversionException;
 import ubic.gemma.core.analysis.preprocess.convert.UnsupportedQuantitationTypeConversionException;
 import ubic.gemma.core.datastructure.matrix.SingleCellExpressionDataMatrix;
+import ubic.gemma.core.datastructure.matrix.io.SingleCellExpressionDataMatrixWriter;
 import ubic.gemma.core.util.TsvUtils;
 import ubic.gemma.model.common.quantitationtype.PrimitiveType;
 import ubic.gemma.model.common.quantitationtype.QuantitationTypeUtils;

--- a/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserUtils.java
@@ -1,0 +1,18 @@
+package ubic.gemma.core.visualization.cellbrowser;
+
+import ubic.gemma.model.expression.bioAssay.BioAssay;
+
+import static ubic.gemma.core.datastructure.matrix.io.ExpressionDataWriterUtils.constructAssayName;
+
+public class CellBrowserUtils {
+
+    public static String constructCellId( BioAssay bioAssay, String cellId, boolean useBioAssayIds ) {
+        String sampleId;
+        if ( useBioAssayIds ) {
+            sampleId = String.valueOf( bioAssay.getId() );
+        } else {
+            sampleId = constructAssayName( bioAssay );
+        }
+        return sampleId + "_" + cellId;
+    }
+}

--- a/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/package-info.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/visualization/cellbrowser/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * This package contains classes related to the <a href="https://cellbrowser.readthedocs.io/en/master/index.html">Cell Browser</a> visualization tool.
+ * @author poirigui
+ */
+@ParametersAreNonnullByDefault
+package ubic.gemma.core.visualization.cellbrowser;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/SingleCellExpressionExperimentService.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/SingleCellExpressionExperimentService.java
@@ -189,6 +189,16 @@ public interface SingleCellExpressionExperimentService {
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     SingleCellDimension getSingleCellDimensionWithCellLevelCharacteristics( ExpressionExperiment ee, QuantitationType qt );
 
+    /**
+     * Retrieve a single-cell dimension with its bioassays and cell-level  characteristics initialized.
+     * @param ee
+     * @param qt
+     * @return
+     */
+    @Nullable
+    @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
+    SingleCellDimension getSingleCellDimensionWithAssaysAndCellLevelCharacteristics( ExpressionExperiment ee, QuantitationType qt );
+
     @Nullable
     @Secured({ "IS_AUTHENTICATED_ANONYMOUSLY", "ACL_SECURABLE_READ" })
     SingleCellDimension getSingleCellDimensionWithoutCellIds( ExpressionExperiment ee, QuantitationType qt );

--- a/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/SingleCellExpressionExperimentServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/persistence/service/expression/experiment/SingleCellExpressionExperimentServiceImpl.java
@@ -699,6 +699,18 @@ public class SingleCellExpressionExperimentServiceImpl implements SingleCellExpr
 
     @Override
     @Transactional(readOnly = true)
+    public SingleCellDimension getSingleCellDimensionWithAssaysAndCellLevelCharacteristics( ExpressionExperiment ee, QuantitationType qt ) {
+        SingleCellDimension scd = expressionExperimentDao.getSingleCellDimension( ee, qt );
+        if ( scd == null ) {
+            throw new IllegalStateException( qt + " does not have an associated single-cell dimension." );
+        }
+        scd.getBioAssays().forEach( Thaws::thawBioAssay );
+        Thaws.thawSingleCellDimension( scd );
+        return scd;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public SingleCellDimension getSingleCellDimensionWithoutCellIds( ExpressionExperiment ee, QuantitationType qt, SingleCellDimensionInitializationConfig config ) {
         return expressionExperimentDao.getSingleCellDimensionWithoutCellIds( ee, qt, config.isIncludeBioAssays(), config.isIncludeCtas(), config.isIncludeClcs(), config.isIncludeProtocol(), config.isIncludeCharacteristics(), config.isIncludeIndices() );
     }

--- a/gemma-core/src/test/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserTabularMatrixWriterTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/visualization/cellbrowser/CellBrowserTabularMatrixWriterTest.java
@@ -1,4 +1,4 @@
-package ubic.gemma.core.datastructure.matrix.io;
+package ubic.gemma.core.visualization.cellbrowser;
 
 import org.junit.Test;
 import ubic.gemma.core.datastructure.matrix.SingleCellExpressionDataDoubleMatrix;


### PR DESCRIPTION
This will complement our ability to write Cell Browser-compatible expression data files.

 - [x] write sample-level factors
 - [x] write cell-level characteristics
 - [ ] write cell-level measurement (once #1375 is merged)
