### PR TITLE
Single-cell tabular data: one build per cold request, not two

### DIFF
--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileService.java
@@ -349,6 +349,15 @@ public interface ExpressionDataFileService {
     void streamAndWriteRawExpressionData( ExpressionExperiment ee, QuantitationType qt, boolean forceWrite, Writer writer, boolean autoFlush ) throws IOException;
 
     /**
+     * Tabular single-cell sibling of
+     * {@link #streamAndWriteProcessedExpressionData(ExpressionExperiment, boolean, boolean, Writer, boolean)} —
+     * the payloads here are the largest in the system, so the duplicated cold build this replaces was at
+     * its most expensive on this path: two concurrent full scans of the single-cell vectors per cold
+     * request.
+     */
+    void streamAndWriteTabularSingleCellExpressionData( ExpressionExperiment ee, QuantitationType qt, int fetchSize, boolean useCursorFetchIfSupported, boolean forceWrite, Writer writer, boolean autoFlush ) throws IOException;
+
+    /**
      * Writes out the experimental design for the given experiment.
      * <p>
      * The bioassays (col 0) matches the header row of the data matrix printed out by the {@link MatrixWriter}.

--- a/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
+++ b/gemma-core/src/main/java/ubic/gemma/core/analysis/service/ExpressionDataFileServiceImpl.java
@@ -923,6 +923,16 @@ public class ExpressionDataFileServiceImpl implements ExpressionDataFileService 
                 w -> writeRawExpressionData( ee, qt, null, false, false, false, w, autoFlush ) );
     }
 
+    @Override
+    public void streamAndWriteTabularSingleCellExpressionData( ExpressionExperiment ee, QuantitationType qt, int fetchSize, boolean useCursorFetchIfSupported, boolean forceWrite, Writer writer, boolean autoFlush ) throws IOException {
+        String filename = getDataOutputFilename( ee, qt, TABULAR_SC_DATA_SUFFIX );
+        // same staleness rule as writeOrLocateTabularSingleCellExpressionData: a file older than the
+        // dataset's last curation update is rebuilt
+        Date invalidatedBefore = ee.getCurationDetails() != null ? ee.getCurationDetails().getLastUpdated() : null;
+        this.<IOException>streamAndPopulateCache( filename, invalidatedBefore, forceWrite, writer,
+                w -> writeTabularSingleCellExpressionData( ee, qt, null, false, false, fetchSize, useCursorFetchIfSupported, w, autoFlush, null ) );
+    }
+
     /** The expensive single-pass producer a {@link #streamAndPopulateCache} call tees into two consumers. */
     @FunctionalInterface
     private interface DataWriter<E extends Exception> {

--- a/gemma-rest/src/main/java/ubic/gemma/rest/DatasetsWebService.java
+++ b/gemma-rest/src/main/java/ubic/gemma/rest/DatasetsWebService.java
@@ -7103,20 +7103,19 @@ public class DatasetsWebService {
                             .header( "Content-Disposition", "attachment; filename=\"" + ( download ? p.getPath().getFileName().toString() : FilenameUtils.removeExtension( p.getPath().getFileName().toString() ) ) + "\"" )
                             .build();
                 } else {
-                    // generate the file in the background and stream it
-                    // TODO: limit the number of threads writing SC data to disk to not overwhelm the short-lived task pool
-                    log.info( "Single-cell data for " + qt + " is not available, will generate it in the background and stream it in the meantime." );
-                    // we do not want to use cursor fetch because it requires a lot of memory on the database server
-                    expressionDataFileService.writeOrLocateTabularSingleCellExpressionDataAsync( ee, qt, 30, false, force );
-                    return streamTabularDatasetSingleCellExpression( ee, qt, download );
+                    // One build, two consumers — same tee as the bulk data endpoints: the in-band stream
+                    // and the cache file are fed from a single pass. The single-cell payloads are the
+                    // largest in the system, so the racing fire-and-forget build this replaces was at its
+                    // most expensive here: two concurrent full vector scans per cold request. A concurrent
+                    // builder degrades to a plain stream inside the service; a disconnected caller does
+                    // not abort the cache build.
+                    log.info( "Single-cell data for " + qt + " is not available, will generate and stream it in one pass." );
+                    return streamTabularDatasetSingleCellExpression( ee, qt, download, force );
                 }
             } catch ( TimeoutException e ) {
-                // file is being written, recommend to the user to wait a little bit, stacktrace is superfluous
+                // file is locked by a concurrent writer; the service degrades to a plain stream internally
                 log.warn( "Single-cell data for " + qt + " is still being generated, it will be streamed in the meantime." );
-                return streamTabularDatasetSingleCellExpression( ee, qt, download );
-            } catch ( RejectedExecutionException e ) {
-                log.warn( "Too many file generation tasks are being executed, will stream the single-cell data instead.", e );
-                return streamTabularDatasetSingleCellExpression( ee, qt, download );
+                return streamTabularDatasetSingleCellExpression( ee, qt, download, force );
             } catch ( InterruptedException e ) {
                 Thread.currentThread().interrupt();
                 throw new InternalServerErrorException( e );
@@ -7126,11 +7125,12 @@ public class DatasetsWebService {
         }
     }
 
-    private Response streamTabularDatasetSingleCellExpression( ExpressionExperiment ee, QuantitationType qt, Boolean download ) {
+    private Response streamTabularDatasetSingleCellExpression( ExpressionExperiment ee, QuantitationType qt, Boolean download, boolean force ) {
         String filename = getDataOutputFilename( ee, qt, TABULAR_SC_DATA_SUFFIX );
         return Response.ok( ( StreamingOutput ) stream -> {
                     try ( Writer writer = new OutputStreamWriter( new GZIPOutputStream( stream ), StandardCharsets.UTF_8 ) ) {
-                        expressionDataFileService.writeTabularSingleCellExpressionData( ee, qt, null, false, false, 30, false, writer, true, null );
+                        // we do not want to use cursor fetch because it requires a lot of memory on the database server
+                        expressionDataFileService.streamAndWriteTabularSingleCellExpressionData( ee, qt, 30, false, force, writer, true );
                     }
                 } )
                 .type( download ? MediaType.APPLICATION_OCTET_STREAM_TYPE : TEXT_TAB_SEPARATED_VALUES_UTF8_TYPE )

--- a/gemma-rest/src/test/java/ubic/gemma/rest/DatasetsWebServiceTest.java
+++ b/gemma-rest/src/test/java/ubic/gemma/rest/DatasetsWebServiceTest.java
@@ -90,6 +90,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.io.Writer;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1272,6 +1273,40 @@ public class DatasetsWebServiceTest extends BaseJerseyTest5 {
                 .hasMediaType( TEXT_TAB_SEPARATED_VALUES_UTF8_TYPE )
                 .hasEncoding( "gzip" )
                 .hasHeaderWithValue( "Content-Disposition", "attachment; filename=\"data.txt\"" );
+    }
+
+    /**
+     * Cold cache: the tabular single-cell data is generated ONCE, streaming to the caller and
+     * populating the cache file in the same pass — never by racing a fire-and-forget background
+     * build against an in-band stream of the same data, which on this endpoint meant two
+     * concurrent full scans of the largest payloads in the system.
+     */
+    @Test
+    public void testGetDatasetSingleCellDataWhenCacheIsCold() throws Exception {
+        ee.setShortName( "GSE1" ); // the cold path derives the cache filename from the EE short name...
+        QuantitationType qt = new QuantitationType();
+        qt.setName( "counts" ); // ...and the QT name
+        when( singleCellExpressionExperimentService.getPreferredSingleCellQuantitationType( ee ) )
+                .thenReturn( Optional.of( qt ) );
+        when( expressionDataFileService.getDataFile( eq( ee ), eq( qt ), eq( ExpressionExperimentDataFileType.TABULAR ), anyBoolean(), anyLong(), any() ) )
+                .thenReturn( new DummyLockedPath( Paths.get( "/nonexistent/sc-data.tsv.gz" ), true ) );
+        doAnswer( a -> {
+            Writer w = a.getArgument( 5 );
+            w.write( "probe\tvalue\ncs1\t1.0\n" );
+            return null;
+        } ).when( expressionDataFileService ).streamAndWriteTabularSingleCellExpressionData(
+                eq( ee ), eq( qt ), anyInt(), anyBoolean(), anyBoolean(), any(), anyBoolean() );
+
+        assertThat( target( "/datasets/1/data/singleCell" ).request()
+                .accept( TEXT_TAB_SEPARATED_VALUES_UTF8_TYPE ).get() )
+                .hasStatus( Response.Status.OK )
+                .hasMediaType( TEXT_TAB_SEPARATED_VALUES_UTF8_TYPE );
+
+        verify( expressionDataFileService ).streamAndWriteTabularSingleCellExpressionData(
+                eq( ee ), eq( qt ), anyInt(), anyBoolean(), eq( false ), any(), anyBoolean() );
+        // the point: no duplicate background build alongside the stream
+        verify( expressionDataFileService, never() ).writeOrLocateTabularSingleCellExpressionDataAsync(
+                any(), any(), anyInt(), anyBoolean(), anyBoolean() );
     }
 
     @Test


### PR DESCRIPTION
## What

`GET /datasets/{id}/data/singleCell` (tabular branch) had the cold-cache pattern the bulk data endpoints had until d5ff9692b5: a fire-and-forget executor build of the cache file **racing** an in-band stream of the same data — two concurrent full scans of the single-cell vectors, the largest payloads in the system, per cold request. This PR routes the tabular miss through the same tee engine the bulk endpoints now use: one pass feeds both the response stream and the cache file.

The **MEX branch is untouched** — it never double-built (cache miss returns 503 Retry-After and only the async build runs).

## Behaviour

- Cold miss: one build, streamed to the caller while the cache file is written in the same pass.
- Caller disconnects mid-stream: the cache build completes anyway (the property the fire-and-forget design existed for), so an impatient client no longer re-cools the cold path.
- Concurrent builder holds the file: the call degrades to a plain in-band stream inside the service (previously the `TimeoutException`/`RejectedExecutionException` fallbacks in the handler).
- Cache-write failure mid-build: the partial file is deleted, the stream continues.
- Staleness rule inherited unchanged from `writeOrLocateTabularSingleCellExpressionData`: rebuild when the file is older than the dataset's last curation update. `fetchSize=30` and no-cursor-fetch also unchanged.

## What to scrutinize (why you specifically)

- **Thread economics changed.** The build now runs on the Jersey request thread instead of the bounded `expressionDataFileTaskExecutor`, so the old `RejectedExecutionException` backpressure no longer applies to this path. The retired TODO about limiting concurrent SC writers applies to the new shape as a limit on concurrent *degraded* streams — if you think SC builds are long enough that request-thread occupancy needs a bound, that's the discussion to have here.
- Whether the curation-lastUpdated staleness date is still the right invalidation signal for SC tabular files given your recent data-flow work.
- Anything about the SC vector streaming path that makes a single shared pass unsafe in ways bulk wasn't.

## Verification

- The tee engine itself landed for bulk in d5ff9692b5 and was verified on frink yesterday (one thaw per cold build, cache written in-pass, concurrent probes degrade gracefully, zero `OverlappingFileLockException`); its semantics are pinned by three tests in `ExpressionDataFileServiceTest` (tee correctness + build-once, caller-death resilience, concurrent-writer degradation).
- New REST test pins the cold path: the tee service method is called, the duplicate background build is not. `DatasetsWebServiceTest` 189/189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
