### PR TITLE
Move build information into the manifest

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
         stage('Run quick unit tests') {
             steps {
                 setBuildStatus "Tests", "Tests for build #${env.BUILD_NUMBER} have started...", 'PENDING'
-                sh 'mvn -B test --fail-at-end -DexcludedGroups=SlowTest -DskipVersionFile'
+                sh 'mvn -B test --fail-at-end -DexcludedGroups=SlowTest'
             }
             post {
                 always {
@@ -117,7 +117,7 @@ pipeline {
         stage('Package') {
             steps {
                 setBuildStatus "Package", "Package for build #${env.BUILD_NUMBER} have started...", 'PENDING'
-                sh 'mvn -B package -DskipTests -DskipVersionFile'
+                sh 'mvn -B package -DskipTests'
             }
             post {
                 success {
@@ -158,7 +158,7 @@ pipeline {
                     steps {
                         lock('gemma-slow-tests') {
                             setBuildStatus "Slow tests", "Slow tests #${env.BUILD_NUMBER} have started...", 'PENDING'
-                            sh 'mvn -B test --fail-at-end -Dgroups=SlowTest -DskipWebpack -DskipVersionFile'
+                            sh 'mvn -B test --fail-at-end -Dgroups=SlowTest -DskipWebpack'
                         }
                     }
                     post {
@@ -187,7 +187,7 @@ pipeline {
                     steps {
                         setBuildStatus "Integration tests", "Integration tests #${env.BUILD_NUMBER} have started...", 'PENDING'
                         lock('database/gemdtest') {
-                            sh 'mvn -B verify --fail-at-end -DskipUnitTests -DskipJavadoc -DskipWebpack -DskipVersionFile'
+                            sh 'mvn -B verify --fail-at-end -DskipUnitTests -DskipJavadoc -DskipWebpack'
                         }
                     }
                     post {
@@ -220,7 +220,7 @@ pipeline {
                         lock('gemma-sonarqube-analysis') {
                             setBuildStatus "SonarQube Analysis", "SonarQube analysis for build #${env.BUILD_NUMBER} has started...", 'PENDING'
                             withSonarQubeEnv('UBC SonarQube') {
-                                sh "mvn package -DskipTests -DskipJavadoc -DskipWebpack -DskipVersionFile dependency-check:check org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=mslg -Dsonar.projectName='MSL - Gemma'"
+                                sh "mvn package -DskipTests -DskipJavadoc -DskipWebpack dependency-check:check org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=mslg -Dsonar.projectName='MSL - Gemma'"
                             }
                         }
                     }
@@ -247,7 +247,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh 'mvn -B deploy -DskipTests -DskipJavadoc -DskipWebpack -DskipVersionFile'
+                        sh 'mvn -B deploy -DskipTests -DskipJavadoc -DskipWebpack'
                     }
                 }
                 stage('Deploy Maven website') {
@@ -261,7 +261,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh 'mvn -B site-deploy -DskipWebpack -DskipVersionFile'
+                        sh 'mvn -B site-deploy -DskipWebpack'
                         script {
                             if (dataDir != null) {
                                 sh "ln -Tsf ${params.MAVEN_SITES_DIR}/gemma/gemma-${gemmaVersion} ${dataDir}/gemma-devsite"

--- a/gemma-cli/src/main/java/ubic/gemma/cli/main/GemmaCLI.java
+++ b/gemma-cli/src/main/java/ubic/gemma/cli/main/GemmaCLI.java
@@ -143,7 +143,7 @@ public class GemmaCLI {
         }
 
         if ( commandLine.hasOption( VERSION_OPTION ) ) {
-            BuildInfo buildInfo = BuildInfo.fromClasspath();
+            BuildInfo buildInfo = BuildInfo.fromManifest();
             System.out.printf( "Gemma %s%n", buildInfo );
             System.exit( 0 );
             return;

--- a/gemma-core/pom.xml
+++ b/gemma-core/pom.xml
@@ -12,27 +12,20 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.2.0</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.2</version>
                 <executions>
                     <execution>
-                        <id>version-file</id>
-                        <phase>generate-resources</phase>
+                        <id>generate-build-info</id>
+                        <phase>initialize</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>revision</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipVersionFile}</skip>
-                            <target>
-                                <exec executable="git" outputproperty="gemma.hash" logError="true">
-                                    <arg value="rev-parse"/>
-                                    <arg value="HEAD"/>
-                                </exec>
-                                <echo append="false" file="${project.build.directory}/classes/ubic/gemma/version.properties">
-                                    gemma.version=${project.version}${line.separator}gemma.build.timestamp=${maven.build.timestamp}${line.separator}gemma.build.gitHash=${gemma.hash}
-                                </echo>
-                            </target>
+                            <offline>true</offline>
+                            <useNativeGit>true</useNativeGit>
+                            <includeOnlyProperties>git.commit.id</includeOnlyProperties>
                         </configuration>
                     </execution>
                 </executions>
@@ -42,6 +35,23 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>default-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Gemma-Version>${project.version}</Gemma-Version>
+                                    <Gemma-Build-Timestamp>${maven.build.timestamp}</Gemma-Build-Timestamp>
+                                    <!--suppress MavenModelInspection -->
+                                    <Gemma-Build-GitHash>${git.commit.id}</Gemma-Build-GitHash>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-test-jar</id>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>

--- a/gemma-core/src/main/java/ubic/gemma/core/config/SettingsConfig.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/config/SettingsConfig.java
@@ -14,6 +14,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.format.support.DefaultFormattingConversionService;
+import ubic.gemma.core.util.ManifestUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -169,16 +170,8 @@ public class SettingsConfig {
             result.addLast( new ResourcePropertySource( new ClassPathResource( loc ) ) );
         }
 
-        ClassPathResource versionResource = new ClassPathResource( "ubic/gemma/version.properties" );
-        if ( versionResource.exists() ) {
-            result.addLast( new ResourcePropertySource( versionResource ) );
-        } else {
-            String mvnPath = System.getenv( "MAVEN" );
-            if ( mvnPath == null ) {
-                mvnPath = "mvn";
-            }
-            log.warn( "The ubic/gemma/version.properties resource was not found; run `" + mvnPath + " generate-resources -pl gemma-core` to generate it." );
-        }
+        // include build information from the manifest
+        result.addLast( new PropertiesPropertySource( "manifest", ManifestUtils.readGemmaPropertiesFromManifest() ) );
 
         cachedSettingsPropertySources = result;
 

--- a/gemma-core/src/main/java/ubic/gemma/core/context/SpringContextUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/context/SpringContextUtils.java
@@ -136,7 +136,7 @@ public class SpringContextUtils {
                 ( ( AbstractXmlApplicationContext ) context ).setValidating( false );
             }
         }
-        BuildInfo buildInfo = BuildInfo.fromClasspath();
+        BuildInfo buildInfo = BuildInfo.fromManifest();
         SpringContextUtils.log.info( String.format( "Loading Gemma %s%s, hold on!",
                 buildInfo,
                 context.getEnvironment().getActiveProfiles().length > 0 ?

--- a/gemma-core/src/main/java/ubic/gemma/core/util/BuildInfo.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/BuildInfo.java
@@ -3,14 +3,12 @@ package ubic.gemma.core.util;
 import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import ubic.gemma.core.loader.util.hdf5.H5Utils;
 
 import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -39,15 +37,14 @@ public class BuildInfo implements InitializingBean {
     }
 
     /**
-     * Retrieve build information directly from the classpath.
+     * Retrieve build information directly from the manifest of gemma-core.
      */
-    public static BuildInfo fromClasspath() {
-        Properties props = new Properties();
-        try ( InputStream reader = new ClassPathResource( "/ubic/gemma/version.properties" ).getInputStream() ) {
-            props.load( reader );
-            return new BuildInfo( props.getProperty( "gemma.version" ),
-                    props.getProperty( "gemma.build.timestamp" ),
-                    props.getProperty( "gemma.build.gitHash" ) );
+    public static BuildInfo fromManifest() {
+        try {
+            Properties buildProps = ManifestUtils.readGemmaPropertiesFromManifest();
+            return new BuildInfo( buildProps.getProperty( "gemma.version" ),
+                    buildProps.getProperty( "gemma.build.timestamp" ),
+                    buildProps.getProperty( "gemma.build.gitHash" ) );
         } catch ( FileNotFoundException e ) {
             return new BuildInfo();
         } catch ( IOException e ) {

--- a/gemma-core/src/main/java/ubic/gemma/core/util/ManifestUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/util/ManifestUtils.java
@@ -1,0 +1,49 @@
+package ubic.gemma.core.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+public class ManifestUtils {
+
+    private static final Map<String, String> gemmaManifestProperties = new HashMap<>();
+
+    static {
+        gemmaManifestProperties.put( "Gemma-Version", "gemma.version" );
+        gemmaManifestProperties.put( "Gemma-Build-Timestamp", "gemma.build.timestamp" );
+        gemmaManifestProperties.put( "Gemma-Build-GitHash", "gemma.build.gitHash" );
+    }
+
+    private static Properties cachedProps = null;
+
+    /**
+     * Read all the Gemma-related properties from the manifest files.
+     */
+    public static synchronized Properties readGemmaPropertiesFromManifest() throws IOException {
+        if ( cachedProps != null ) {
+            return cachedProps;
+        }
+        Properties gemmaProps = new Properties();
+        Enumeration<URL> urls = ManifestUtils.class.getClassLoader().getResources( JarFile.MANIFEST_NAME );
+        while ( urls.hasMoreElements() ) {
+            URL url = urls.nextElement();
+            try ( InputStream is = url.openStream() ) {
+                Manifest manifest = new Manifest( is );
+                for ( Map.Entry<String, String> e : gemmaManifestProperties.entrySet() ) {
+                    String val = manifest.getMainAttributes().getValue( e.getKey() );
+                    if ( val != null ) {
+                        gemmaProps.setProperty( e.getValue(), val );
+                    }
+                }
+            }
+        }
+        cachedProps = gemmaProps;
+        return gemmaProps;
+    }
+}

--- a/gemma-core/src/test/java/ubic/gemma/core/config/SettingsConfigTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/config/SettingsConfigTest.java
@@ -6,12 +6,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySources;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import ubic.gemma.core.context.EnvironmentProfiles;
 import ubic.gemma.core.context.TestComponent;
 import ubic.gemma.core.util.test.BaseTest;
@@ -42,7 +42,11 @@ public class SettingsConfigTest extends BaseTest {
             MutablePropertySources result = new MutablePropertySources();
             result.addLast( new ResourcePropertySource( new ClassPathResource( "default.properties" ) ) );
             result.addLast( new ResourcePropertySource( new ClassPathResource( "project.properties" ) ) );
-            result.addLast( new ResourcePropertySource( new ClassPathResource( "ubic/gemma/version.properties" ) ) );
+            Properties buildProps = new Properties();
+            buildProps.setProperty( "gemma.version", "1.32.0-SNAPSHOT" );
+            buildProps.setProperty( "gemma.build.timestamp", "2026-01-21T20:47:30Z" );
+            buildProps.setProperty( "gemma.build.gitHash", "07f91f2083d625f05d367a7a8e6100bfbf83fea8" );
+            result.addLast( new PropertiesPropertySource( "manifest", buildProps ) );
             return result;
         }
     }

--- a/gemma-core/src/test/java/ubic/gemma/core/datastructure/matrix/io/TabularMatrixWriterTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/datastructure/matrix/io/TabularMatrixWriterTest.java
@@ -25,7 +25,7 @@ public class TabularMatrixWriterTest {
     @Before
     public void setUp() {
         EntityUrlBuilder entityUrlBuilder = new EntityUrlBuilder( "https://gemma.msl.ubc.ca" );
-        writer = new TabularMatrixWriter( entityUrlBuilder, BuildInfo.fromClasspath() );
+        writer = new TabularMatrixWriter( entityUrlBuilder, BuildInfo.fromManifest() );
     }
 
     @Test

--- a/gemma-core/src/test/java/ubic/gemma/core/util/BuildInfoTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/util/BuildInfoTest.java
@@ -1,5 +1,6 @@
 package ubic.gemma.core.util;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -55,10 +56,9 @@ public class BuildInfoTest extends BaseTest {
     }
 
     @Test
-    public void testFromClasspath() {
-        assumeTrue( "Make sure that Gemma is build with Maven so that version.properties is generated.",
-                getClass().getResource( "/ubic/gemma/version.properties" ) != null );
-        BuildInfo buildInfo = BuildInfo.fromClasspath();
+    @Ignore("The manifest is not available during the test phase.")
+    public void testFromManifest() {
+        BuildInfo buildInfo = BuildInfo.fromManifest();
         assertNotNull( buildInfo.getVersion() );
         assertNotNull( buildInfo.getTimestamp() );
         assertNotNull( buildInfo.getGitHash() );

--- a/pom.xml
+++ b/pom.xml
@@ -784,7 +784,6 @@
 		<profile>
 			<id>fast</id>
 			<properties>
-				<skipVersionFile>true</skipVersionFile>
 				<skipJavadoc>true</skipJavadoc>
 				<skipTests>true</skipTests>
 				<skipWebpack>true</skipWebpack>
@@ -888,7 +887,6 @@
 		<assertj.version>3.27.6</assertj.version>
 		<!-- this ensures that -DexcludedGroups works properly -->
 		<excludedGroups/>
-		<skipVersionFile>false</skipVersionFile>
 		<skipJavadoc>false</skipJavadoc>
 		<skipWebpack>false</skipWebpack>
 		<maven.javadoc.skip>${skipJavadoc}</maven.javadoc.skip>


### PR DESCRIPTION
This has the main advantage of not altering the JAR (from Maven's perspective) when re-building, packaging is much faster when gemma-core is not modified.

It's also a better place to put version information in general.