### PR TITLE
Delombok sources used for generating Javadocs

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
         stage('Run quick unit tests') {
             steps {
                 setBuildStatus "Tests", "Tests for build #${env.BUILD_NUMBER} have started...", 'PENDING'
-                sh 'mvn -B test --fail-at-end -DexcludedGroups=SlowTest -DskipVersionFile'
+                sh 'mvn -B test --fail-at-end -DexcludedGroups=SlowTest -DskipVersionFile -DskipDelombok'
             }
             post {
                 always {
@@ -117,7 +117,7 @@ pipeline {
         stage('Package') {
             steps {
                 setBuildStatus "Package", "Package for build #${env.BUILD_NUMBER} have started...", 'PENDING'
-                sh 'mvn -B package -DskipTests -DskipVersionFile'
+                sh 'mvn -B package -DskipTests -DskipVersionFile -DskipDelombok'
             }
             post {
                 success {
@@ -158,7 +158,7 @@ pipeline {
                     steps {
                         lock('gemma-slow-tests') {
                             setBuildStatus "Slow tests", "Slow tests #${env.BUILD_NUMBER} have started...", 'PENDING'
-                            sh 'mvn -B test --fail-at-end -Dgroups=SlowTest -DskipWebpack -DskipVersionFile'
+                            sh 'mvn -B test --fail-at-end -Dgroups=SlowTest -DskipWebpack -DskipVersionFile -DskipDelombok'
                         }
                     }
                     post {
@@ -187,7 +187,7 @@ pipeline {
                     steps {
                         setBuildStatus "Integration tests", "Integration tests #${env.BUILD_NUMBER} have started...", 'PENDING'
                         lock('database/gemdtest') {
-                            sh 'mvn -B verify --fail-at-end -DskipUnitTests -DskipJavadoc -DskipWebpack -DskipVersionFile'
+                            sh 'mvn -B verify --fail-at-end -DskipUnitTests -DskipJavadoc -DskipWebpack -DskipVersionFile -DskipDelombok'
                         }
                     }
                     post {
@@ -217,7 +217,7 @@ pipeline {
                         lock('gemma-sonarqube-analysis') {
                             setBuildStatus "SonarQube Analysis", "SonarQube analysis for build #${env.BUILD_NUMBER} has started...", 'PENDING'
                             withSonarQubeEnv('UBC SonarQube') {
-                                sh "mvn package -DskipTests -DskipJavadoc -DskipWebpack -DskipVersionFile dependency-check:check sonar:sonar -Dsonar.projectKey=mslg -Dsonar.projectName='MSL - Gemma'"
+                                sh "mvn package -DskipTests -DskipJavadoc -DskipWebpack -DskipVersionFile -DskipDelombok dependency-check:check sonar:sonar -Dsonar.projectKey=mslg -Dsonar.projectName='MSL - Gemma'"
                             }
                         }
                     }
@@ -244,7 +244,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh 'mvn -B deploy -DskipTests -DskipJavadoc -DskipWebpack -DskipVersionFile'
+                        sh 'mvn -B deploy -DskipTests -DskipJavadoc -DskipWebpack -DskipVersionFile -DskipDelombok'
                     }
                 }
                 stage('Deploy Maven website') {
@@ -258,7 +258,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh 'mvn -B site-deploy -DskipWebpack -DskipVersionFile'
+                        sh 'mvn -B site-deploy -DskipWebpack -DskipVersionFile -DskipDelombok'
                         script {
                             if (dataDir != null) {
                                 sh "ln -Tsf ${params.MAVEN_SITES_DIR}/gemma/gemma-${gemmaVersion} ${dataDir}/gemma-devsite"

--- a/gemma-rest/pom.xml
+++ b/gemma-rest/pom.xml
@@ -209,4 +209,8 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <javadocSourcePaths>${delombok.output};${project.build.directory}/generated-sources/antlr4</javadocSourcePaths>
+    </properties>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -575,12 +575,38 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.projectlombok</groupId>
+				<artifactId>lombok-maven-plugin</artifactId>
+				<version>1.18.20.0</version>
+				<configuration>
+					<sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+					<outputDirectory>${delombok.output}</outputDirectory>
+					<addOutputDirectory>false</addOutputDirectory>
+					<skip>${skipDelombok}</skip>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>delombok</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.projectlombok</groupId>
+						<artifactId>lombok</artifactId>
+						<version>1.18.40</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<configuration>
+					<sourcepath>${javadocSourcePaths}</sourcepath>
 					<quiet>true</quiet>
-					<!-- with lombok, some references are invalid in the original source code -->
-					<doclint>all,-reference,-missing</doclint>
+					<doclint>all,-reference</doclint>
 					<links>
 						<link>https://gemma.msl.ubc.ca/resources/baseCode/apidocs/</link>
 						<link>https://dst.lbl.gov/ACSSoftware/colt/api/</link>
@@ -752,6 +778,7 @@
 				<skipJavadoc>true</skipJavadoc>
 				<skipTests>true</skipTests>
 				<skipWebpack>true</skipWebpack>
+				<skipDelombok>true</skipDelombok>
 			</properties>
 		</profile>
 	</profiles>
@@ -771,8 +798,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<configuration>
+					<sourcepath>${javadocSourcePaths}</sourcepath>
 					<quiet>true</quiet>
-					<doclint>all,-reference,-missing</doclint>
+					<doclint>all,-reference</doclint>
 					<links>
 						<link>https://gemma.msl.ubc.ca/resources/baseCode/apidocs/</link>
 						<link>https://dst.lbl.gov/ACSSoftware/colt/api/</link>
@@ -825,6 +853,7 @@
 		<skipTests>false</skipTests>
 		<skipUnitTests>${skipTests}</skipUnitTests>
 		<skipIntegrationTests>${skipTests}</skipIntegrationTests>
+		<skipDelombok>false</skipDelombok>
 		<redirectTestOutputToFile>true</redirectTestOutputToFile>
 		<!-- common JVM options -->
 		<jvmOptions>
@@ -841,5 +870,7 @@
 			<!-- the location of libhdf5 is system-dependent, so we do not want to add it to the default ${jvmOptions} -->
 			-Djava.library.path=${hdf5.libDir}
 		</testJvmOptions>
+		<delombok.output>${project.build.directory}/delombok</delombok.output>
+		<javadocSourcePaths>${delombok.output}</javadocSourcePaths>
 	</properties>
 </project>


### PR DESCRIPTION
We've reached a point where ignoring missing declarations is no-longer enough for generating docs.

Add ANTLR4 generated sources for generating docs for the REST API

Add a mechanism for skipping delombok with -DskipDelombok and add it to the fast profile. In the CI, avoid delomboking repeatedly.