### PR TITLE
Read a term's description where the ontology actually wrote it (CLO's cell-line disease)

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyServiceImpl.java
@@ -573,14 +573,22 @@ public class OntologyServiceImpl implements OntologyService, InitializingBean {
     @Override
     public String getDefinition( String uri, long timeout, TimeUnit timeUnit ) throws TimeoutException {
         OntologyTerm ot = this.getTerm( uri, timeout, timeUnit );
-        if ( ot != null ) {
-            // FIXME: not clear this will work with all ontologies. UBERON, HP, MP, MONDO does it this way.
-            AnnotationProperty annot = ot.getAnnotation( "http://purl.obolibrary.org/obo/IAO_0000115" );
-            if ( annot != null ) {
-                return annot.getContents();
-            }
+        if ( ot == null ) {
+            return null;
         }
-        return null;
+        // UBERON, HP, MP and MONDO all use the OBO definition property.
+        AnnotationProperty annot = ot.getAnnotation( OntologyUtils.DEFINITION_URI );
+        if ( annot != null && StringUtils.isNotBlank( annot.getContents() ) ) {
+            return annot.getContents();
+        }
+        // CLO does not. It writes what it knows about a cell line into rdfs:comment instead —
+        // CLO_0008127 (NCI-H929) carries "disease: plasmacytoma;   myeloma" and no OBO definition at all —
+        // so reading only the OBO property returned null for the very terms whose description is the point.
+        // That disease is a property of the line, knowable without anyone curating it onto an experiment,
+        // and it was sitting in an ontology already loaded here. OLS resolves the same fallback, and reports
+        // the result as the term's definition, so this agrees with what a caller sees there.
+        String comment = ot.getComment();
+        return StringUtils.isNotBlank( comment ) ? comment : null;
     }
 
     @Override

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyUtils.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/OntologyUtils.java
@@ -38,6 +38,15 @@ public class OntologyUtils {
     public static final String BASE_GEMMA_ONTOLOGY_URI = "http://gemma.msl.ubc.ca/ont/";
 
     /**
+     * The OBO definition annotation property, which UBERON, HP, MP and MONDO all use.
+     * <p>
+     * Not universal: CLO writes its descriptions into {@code rdfs:comment} instead, which is why
+     * {@link OntologyService#getDefinition(String, long, java.util.concurrent.TimeUnit)} falls back to the
+     * comment rather than treating the absence of this property as the absence of a description.
+     */
+    public static final String DEFINITION_URI = BASE_PURL_URI + "IAO_0000115";
+
+    /**
      * Base URI used by EFO.
      */
     public static final String BASE_EFO_URI = "http://www.ebi.ac.uk/efo/";

--- a/gemma-core/src/main/java/ubic/gemma/core/ontology/lexical/LexicalOntologyTerm.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/ontology/lexical/LexicalOntologyTerm.java
@@ -32,7 +32,7 @@ public class LexicalOntologyTerm extends OntologyTermSimple {
      * same role, so exposing it here means {@code OntologyService.getDefinition} — and therefore the
      * existing /annotations/search enrichment — surfaces it with no special-casing for lexical sources.
      */
-    private static final String DEFINITION_URI = "http://purl.obolibrary.org/obo/IAO_0000115";
+    private static final String DEFINITION_URI = ubic.gemma.core.ontology.OntologyUtils.DEFINITION_URI;
 
     private final LexicalTermMetadata metadata;
 

--- a/gemma-core/src/test/java/ubic/gemma/core/ontology/OntologyServiceTest.java
+++ b/gemma-core/src/test/java/ubic/gemma/core/ontology/OntologyServiceTest.java
@@ -25,6 +25,7 @@ import ubic.gemma.core.context.TestComponent;
 import ubic.gemma.core.ontology.providers.GeneOntologyService;
 import ubic.gemma.core.search.SearchException;
 import ubic.gemma.core.search.SearchService;
+import ubic.gemma.core.ontology.model.AnnotationProperty;
 import ubic.gemma.core.util.test.BaseTest5;
 import ubic.gemma.core.util.test.TestPropertyPlaceholderConfigurer;
 import ubic.gemma.model.common.description.CharacteristicValueObject;
@@ -333,5 +334,63 @@ public class OntologyServiceTest extends BaseTest5 {
         when( obiService.isOntologyLoaded() ).thenReturn( true );
         when( obiService.getTerm( "http://test" ) ).thenReturn( new OntologyTermSimple( "http://test", "this is a test term" ) );
         assertNotNull( ontologyService.getTerm( "http://test", 5000, TimeUnit.MILLISECONDS ) );
+    }
+
+    /**
+     * CLO does not use the OBO definition property. It writes what it knows about a cell line into
+     * {@code rdfs:comment} — {@code CLO_0008127} (NCI-H929) carries "disease: plasmacytoma;   myeloma" and no
+     * OBO definition at all — so probing only {@code IAO_0000115} returned null for exactly the terms whose
+     * description is the point. That disease is a property of the line, and nobody should have to curate it
+     * onto an experiment when an ontology already loaded here asserts it.
+     */
+    @Test
+    public void testDefinitionFallsBackToCommentWhenTheOntologyUsesOne() throws TimeoutException {
+        String uri = "http://purl.obolibrary.org/obo/CLO_0008127";
+        OntologyTerm term = mock();
+        when( term.getLabel() ).thenReturn( "NCI-H929 cell" );
+        when( term.getAnnotation( OntologyUtils.DEFINITION_URI ) ).thenReturn( null );
+        when( term.getComment() ).thenReturn( "disease: plasmacytoma;   myeloma" );
+        when( chebiOntologyService.isOntologyLoaded() ).thenReturn( true );
+        when( chebiOntologyService.getTerm( uri ) ).thenReturn( term );
+
+        assertEquals( "disease: plasmacytoma;   myeloma",
+                ontologyService.getDefinition( uri, 5000, TimeUnit.MILLISECONDS ) );
+    }
+
+    /**
+     * The fallback is a fallback: an ontology that states a definition properly still wins, so a MONDO or
+     * UBERON term never reports an editorial comment as its definition.
+     */
+    @Test
+    public void testOboDefinitionWinsOverComment() throws TimeoutException {
+        String uri = "http://purl.obolibrary.org/obo/MONDO_0004975";
+        AnnotationProperty definition = mock();
+        when( definition.getContents() ).thenReturn( "A progressive form of dementia." );
+        OntologyTerm term = mock();
+        when( term.getLabel() ).thenReturn( "Alzheimer disease" );
+        when( term.getAnnotation( OntologyUtils.DEFINITION_URI ) ).thenReturn( definition );
+        when( chebiOntologyService.isOntologyLoaded() ).thenReturn( true );
+        when( chebiOntologyService.getTerm( uri ) ).thenReturn( term );
+
+        assertEquals( "A progressive form of dementia.",
+                ontologyService.getDefinition( uri, 5000, TimeUnit.MILLISECONDS ) );
+        verify( term, never() ).getComment();
+    }
+
+    /**
+     * A term with neither still reports nothing, rather than an empty string a caller would render as a
+     * definition that exists and is blank.
+     */
+    @Test
+    public void testDefinitionIsNullWhenTheTermDescribesItselfNowhere() throws TimeoutException {
+        String uri = "http://purl.obolibrary.org/obo/CLO_0000019";
+        OntologyTerm term = mock();
+        when( term.getLabel() ).thenReturn( "immortal cell line cell" );
+        when( term.getAnnotation( OntologyUtils.DEFINITION_URI ) ).thenReturn( null );
+        when( term.getComment() ).thenReturn( "   " );
+        when( chebiOntologyService.isOntologyLoaded() ).thenReturn( true );
+        when( chebiOntologyService.getTerm( uri ) ).thenReturn( term );
+
+        assertNull( ontologyService.getDefinition( uri, 5000, TimeUnit.MILLISECONDS ) );
     }
 }


### PR DESCRIPTION
Answers CAB's ask from today (`CAB_ASK_2026_08_12_SERVE_CLO_DISEASE_ON_CELL_LINE_HITS`) — their option 2, "add the term's description to the search row generally", which turns out to need no new field at all.

## The bug

`OntologyServiceImpl.getDefinition` probed `IAO_0000115` and nothing else, under a `FIXME` admitting it was not clear that would work for every ontology. It does not.

CLO writes what it knows about a cell line into `rdfs:comment`:

```
CLO_0008127  NCI-H929 cell   rdfs:comment "disease: plasmacytoma;   myeloma"
```

and gives it no OBO definition, so the probe returned `null` for exactly the terms whose description is the point. Verified against frink and OLS this afternoon:

| | frink today | OLS |
|---|---|---|
| `CLO_0008127` definition | `null` | `disease: plasmacytoma;   myeloma` |

## The fix

Fall back to `rdfs:comment` when the OBO property is absent. OLS resolves the same fallback and reports the result as the term's *definition*, so this agrees with what a caller sees there. A term that states a definition properly still wins, so a MONDO or UBERON term never reports an editorial comment as its definition — pinned by a test with `verify(term, never()).getComment()`.

This flows straight through `/annotations/term` and the enriched rows of `/annotations/search` with no wire change, which is why there is no new field for anyone to migrate to.

## Why it is worth doing

A cell line's disease is a property of the line. Curation should not have to put it on an experiment, and on the 500-experiment gold **26 of 33** cell-line experiments carrying a `disease` tag were restating the line's own disease. That fact was already in an ontology loaded in this process, unreachable because of which property we read — CAB are currently paying an OLS round trip per term, inside the proposer's hot path, to ask a third party what our own annotation says.

## What this does not do

* **Does not cover every line.** CLO answered `MM.1S` and `NCI-H929` where Cellosaurus has no disease field; Cellosaurus answers 24 lines CLO does not reach, and holds it *structurally* — `CVCL_0511` (Raji) has `disease-list` → NCIt `EBV-related Burkitt lymphoma`, `species-list` → NCBITaxon 9606, `derived-from-site-list` → UBERON maxilla, all with URIs. Serving those is a separate change; our Cellosaurus OBO parser reads id/name/synonym/xref/subset/comment and drops the rest.
* **Does not make redundancy checkable by URI.** Comparing a CLO/NCIt disease string to Gemma's MONDO tag is still a label match, and CAB lost two tokenisation bugs to it today. Exposing MONDO xrefs would end that class of bug; `dbXrefs` comes back empty for these terms too, so there is a second gap of the same shape sitting behind this one.
* **Not deployed.** Committed and pushed only.

## Verification

`OntologyServiceTest` — 11 green, 3 new: the CLO fallback, the OBO-definition-wins case, and a blank comment reporting `null` rather than an empty string a caller would render as a definition that exists and is empty.
