### PR TITLE
fixes gemma not refreshing on logout

### DIFF
--- a/gemma-web/src/main/webapp/scripts/api/security/AjaxLogin.js
+++ b/gemma-web/src/main/webapp/scripts/api/security/AjaxLogin.js
@@ -58,7 +58,7 @@ Gemma.AjaxLogin.logoutFn = function() {
           * this is the default behaviour unless otherwise specified in the page's jsp
           */
          var reloadOnLogout = Ext.getDom( 'reloadOnLogout' );
-         if ( reloadOnLogout == undefined || reloadOnLogout.getValue() === "true" ) {
+         if ( reloadOnLogout == undefined || reloadOnLogout.value === "true" ) {
             Ext.getBody().mask( "Logging you out" );
             window.location.reload();
          }


### PR DESCRIPTION
getValue isn't defined so we were failing to refresh the page when a user logged out