### PR TITLE
compat(preboarded): stop mapping the column phase2 renames to SOURCE_METADATA

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/PreboardedExperiment.java
+++ b/gemma-core/src/main/java/ubic/gemma/model/expression/experiment/PreboardedExperiment.java
@@ -37,7 +37,17 @@ public class PreboardedExperiment extends Investigation {
     private String source;
     /**
      * Free-form JSON payload of identifying metadata the agent harvested before
-     * loading (title, summary, submitter, pubmed id, etc.). Stored as LONGTEXT.
+     * loading (title, summary, submitter, pubmed id, etc.).
+     * <p>
+     * <b>Not persisted on this branch.</b> phase2 renames the backing column from
+     * {@code PREBOARDED_IDENTIFYING_METADATA} to {@code SOURCE_METADATA}, and because
+     * {@code INVESTIGATION} is single-table inheritance, mapping it here would put the
+     * old name into the SQL for every polymorphic {@code Investigation} query and break
+     * this build against the shared database the moment that migration runs. Nothing in
+     * 1.32.x reads the value, so it is left unmapped and the two can deploy in either
+     * order. See the comment in {@code Investigation.hbm.xml}; the accessors are kept
+     * only so existing call sites still compile, and they will always read {@code null}
+     * on a reloaded instance.
      */
     private String identifyingMetadata;
 

--- a/gemma-core/src/main/resources/ubic/gemma/model/analysis/Investigation.hbm.xml
+++ b/gemma-core/src/main/resources/ubic/gemma/model/analysis/Investigation.hbm.xml
@@ -208,10 +208,27 @@
 				<column name="PREBOARDED_SOURCE" not-null="false" unique="false"
 						sql-type="VARCHAR(32)"/>
 			</property>
-			<property name="identifyingMetadata" type="org.hibernate.type.MaterializedClobType">
-				<column name="PREBOARDED_IDENTIFYING_METADATA" not-null="false" unique="false"
-						sql-type="LONGTEXT"/>
-			</property>
+			<!-- identifyingMetadata is DELIBERATELY NOT MAPPED here.
+
+			     phase2 renames PREBOARDED_IDENTIFYING_METADATA to SOURCE_METADATA,
+			     because the same upstream payload is wanted for imported experiments
+			     and not only preboarded ones. INVESTIGATION is single-table
+			     inheritance, so a subclass property here puts that column name into
+			     the SQL generated for any polymorphic Investigation query — and the
+			     rename would then break this build against the shared database, with
+			     an unknown-column SQLGrammarException, whether or not any preboarded
+			     row exists. The failure is at mapping resolution, not row read, so an
+			     empty table does not save us.
+
+			     Leaving the property unmapped makes 1.32.x indifferent to the column's
+			     name: the migration and this deployment can happen in either order,
+			     with no window in which one is broken. Nothing in 1.32.x reads the
+			     value — it is a JSON payload only phase2 consumes — so mapping it was
+			     always past "the minimum metadata to avoid the explosion" this compat
+			     port exists to provide.
+
+			     Do not re-add it. If 1.32.x ever needs the payload, map it to
+			     SOURCE_METADATA and sequence the migration before the deploy. -->
 		</subclass>
 	</class>
 </hibernate-mapping>

--- a/gemma-core/src/test/java/ubic/gemma/persistence/service/expression/experiment/PreboardedExperimentMappingTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/persistence/service/expression/experiment/PreboardedExperimentMappingTest.java
@@ -83,6 +83,15 @@ public class PreboardedExperimentMappingTest extends BaseDatabaseTest {
         PreboardedExperiment rt = ( PreboardedExperiment ) reloaded;
         assertThat( rt.getAccession() ).isEqualTo( "GSE12345" );
         assertThat( rt.getSource() ).isEqualTo( "GEO" );
-        assertThat( rt.getIdentifyingMetadata() ).isEqualTo( "{\"title\":\"test\",\"pubmed\":\"1\"}" );
+        // identifyingMetadata is deliberately unmapped on this branch, so it must NOT
+        // survive the round trip. Mapping it would name PREBOARDED_IDENTIFYING_METADATA
+        // in every polymorphic Investigation query, and phase2 renames that column to
+        // SOURCE_METADATA in the database both versions share — this build would then
+        // fail on an unknown column regardless of whether any preboarded row exists.
+        // If this assertion starts failing, someone re-added the mapping: read the
+        // comment in Investigation.hbm.xml before "fixing" it.
+        assertThat( rt.getIdentifyingMetadata() )
+                .as( "identifyingMetadata must not be persisted; the column is renamed by phase2" )
+                .isNull();
     }
 }


### PR DESCRIPTION
phase2 renames `INVESTIGATION.PREBOARDED_IDENTIFYING_METADATA` to `SOURCE_METADATA` (mysql `V24` / h2 `V25`, on `phase2-acl-migrate`), generalizing the payload so it can carry upstream metadata for imported experiments and not only preboarded ones.

`INVESTIGATION` is single-table inheritance, so the `identifyingMetadata` property in `Investigation.hbm.xml` puts the old column name into the SQL generated for **any polymorphic `Investigation` query**. Once that migration runs against the database both versions share, this build fails with an unknown-column `SQLGrammarException`. The failure is at mapping resolution, not row read, so the table currently holding zero preboarded rows does not save us.

## Why unmap rather than repoint

Repointing the mapping at `SOURCE_METADATA` would couple the two changes: this build would be broken until the migration ran, and the currently deployed build broken the moment it did. There is no ordering that avoids a window.

Unmapped, 1.32.x is indifferent to what the column is called, and the migration and any redeploy can happen in either order.

Nothing in 1.32.x reads the value — it is a JSON payload only phase2 consumes; the only reference was the round-trip assertion in the compat test. Mapping it was always beyond the "minimum metadata to avoid the explosion" that #1659 set out to provide.

## What is unchanged

The `<subclass>` declaration, `accession` and `source` all stay, so the `WrongClassException` protection #1659 added still works — a phase2-written preboarded row still materializes correctly under a polymorphic load. The Java accessors are kept so existing call sites compile; they now always read `null` on a reloaded instance, which is documented on the field.

## Test

`PreboardedExperimentMappingTest.preboardedRoundTripsThroughHibernate` still asserts the polymorphic load and the `accession` / `source` round trip. Its `identifyingMetadata` assertion is inverted: it now asserts the value does **not** survive persistence, so re-adding the mapping fails the test and the message points at the explanation in `Investigation.hbm.xml` rather than inviting someone to "fix" it.

Verified green against gemdtest. The other failures in a full run on that branch are the pre-existing environmental set on this machine (POSIX file locks, missing `cellranger` binary, h5ad transform) and are unrelated.

## Note on sequencing

This does not need to land before the migration, which is the point of it. But it should land before anyone runs `V24` against a shared `gemd`, since that is the moment an unpatched 1.32.x starts throwing.