### PR TITLE
fix pubpeer ignoring PMIDs if any DOIs are present

### DIFF
--- a/gemma-web/src/main/webapp/scripts/api/entities/experiment/ExpressionExperimentDetails.js
+++ b/gemma-web/src/main/webapp/scripts/api/entities/experiment/ExpressionExperimentDetails.js
@@ -893,7 +893,7 @@ Gemma.ExpressionExperimentDetails = Ext
                                         width: 80
                                     }*/
                                     , {
-                                        fieldLabel: 'Differential Expr. Analyses (<a href="https://pubmed.ncbi.nlm.nih.gov/33599246/">ANOVA</a>)',
+                                        fieldLabel: 'Differential Expr. Analyses (<a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7904053/#s2-s16">ANOVA</a>)',
                                         items: new Gemma.DifferentialExpressionAnalysesSummaryTree({
                                             experimentDetails: e,
                                             editable: this.editable,


### PR DESCRIPTION
Re-fixes #1283 because apparently pubpeer ignores PMIDs if any DOIs are present on the page