### PR TITLE
Provide processed data-specific experimental design

### DIFF
--- a/gemma-cli/src/main/java/ubic/gemma/apps/ExperimentalDesignWriterCLI.java
+++ b/gemma-cli/src/main/java/ubic/gemma/apps/ExperimentalDesignWriterCLI.java
@@ -52,7 +52,8 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
             USE_MULTIPLE_ROWS_FOR_ASSAYS = "useMultipleRowsForAssays",
             SEPARATE_SAMPLE_FROM_ASSAYS_IDENTIFIERS_OPTION = "separateSampleFromAssayIdentifiers",
             USE_BIO_ASSAY_IDS = "useBioAssayIds",
-            USE_RAW_COLUMN_NAMES_OPTION = "useRawColumnNames";
+            USE_RAW_COLUMN_NAMES_OPTION = "useRawColumnNames",
+            USE_PROCESSED_DATA_OPTION = "useProcessedData";
 
     @Autowired
     private BuildInfo buildInfo;
@@ -65,6 +66,7 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
     private boolean separateSampleFromAssaysIdentifiers;
     private boolean useBioAssayIds;
     private boolean useRawColumnNames;
+    private boolean useProcessedData;
     @Nullable
     private String outFileName;
 
@@ -87,6 +89,7 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
                 "Separate sample and assay(s) identifiers in distinct columns named 'Sample' and 'Assays' (instead of a single 'Bioassay' column). The assays will be delimited by a '" + TsvUtils.SUB_DELIMITER + "' character." );
         options.addOption( USE_BIO_ASSAY_IDS, "use-bioassay-ids", false, "Use IDs instead of names or short names for bioassays and samples." );
         options.addOption( USE_RAW_COLUMN_NAMES_OPTION, "use-raw-column-names", false, "Use raw names for the columns, otherwise R-friendly names are used. This option is incompatible with " + formatOption( options, STANDARD_LOCATION_OPTION ) + "." );
+        options.addOption( USE_PROCESSED_DATA_OPTION, "use-processed-data", false, "Write the experimental design for the assays of the processed data." );
         addForceOption( options );
     }
 
@@ -98,6 +101,7 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
         separateSampleFromAssaysIdentifiers = commandLine.hasOption( SEPARATE_SAMPLE_FROM_ASSAYS_IDENTIFIERS_OPTION );
         useBioAssayIds = commandLine.hasOption( USE_BIO_ASSAY_IDS );
         useRawColumnNames = commandLine.hasOption( USE_RAW_COLUMN_NAMES_OPTION );
+        useProcessedData = commandLine.hasOption( USE_PROCESSED_DATA_OPTION );
     }
 
     @Override
@@ -106,7 +110,7 @@ public class ExperimentalDesignWriterCLI extends ExpressionExperimentManipulatin
         Path dest;
         if ( standardLocation ) {
             ExpressionExperiment finalEe = ee;
-            dest = expressionDataFileService.writeOrLocateDesignFile( ee, isForce() )
+            dest = expressionDataFileService.writeOrLocateDesignFile( ee, useProcessedData, isForce() )
                     .map( LockedPath::closeAndGetPath )
                     .orElseThrow( () -> new IllegalStateException( finalEe + " does not have an experimental design." ) );
         } else {

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
@@ -61,6 +61,8 @@ public interface ExpressionDataFileService {
      */
     boolean deleteDesignFile( ExpressionExperiment ee );
 
+    boolean deleteProcessedDataDesignFile( ExpressionExperiment ee );
+
     /**
      * Delete all files that contain platform annotations for a given experiment.
      * <p>
@@ -329,7 +331,7 @@ public interface ExpressionDataFileService {
      *
      * @see ubic.gemma.core.datastructure.matrix.io.ExperimentalDesignWriter
      */
-    void writeDesignMatrix( ExpressionExperiment ee, Writer writer, boolean autoFlush ) throws IOException;
+    void writeDesignMatrix( ExpressionExperiment ee, boolean useProcessedData, Writer writer, boolean autoFlush ) throws IOException;
 
     /**
      * Write or located the coexpression data file for a given experiment
@@ -372,14 +374,17 @@ public interface ExpressionDataFileService {
      * The file will be regenerated even if one already exists if the forceWrite parameter is true, or if there was
      * a recent change (more recent than the last modified date of the existing file) to any of the experiments platforms.
      *
-     * @param ee         the experiment
-     * @param forceWrite force re-write even if file already exists and is up to date
+     * @param ee                           the experiment
+     * @param useProcessedQuantitationType if true, produce the design for the assays of the processed data instead of
+     *                                     the assays of the experiment. These two are usually the same, but they will
+     *                                     differ if there is a sub-sample structure (i.e. single-cell data).
+     * @param forceWrite                   force re-write even if file already exists and is up to date
      * @return a file or empty if the experiment does not have a design
-     * @see #writeDesignMatrix(ExpressionExperiment, Writer, boolean)
+     * @see #writeDesignMatrix(ExpressionExperiment, boolean, Writer, boolean)
      */
-    Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean forceWrite ) throws IOException;
+    Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean useProcessedQuantitationType, boolean forceWrite ) throws IOException;
 
-    Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean forceWrite, long timeout, TimeUnit timeUnit ) throws TimeoutException, IOException, InterruptedException;
+    Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean useProcessedQuantitationType, boolean forceWrite, long timeout, TimeUnit timeUnit ) throws TimeoutException, IOException, InterruptedException;
 
     /**
      * @see #writeOrLocateProcessedDataFile(ExpressionExperiment, boolean, boolean)

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -144,7 +144,12 @@ public class ExpressionDataFileServiceImpl implements ExpressionDataFileService 
 
     @Override
     public boolean deleteDesignFile( ExpressionExperiment ee ) {
-        return this.deleteAndLog( dataDir.resolve( getDesignFileName( ee ) ) );
+        return this.deleteAndLog( dataDir.resolve( getDesignFileName( ee, false ) ) );
+    }
+
+    @Override
+    public boolean deleteProcessedDataDesignFile( ExpressionExperiment ee ) {
+        return this.deleteAndLog( dataDir.resolve( getDesignFileName( ee, true ) ) );
     }
 
     @Override
@@ -207,6 +212,7 @@ public class ExpressionDataFileServiceImpl implements ExpressionDataFileService 
             } catch ( IOException e ) {
                 log.error( "Failed to delete: " + getDataFileInternal( ee, false, type ), e );
             }
+            deleteProcessedDataDesignFile( ee );
         }
         return deleted;
     }
@@ -706,12 +712,27 @@ public class ExpressionDataFileServiceImpl implements ExpressionDataFileService 
     }
 
     @Override
-    public void writeDesignMatrix( ExpressionExperiment ee, Writer writer, boolean autoFlush ) throws IOException {
+    public void writeDesignMatrix( ExpressionExperiment ee, boolean useProcessedData, Writer writer, boolean autoFlush ) throws IOException {
         ee = expressionExperimentService.thawLite( ee );
         if ( ee.getExperimentalDesign() == null || ee.getExperimentalDesign().getExperimentalFactors().isEmpty() ) {
             throw new IllegalStateException( "No experimental design for " + ee );
         }
-        new ExperimentalDesignWriter( entityUrlBuilder, buildInfo, autoFlush ).write( ee, writer );
+        ExperimentalDesignWriter edWriter = new ExperimentalDesignWriter( entityUrlBuilder, buildInfo, autoFlush );
+        if ( useProcessedData ) {
+            ExpressionExperiment finalEe = ee;
+            QuantitationType processedQuantitationType = expressionExperimentService.getProcessedQuantitationType( ee )
+                    .orElseThrow( () -> new IllegalStateException( "No processed data for " + finalEe + "." ) );
+            Collection<BioAssayDimension> processedDimension = expressionExperimentService.getProcessedBioAssayDimensionsWithAssays( ee );
+            if ( processedDimension.isEmpty() ) {
+                throw new IllegalStateException( "No processed data for " + ee + "." );
+            } else if ( processedDimension.size() > 1 ) {
+                throw new IllegalStateException( "Multiple processed bioassay dimensions found for " + ee + "." );
+            } else {
+                edWriter.write( ee, processedQuantitationType, ProcessedExpressionDataVector.class, processedDimension.iterator().next().getBioAssays(), true, writer );
+            }
+        } else {
+            edWriter.write( ee, writer );
+        }
     }
 
     @Override
@@ -863,19 +884,19 @@ public class ExpressionDataFileServiceImpl implements ExpressionDataFileService 
     }
 
     @Override
-    public Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean forceWrite ) throws IOException {
+    public Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean useProcessedData, boolean forceWrite ) throws IOException {
         ee = expressionExperimentService.thawLite( ee );
         if ( ee.getExperimentalDesign() == null || ee.getExperimentalDesign().getExperimentalFactors().isEmpty() ) {
             return Optional.empty();
         }
-        try ( LockedPath f = this.getOutputFile( getDesignFileName( ee ), false ) ) {
+        try ( LockedPath f = this.getOutputFile( getDesignFileName( ee, useProcessedData ), false ) ) {
             Date check = ee.getCurationDetails().getLastUpdated();
             if ( this.checkFileOkToReturn( forceWrite, f.getPath(), check ) ) {
                 return Optional.of( f.steal() );
             }
             try ( LockedPath lockedPath = f.toExclusive();
                     Writer writer = openCompressedFile( lockedPath.getPath() ) ) {
-                writeDesignMatrix( ee, writer, false );
+                writeDesignMatrix( ee, useProcessedData, writer, false );
                 return Optional.of( lockedPath.toShared() );
             } catch ( Exception e ) {
                 Files.deleteIfExists( f.getPath() );
@@ -885,19 +906,19 @@ public class ExpressionDataFileServiceImpl implements ExpressionDataFileService 
     }
 
     @Override
-    public Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean forceWrite, long timeout, TimeUnit timeUnit ) throws TimeoutException, IOException, InterruptedException {
+    public Optional<LockedPath> writeOrLocateDesignFile( ExpressionExperiment ee, boolean useProcessedData, boolean forceWrite, long timeout, TimeUnit timeUnit ) throws TimeoutException, IOException, InterruptedException {
         ee = expressionExperimentService.thawLite( ee );
         if ( ee.getExperimentalDesign() == null || ee.getExperimentalDesign().getExperimentalFactors().isEmpty() ) {
             return Optional.empty();
         }
-        try ( LockedPath f = this.getOutputFile( getDesignFileName( ee ), false, timeout, timeUnit ) ) {
+        try ( LockedPath f = this.getOutputFile( getDesignFileName( ee, useProcessedData ), false, timeout, timeUnit ) ) {
             Date check = ee.getCurationDetails().getLastUpdated();
             if ( this.checkFileOkToReturn( forceWrite, f.getPath(), check ) ) {
                 return Optional.of( f.steal() );
             }
             try ( LockedPath lockedPath = f.toExclusive( timeout, timeUnit );
                     Writer writer = openCompressedFile( lockedPath.getPath() ) ) {
-                writeDesignMatrix( ee, writer, false );
+                writeDesignMatrix( ee, useProcessedData, writer, false );
                 return Optional.of( lockedPath.toShared() );
             } catch ( Exception e ) {
                 Files.deleteIfExists( f.getPath() );

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileUtils.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 /**
  * Generate filenames for various types of data files.
+ *
  * @author poirigui
  */
 public class ExpressionDataFileUtils {
@@ -72,8 +73,8 @@ public class ExpressionDataFileUtils {
         return formatExpressionExperimentFilename( ee ) + "_coExp" + TABULAR_BULK_DATA_FILE_SUFFIX;
     }
 
-    public static String getDesignFileName( ExpressionExperiment ee ) {
-        return formatExpressionExperimentFilename( ee ) + "_expdesign" + TABULAR_BULK_DATA_FILE_SUFFIX;
+    public static String getDesignFileName( ExpressionExperiment ee, boolean useProcessedData ) {
+        return formatExpressionExperimentFilename( ee ) + "_expdesign" + ( useProcessedData ? "_processed" : "" ) + TABULAR_BULK_DATA_FILE_SUFFIX;
     }
 
     public static String getDiffExArchiveFileName( DifferentialExpressionAnalysis diff ) {

--- a/gemma-rest/src/main/resources/openapi-configuration.yaml
+++ b/gemma-rest/src/main/resources/openapi-configuration.yaml
@@ -4,7 +4,7 @@ defaultResponseCode: 200
 openAPI:
   info:
     title: Gemma RESTful API
-    version: 2.9.3
+    version: 2.9.4
     description: |
       This website documents the usage of the [Gemma RESTful API](https://gemma.msl.ubc.ca/rest/v2/). Here you can find
       example script usage of the API, as well as graphical interface for each endpoint, with description of its

--- a/gemma-rest/src/main/resources/restapidocs/CHANGELOG.md
+++ b/gemma-rest/src/main/resources/restapidocs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Updates
 
+### Update 2.9.4
+
+Add a `useProcessedQuantitationType` option to the `getDatasetDesign` endpoint to generate a design matrix that is
+tailored to the processed data vectors.
+
 ### Update 2.9.3
 
 Add various single-cell metrics to the `BioAssayValueObject` model.

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentDataFetchController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentDataFetchController.java
@@ -310,7 +310,7 @@ public class ExpressionExperimentDataFetchController {
                 /* the design file */
                 if ( eedId != null ) {
                     ExpressionExperiment finalEe = ee;
-                    try ( LockedPath lockedPath = expressionDataFileService.writeOrLocateDesignFile( ee, false )
+                    try ( LockedPath lockedPath = expressionDataFileService.writeOrLocateDesignFile( ee, false, false )
                             .orElseThrow( () -> new IllegalStateException( finalEe + " does not have an experimental design" ) ) ) {
                         f = lockedPath.getPath();
                     } catch ( IOException e ) {

--- a/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentQCController.java
+++ b/gemma-web/src/main/java/ubic/gemma/web/controller/expression/experiment/ExpressionExperimentQCController.java
@@ -222,10 +222,10 @@ public class ExpressionExperimentQCController {
         StringWriter writer = new StringWriter();
         appendBaseHeader( ee, "Outliers removed", entityUrlBuilder.fromHostUrl().entity( ee ).toUriString(), buildInfo, new Date(), writer );
         new ExperimentalDesignWriter( entityUrlBuilder, buildInfo, false )
-                .write( ee, bioAssays, false, writer );
+                .write( ee, null, null, bioAssays, false, writer );
 
         TextView tv = new TextView( "tab-separated-values" );
-        tv.setContentDisposition( "attachment; filename=\"" + FilenameUtils.removeExtension( getDesignFileName( ee ) ) + "\"" );
+        tv.setContentDisposition( "attachment; filename=\"" + FilenameUtils.removeExtension( getDesignFileName( ee, false ) ) + "\"" );
         return new ModelAndView( tv ).addObject( TextView.TEXT_PARAM, writer.toString() );
     }
 
@@ -260,10 +260,10 @@ public class ExpressionExperimentQCController {
         StringWriter writer = new StringWriter();
         appendBaseHeader( ee, "Sample outlier", entityUrlBuilder.fromHostUrl().entity( ee ).toUriString(), buildInfo, new Date(), writer );
         new ExperimentalDesignWriter( entityUrlBuilder, buildInfo, false )
-                .write( ee, bioAssays, false, writer );
+                .write( ee, null, null, bioAssays, false, writer );
 
         TextView tv = new TextView( "tab-separated-values" );
-        tv.setContentDisposition( "attachment; filename=\"" + FilenameUtils.removeExtension( getDesignFileName( ee ) ) + "\"" );
+        tv.setContentDisposition( "attachment; filename=\"" + FilenameUtils.removeExtension( getDesignFileName( ee, false ) ) + "\"" );
         return new ModelAndView( tv )
                 .addObject( TextView.TEXT_PARAM, writer.toString() );
     }

--- a/gemma-web/src/main/webapp/scripts/api/entities/analysis/differentialExpression/DifferentialExpressionAnalysesSummaryTree.js
+++ b/gemma-web/src/main/webapp/scripts/api/entities/analysis/differentialExpression/DifferentialExpressionAnalysesSummaryTree.js
@@ -329,18 +329,18 @@ Gemma.DifferentialExpressionAnalysesSummaryTree = Ext
             getExpressionNumbers: function (resultSet, nodeId, showThreshold) {
                 /* Show how many elements are differentially expressed; */
 
-                var numbers = resultSet.numberOfDiffExpressedProbes + ' of ' + this.totalProbes
+                var numbers = formatNumber(resultSet.numberOfDiffExpressedProbes) + ' of ' + formatNumber(this.totalProbes)
                     + ' elements were differentially expressed<br>';
 
                 // if (resultSet.upregulatedCount != 0) {
-                numbers += resultSet.upregulatedCount + "&nbsp;Up";
+                numbers += formatNumber(resultSet.upregulatedCount) + "&nbsp;Up";
                 // }
 
                 // if (resultSet.downregulatedCount != 0) {
-                numbers += ';&nbsp;' + resultSet.downregulatedCount + "&nbsp;Down";
+                numbers += ';&nbsp;' + formatNumber(resultSet.downregulatedCount) + "&nbsp;Down";
                 // }
                 if (showThreshold) {
-                    numbers += '. <br>Threshold value = ' + resultSet.threshold;
+                    numbers += '. <br>Threshold value = ' + formatNumber(resultSet.threshold);
                     numbers += (resultSet.qValue) ? (', qvalue = ' + resultSet.qValue) : '';
                 }
 

--- a/gemma-web/src/main/webapp/scripts/api/entities/experiment/ExpressionExperimentDetails.js
+++ b/gemma-web/src/main/webapp/scripts/api/entities/experiment/ExpressionExperimentDetails.js
@@ -822,18 +822,18 @@ Gemma.ExpressionExperimentDetails = Ext
                                     {
                                         fieldLabel: 'Profiles',
                                         // id: 'processedExpressionVectorCount-region',
-                                        html: '<div id="downloads"> '
-                                        + this.renderProcessedExpressionVectorCount(e)
-                                        + '&nbsp;&nbsp;'
-                                        + '<i>Downloads:</i> &nbsp;&nbsp; <span class="link"  ext:qtip="Download the filtered tab-delimited data" onClick="Gemma.ExpressionExperimentDataFetch.fetchData(true,'
+                                        html: '<div id="downloads" class="flex g-3"> '
+                                        + '<span>' + this.renderProcessedExpressionVectorCount( e  ) + '</span>'
+                                        + '<i>Downloads:</i> <span class="link" ext:qtip="Download the filtered tab-delimited data." onClick="Gemma.ExpressionExperimentDataFetch.fetchData(true,'
                                         + e.id
-                                        + ', \'text\', null, null)">Filtered</span> &nbsp;&nbsp;'
-                                        + '<span class="link" ext:qtip="Download the unfiltered tab-delimited data" onClick="Gemma.ExpressionExperimentDataFetch.fetchData(false,'
+                                        + ', \'text\', null, null)">Data (filtered)</span>'
+                                        + '<span class="link" ext:qtip="Download the unfiltered tab-delimited data." onClick="Gemma.ExpressionExperimentDataFetch.fetchData(false,'
                                         + e.id
-                                        + ', \'text\', null, null)">Unfiltered</span> &nbsp;&nbsp;'
+                                        + ', \'text\', null, null)">Data (unfiltered)</span>'
+                                        + '<a href="' + Gemma.CONTEXT_PATH + '/rest/v2/datasets/' + e.id + '/design?useProcessedQuantitationType=true&download=true" ext:qtip="Download the tab-delimited experimental design.">Experimental Design</a>'
                                         + '<i class="qtp fa fa-question-circle fa-fw"></i>'
                                         + '</div>',
-                                        width: 400,
+                                        width: 600,
                                         listeners: {
                                             'afterrender': function (c) {
                                                 window.jQuery('#downloads').find('i')

--- a/gemma-web/src/main/webapp/scripts/api/userHelpMessages.js
+++ b/gemma-web/src/main/webapp/scripts/api/userHelpMessages.js
@@ -440,8 +440,8 @@ Gemma.HelpText.WidgetDefaults = {
 		statusMultiplePreferredQuantitationTypes: 'This experiment has multiple \'preferred\' quantitation types. '
 			+ 'This isn\'t necessarily a problem but is suspicious.',
 		statusMultipleTechnologyTypes: 'This experiment seems to mix platforms with different technology types.',
-		profileDownloadTT: 'Tab-delimited data file for this experiment. '
-			+ 'The filtered version corresponds to what is used in most Gemma analyses, removing some probes/elements. Unfiltered includes all elements',
+		profileDownloadTT: 'Tab-delimited data and experimental design files for this experiment. '
+			+ 'The filtered version corresponds to what is used in most Gemma analyses, removing some probes/elements. Unfiltered includes all elements.',
 		dataReprocessed: "Reprocessed from raw data by Gemma.",
 		dataExternal: "Processed data are from external source, not reprocessed from raw by Gemma",
 		noBatchInfo: "Information on sample batching was not available",


### PR DESCRIPTION
The current experimental design file is solely based on the assay of the experiment. 

For single-cell datasets, the assays of the processed data differ as we create a subset of sub-assay structure.

This is providing in multiple places an option to get the design tailored to the processed data vectors.